### PR TITLE
[refactor] 카테고리 엔티티와 기존의 생성기능을 수정한다. 

### DIFF
--- a/backend/src/main/java/com/allog/dallog/category/controller/CategoryController.java
+++ b/backend/src/main/java/com/allog/dallog/category/controller/CategoryController.java
@@ -1,5 +1,7 @@
 package com.allog.dallog.category.controller;
 
+import com.allog.dallog.auth.dto.LoginMember;
+import com.allog.dallog.auth.support.AuthenticationPrincipal;
 import com.allog.dallog.category.dto.request.CategoryCreateRequest;
 import com.allog.dallog.category.dto.response.CategoriesResponse;
 import com.allog.dallog.category.dto.response.CategoryResponse;
@@ -26,8 +28,9 @@ public class CategoryController {
     }
 
     @PostMapping
-    public ResponseEntity<CategoryResponse> save(@Valid @RequestBody final CategoryCreateRequest request) {
-        CategoryResponse categoryResponse = categoryService.save(request);
+    public ResponseEntity<CategoryResponse> save(@AuthenticationPrincipal final LoginMember loginMember,
+                                                 @Valid @RequestBody final CategoryCreateRequest request) {
+        CategoryResponse categoryResponse = categoryService.save(loginMember.getId(), request);
         return ResponseEntity.created(URI.create("/api/categories/" + categoryResponse.getId())).body(categoryResponse);
     }
 

--- a/backend/src/main/java/com/allog/dallog/category/domain/Category.java
+++ b/backend/src/main/java/com/allog/dallog/category/domain/Category.java
@@ -2,11 +2,15 @@ package com.allog.dallog.category.domain;
 
 import com.allog.dallog.category.exception.InvalidCategoryException;
 import com.allog.dallog.global.domain.BaseEntity;
+import com.allog.dallog.member.domain.Member;
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 
 @Table(name = "categories")
@@ -23,12 +27,17 @@ public class Category extends BaseEntity {
     @Column(name = "name", nullable = false)
     private String name;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "members_id", nullable = false)
+    private Member member;
+
     protected Category() {
     }
 
-    public Category(final String name) {
+    public Category(final String name, final Member member) {
         validateNameLength(name);
         this.name = name;
+        this.member = member;
     }
 
     private void validateNameLength(final String name) {
@@ -46,5 +55,9 @@ public class Category extends BaseEntity {
 
     public String getName() {
         return name;
+    }
+
+    public Member getMember() {
+        return member;
     }
 }

--- a/backend/src/main/java/com/allog/dallog/category/dto/request/CategoryCreateRequest.java
+++ b/backend/src/main/java/com/allog/dallog/category/dto/request/CategoryCreateRequest.java
@@ -1,6 +1,5 @@
 package com.allog.dallog.category.dto.request;
 
-import com.allog.dallog.category.domain.Category;
 import javax.validation.constraints.NotBlank;
 
 public class CategoryCreateRequest {
@@ -13,10 +12,6 @@ public class CategoryCreateRequest {
 
     public CategoryCreateRequest(final String name) {
         this.name = name;
-    }
-
-    public Category toEntity() {
-        return new Category(name);
     }
 
     public String getName() {

--- a/backend/src/main/java/com/allog/dallog/category/dto/response/CategoryResponse.java
+++ b/backend/src/main/java/com/allog/dallog/category/dto/response/CategoryResponse.java
@@ -1,24 +1,25 @@
 package com.allog.dallog.category.dto.response;
 
 import com.allog.dallog.category.domain.Category;
+import com.allog.dallog.member.dto.MemberResponse;
 import java.time.LocalDateTime;
 
 public class CategoryResponse {
 
-    private Long id;
-    private String name;
-    private LocalDateTime createdAt;
-
-    private CategoryResponse() {
-    }
+    private final Long id;
+    private final String name;
+    private final MemberResponse creator;
+    private final LocalDateTime createdAt;
 
     public CategoryResponse(final Category category) {
-        this(category.getId(), category.getName(), category.getCreatedAt());
+        this(category.getId(), category.getName(), new MemberResponse(category.getMember()), category.getCreatedAt());
     }
 
-    public CategoryResponse(final Long id, final String name, final LocalDateTime createdAt) {
+    public CategoryResponse(final Long id, final String name, final MemberResponse creator,
+                            final LocalDateTime createdAt) {
         this.id = id;
         this.name = name;
+        this.creator = creator;
         this.createdAt = createdAt;
     }
 
@@ -28,6 +29,10 @@ public class CategoryResponse {
 
     public String getName() {
         return name;
+    }
+
+    public MemberResponse getCreator() {
+        return creator;
     }
 
     public LocalDateTime getCreatedAt() {

--- a/backend/src/main/java/com/allog/dallog/category/dto/response/CategoryResponse.java
+++ b/backend/src/main/java/com/allog/dallog/category/dto/response/CategoryResponse.java
@@ -6,10 +6,13 @@ import java.time.LocalDateTime;
 
 public class CategoryResponse {
 
-    private final Long id;
-    private final String name;
-    private final MemberResponse creator;
-    private final LocalDateTime createdAt;
+    private Long id;
+    private String name;
+    private MemberResponse creator;
+    private LocalDateTime createdAt;
+
+    private CategoryResponse() {
+    }
 
     public CategoryResponse(final Category category) {
         this(category.getId(), category.getName(), new MemberResponse(category.getMember()), category.getCreatedAt());

--- a/backend/src/main/java/com/allog/dallog/category/service/CategoryService.java
+++ b/backend/src/main/java/com/allog/dallog/category/service/CategoryService.java
@@ -5,6 +5,8 @@ import com.allog.dallog.category.domain.CategoryRepository;
 import com.allog.dallog.category.dto.request.CategoryCreateRequest;
 import com.allog.dallog.category.dto.response.CategoryResponse;
 import com.allog.dallog.category.exception.NoSuchCategoryException;
+import com.allog.dallog.member.domain.Member;
+import com.allog.dallog.member.service.MemberService;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.springframework.data.domain.Pageable;
@@ -16,14 +18,17 @@ import org.springframework.transaction.annotation.Transactional;
 public class CategoryService {
 
     private final CategoryRepository categoryRepository;
+    private final MemberService memberService;
 
-    public CategoryService(final CategoryRepository categoryRepository) {
+    public CategoryService(final CategoryRepository categoryRepository, final MemberService memberService) {
         this.categoryRepository = categoryRepository;
+        this.memberService = memberService;
     }
 
     @Transactional
-    public CategoryResponse save(final CategoryCreateRequest request) {
-        Category category = categoryRepository.save(request.toEntity());
+    public CategoryResponse save(final Long memberId, final CategoryCreateRequest request) {
+        Member member = memberService.getMember(memberId);
+        Category category = categoryRepository.save(new Category(request.getName(), member));
         return new CategoryResponse(category);
     }
 

--- a/backend/src/main/java/com/allog/dallog/member/service/MemberService.java
+++ b/backend/src/main/java/com/allog/dallog/member/service/MemberService.java
@@ -18,8 +18,8 @@ public class MemberService {
     }
 
     @Transactional
-    public Member save(final Member member) {
-        return memberRepository.save(member);
+    public MemberResponse save(final Member member) {
+        return new MemberResponse(memberRepository.save(member));
     }
 
     public MemberResponse findById(final Long id) {

--- a/backend/src/test/java/com/allog/dallog/acceptance/AcceptanceTest.java
+++ b/backend/src/test/java/com/allog/dallog/acceptance/AcceptanceTest.java
@@ -1,13 +1,16 @@
 package com.allog.dallog.acceptance;
 
+import com.allog.dallog.common.config.TestConfig;
 import io.restassured.RestAssured;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.annotation.DirtiesContext;
 
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Import(TestConfig.class)
 class AcceptanceTest {
 
     @LocalServerPort

--- a/backend/src/test/java/com/allog/dallog/acceptance/AuthAcceptanceTest.java
+++ b/backend/src/test/java/com/allog/dallog/acceptance/AuthAcceptanceTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.allog.dallog.auth.dto.OAuthUriResponse;
-import com.allog.dallog.auth.dto.TokenRequest;
 import com.allog.dallog.auth.dto.TokenResponse;
 import com.allog.dallog.common.config.TestConfig;
 import io.restassured.RestAssured;
@@ -60,16 +59,6 @@ public class AuthAcceptanceTest extends AcceptanceTest {
         return RestAssured.given().log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .when().get("/api/auth/{oauthProvider}/oauth-uri", oauthProvider)
-                .then().log().all()
-                .statusCode(HttpStatus.OK.value())
-                .extract();
-    }
-
-    private ExtractableResponse<Response> 자체_토큰을_생성한다(final String oauthProvider, final String code) {
-        return RestAssured.given().log().all()
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .body(new TokenRequest(code))
-                .when().post("/api/auth/{oauthProvider}/token", oauthProvider)
                 .then().log().all()
                 .statusCode(HttpStatus.OK.value())
                 .extract();

--- a/backend/src/test/java/com/allog/dallog/acceptance/AuthAcceptanceTest.java
+++ b/backend/src/test/java/com/allog/dallog/acceptance/AuthAcceptanceTest.java
@@ -1,5 +1,6 @@
 package com.allog.dallog.acceptance;
 
+import static com.allog.dallog.acceptance.fixtures.AuthAcceptanceFixtures.자체_토큰을_생성한다;
 import static com.allog.dallog.acceptance.fixtures.CommonAcceptanceFixtures.상태코드_200이_반환된다;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;

--- a/backend/src/test/java/com/allog/dallog/acceptance/CategoryAcceptanceTest.java
+++ b/backend/src/test/java/com/allog/dallog/acceptance/CategoryAcceptanceTest.java
@@ -1,16 +1,16 @@
 package com.allog.dallog.acceptance;
 
-import static com.allog.dallog.acceptance.fixtures.CategoryAcceptanceFixtures.새로운_카테고리를_등록한다;
-import static com.allog.dallog.acceptance.fixtures.CategoryAcceptanceFixtures.카테고리를_페이징을_통해_조회한다;
-import static com.allog.dallog.acceptance.fixtures.CommonAcceptanceFixtures.상태코드_200이_반환된다;
-import static com.allog.dallog.acceptance.fixtures.CommonAcceptanceFixtures.상태코드_201이_반환된다;
 import static com.allog.dallog.common.fixtures.CategoryFixtures.CATEGORY_NAME;
 import static com.allog.dallog.common.fixtures.CategoryFixtures.PAGE_NUMBER;
 import static com.allog.dallog.common.fixtures.CategoryFixtures.PAGE_SIZE;
+import static com.allog.dallog.common.fixtures.OAuthMemberFixtures.CODE;
+import static com.allog.dallog.common.fixtures.OAuthMemberFixtures.OAUTH_PROVIDER;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+import com.allog.dallog.auth.dto.TokenResponse;
 import com.allog.dallog.category.dto.response.CategoriesResponse;
+import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import org.junit.jupiter.api.DisplayName;
@@ -22,8 +22,12 @@ public class CategoryAcceptanceTest extends AcceptanceTest {
     @DisplayName("정상적인 카테고리 정보를 등록하면 상태코드 201을 반환한다.")
     @Test
     void 정상적인_카테고리_정보를_등록하면_상태코드_201을_반환한다() {
-        // given & when
-        ExtractableResponse<Response> response = 새로운_카테고리를_등록한다(CATEGORY_NAME);
+        // given
+        ExtractableResponse<Response> tokenCreateResponse = 자체_토큰을_생성한다(OAUTH_PROVIDER, CODE);
+        TokenResponse tokenResponse = tokenCreateResponse.as(TokenResponse.class);
+
+        // when
+        ExtractableResponse<Response> response = 새로운_카테고리를_등록한다(tokenResponse, CATEGORY_NAME);
 
         // then
         상태코드_201이_반환된다(response);
@@ -33,11 +37,12 @@ public class CategoryAcceptanceTest extends AcceptanceTest {
     @Test
     void 카테고리를_등록하고_페이징을_통해_나누어_조회한다() {
         // given
-        새로운_카테고리를_등록한다(CATEGORY_NAME);
-        새로운_카테고리를_등록한다(CATEGORY_NAME);
-        새로운_카테고리를_등록한다(CATEGORY_NAME);
-        새로운_카테고리를_등록한다(CATEGORY_NAME);
-
+        ExtractableResponse<Response> tokenCreateResponse = 자체_토큰을_생성한다(OAUTH_PROVIDER, CODE);
+        TokenResponse tokenResponse = tokenCreateResponse.as(TokenResponse.class);
+        새로운_카테고리를_등록한다(tokenResponse, CATEGORY_NAME);
+        새로운_카테고리를_등록한다(tokenResponse, CATEGORY_NAME);
+        새로운_카테고리를_등록한다(tokenResponse, CATEGORY_NAME);
+        새로운_카테고리를_등록한다(tokenResponse, CATEGORY_NAME);
         // when
         ExtractableResponse<Response> response = 카테고리를_페이징을_통해_조회한다(PAGE_NUMBER, PAGE_SIZE);
         CategoriesResponse categoriesResponse = response.as(CategoriesResponse.class);
@@ -48,5 +53,12 @@ public class CategoryAcceptanceTest extends AcceptanceTest {
             assertThat(categoriesResponse.getPage()).isEqualTo(PAGE_NUMBER);
             assertThat(categoriesResponse.getCategories()).hasSize(PAGE_SIZE);
         });
+    }
+
+    private ExtractableResponse<Response> 카테고리를_페이징을_통해_조회한다(final int page, final int size) {
+        return RestAssured.given().log().all()
+                .when().get("/api/categories?page={page}&size={size}", page, size)
+                .then().log().all()
+                .extract();
     }
 }

--- a/backend/src/test/java/com/allog/dallog/acceptance/CategoryAcceptanceTest.java
+++ b/backend/src/test/java/com/allog/dallog/acceptance/CategoryAcceptanceTest.java
@@ -1,5 +1,9 @@
 package com.allog.dallog.acceptance;
 
+import static com.allog.dallog.acceptance.fixtures.AuthAcceptanceFixtures.자체_토큰을_생성한다;
+import static com.allog.dallog.acceptance.fixtures.CategoryAcceptanceFixtures.새로운_카테고리를_등록한다;
+import static com.allog.dallog.acceptance.fixtures.CommonAcceptanceFixtures.상태코드_200이_반환된다;
+import static com.allog.dallog.acceptance.fixtures.CommonAcceptanceFixtures.상태코드_201이_반환된다;
 import static com.allog.dallog.common.fixtures.CategoryFixtures.CATEGORY_NAME;
 import static com.allog.dallog.common.fixtures.CategoryFixtures.PAGE_NUMBER;
 import static com.allog.dallog.common.fixtures.CategoryFixtures.PAGE_SIZE;
@@ -43,6 +47,7 @@ public class CategoryAcceptanceTest extends AcceptanceTest {
         새로운_카테고리를_등록한다(tokenResponse, CATEGORY_NAME);
         새로운_카테고리를_등록한다(tokenResponse, CATEGORY_NAME);
         새로운_카테고리를_등록한다(tokenResponse, CATEGORY_NAME);
+
         // when
         ExtractableResponse<Response> response = 카테고리를_페이징을_통해_조회한다(PAGE_NUMBER, PAGE_SIZE);
         CategoriesResponse categoriesResponse = response.as(CategoriesResponse.class);

--- a/backend/src/test/java/com/allog/dallog/acceptance/MemberAcceptanceTest.java
+++ b/backend/src/test/java/com/allog/dallog/acceptance/MemberAcceptanceTest.java
@@ -1,10 +1,10 @@
 package com.allog.dallog.acceptance;
 
-import static com.allog.dallog.acceptance.fixtures.CommonAcceptanceFixtures.상태코드_200이_반환된다;
+import static com.allog.dallog.common.fixtures.OAuthMemberFixtures.CODE;
+import static com.allog.dallog.common.fixtures.OAuthMemberFixtures.OAUTH_PROVIDER;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
-import com.allog.dallog.auth.dto.TokenRequest;
 import com.allog.dallog.auth.dto.TokenResponse;
 import com.allog.dallog.common.config.TestConfig;
 import com.allog.dallog.common.fixtures.OAuthMemberFixtures;
@@ -26,7 +26,8 @@ public class MemberAcceptanceTest extends AcceptanceTest {
     @Test
     void 등록된_회원이_자신의_정보를_조회하면_상태코드_200_을_반환한다() {
         // given
-        TokenResponse tokenResponse = 자체_토큰을_생성한다(OAuthMemberFixtures.OAUTH_PROVIDER, OAuthMemberFixtures.CODE);
+        ExtractableResponse<Response> tokenCreateResponse = 자체_토큰을_생성한다(OAUTH_PROVIDER, CODE);
+        TokenResponse tokenResponse = tokenCreateResponse.as(TokenResponse.class);
 
         // when
         ExtractableResponse<Response> response = 자신의_정보를_조회한다(tokenResponse);
@@ -39,17 +40,6 @@ public class MemberAcceptanceTest extends AcceptanceTest {
             assertThat(memberResponse.getDisplayName()).isEqualTo(OAuthMemberFixtures.DISPLAY_NAME);
             assertThat(memberResponse.getProfileImageUrl()).isEqualTo(OAuthMemberFixtures.PROFILE_IMAGE_URI);
         });
-    }
-
-    private TokenResponse 자체_토큰을_생성한다(final String oauthProvider, final String code) {
-        return RestAssured.given().log().all()
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .body(new TokenRequest(code))
-                .when().post("/api/auth/{oauthProvider}/token", oauthProvider)
-                .then().log().all()
-                .statusCode(HttpStatus.OK.value())
-                .extract()
-                .as(TokenResponse.class);
     }
 
     private ExtractableResponse<Response> 자신의_정보를_조회한다(final TokenResponse tokenResponse) {

--- a/backend/src/test/java/com/allog/dallog/acceptance/MemberAcceptanceTest.java
+++ b/backend/src/test/java/com/allog/dallog/acceptance/MemberAcceptanceTest.java
@@ -1,5 +1,7 @@
 package com.allog.dallog.acceptance;
 
+import static com.allog.dallog.acceptance.fixtures.AuthAcceptanceFixtures.자체_토큰을_생성한다;
+import static com.allog.dallog.acceptance.fixtures.CommonAcceptanceFixtures.상태코드_200이_반환된다;
 import static com.allog.dallog.common.fixtures.OAuthMemberFixtures.CODE;
 import static com.allog.dallog.common.fixtures.OAuthMemberFixtures.OAUTH_PROVIDER;
 import static org.assertj.core.api.Assertions.assertThat;

--- a/backend/src/test/java/com/allog/dallog/acceptance/SubscriptionAcceptanceTest.java
+++ b/backend/src/test/java/com/allog/dallog/acceptance/SubscriptionAcceptanceTest.java
@@ -1,5 +1,8 @@
 package com.allog.dallog.acceptance;
 
+import static com.allog.dallog.acceptance.fixtures.AuthAcceptanceFixtures.자체_토큰을_생성한다;
+import static com.allog.dallog.acceptance.fixtures.CategoryAcceptanceFixtures.새로운_카테고리를_등록한다;
+import static com.allog.dallog.acceptance.fixtures.CommonAcceptanceFixtures.상태코드_201이_반환된다;
 import static com.allog.dallog.common.fixtures.OAuthMemberFixtures.CODE;
 import static com.allog.dallog.common.fixtures.OAuthMemberFixtures.OAUTH_PROVIDER;
 

--- a/backend/src/test/java/com/allog/dallog/acceptance/SubscriptionAcceptanceTest.java
+++ b/backend/src/test/java/com/allog/dallog/acceptance/SubscriptionAcceptanceTest.java
@@ -1,13 +1,11 @@
 package com.allog.dallog.acceptance;
 
-import static com.allog.dallog.acceptance.fixtures.CommonAcceptanceFixtures.상태코드_201이_반환된다;
+import static com.allog.dallog.common.fixtures.OAuthMemberFixtures.CODE;
+import static com.allog.dallog.common.fixtures.OAuthMemberFixtures.OAUTH_PROVIDER;
 
-import com.allog.dallog.auth.dto.TokenRequest;
 import com.allog.dallog.auth.dto.TokenResponse;
-import com.allog.dallog.category.dto.request.CategoryCreateRequest;
 import com.allog.dallog.category.dto.response.CategoryResponse;
 import com.allog.dallog.common.config.TestConfig;
-import com.allog.dallog.common.fixtures.OAuthMemberFixtures;
 import com.allog.dallog.fixture.SubscriptionFixtures;
 import com.allog.dallog.subscription.dto.request.SubscriptionCreateRequest;
 import io.restassured.RestAssured;
@@ -27,36 +25,15 @@ public class SubscriptionAcceptanceTest extends AcceptanceTest {
     @Test
     void 인증된_회원이_카테고리를_구독하면_201을_반환한다() {
         // given
-        TokenResponse tokenResponse = 자체_토큰을_생성한다(OAuthMemberFixtures.OAUTH_PROVIDER, OAuthMemberFixtures.CODE);
-        CategoryResponse categoryResponse = 새로운_카테고리를_등록한다("BE 공식일정");
+        ExtractableResponse<Response> tokenCreateResponse = 자체_토큰을_생성한다(OAUTH_PROVIDER, CODE);
+        TokenResponse tokenResponse = tokenCreateResponse.as(TokenResponse.class);
+        CategoryResponse categoryResponse = 새로운_카테고리를_등록한다(tokenResponse, "BE 공식일정").as(CategoryResponse.class);
 
         // when
         ExtractableResponse<Response> response = 카테고리를_구독한다(tokenResponse, categoryResponse);
 
         // then
         상태코드_201이_반환된다(response);
-    }
-
-    private TokenResponse 자체_토큰을_생성한다(final String oauthProvider, final String code) {
-        return RestAssured.given().log().all()
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .body(new TokenRequest(code))
-                .when().post("/api/auth/{oauthProvider}/token", oauthProvider)
-                .then().log().all()
-                .statusCode(HttpStatus.OK.value())
-                .extract()
-                .as(TokenResponse.class);
-    }
-
-    private CategoryResponse 새로운_카테고리를_등록한다(final String name) {
-        CategoryCreateRequest request = new CategoryCreateRequest(name);
-        return RestAssured.given().log().all()
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .body(request)
-                .when().post("/api/categories")
-                .then().log().all()
-                .extract()
-                .as(CategoryResponse.class);
     }
 
     private ExtractableResponse<Response> 카테고리를_구독한다(final TokenResponse tokenResponse,

--- a/backend/src/test/java/com/allog/dallog/acceptance/fixtures/AuthAcceptanceFixtures.java
+++ b/backend/src/test/java/com/allog/dallog/acceptance/fixtures/AuthAcceptanceFixtures.java
@@ -1,0 +1,21 @@
+package com.allog.dallog.acceptance.fixtures;
+
+import com.allog.dallog.auth.dto.TokenRequest;
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+public class AuthAcceptanceFixtures {
+
+    public static ExtractableResponse<Response> 자체_토큰을_생성한다(final String oauthProvider, final String code) {
+        return RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(new TokenRequest(code))
+                .when().post("/api/auth/{oauthProvider}/token", oauthProvider)
+                .then().log().all()
+                .statusCode(HttpStatus.OK.value())
+                .extract();
+    }
+}

--- a/backend/src/test/java/com/allog/dallog/acceptance/fixtures/CategoryAcceptanceFixtures.java
+++ b/backend/src/test/java/com/allog/dallog/acceptance/fixtures/CategoryAcceptanceFixtures.java
@@ -1,5 +1,6 @@
 package com.allog.dallog.acceptance.fixtures;
 
+import com.allog.dallog.auth.dto.TokenResponse;
 import com.allog.dallog.category.dto.request.CategoryCreateRequest;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
@@ -8,10 +9,10 @@ import org.springframework.http.MediaType;
 
 public class CategoryAcceptanceFixtures {
 
-    public static ExtractableResponse<Response> 새로운_카테고리를_등록한다(final String name) {
+    public static ExtractableResponse<Response> 새로운_카테고리를_등록한다(final TokenResponse tokenResponse, final String name) {
         CategoryCreateRequest request = new CategoryCreateRequest(name);
-
         return RestAssured.given().log().all()
+                .auth().oauth2(tokenResponse.getAccessToken())
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .body(request)
                 .when().post("/api/categories")

--- a/backend/src/test/java/com/allog/dallog/category/domain/CategoryRepositoryTest.java
+++ b/backend/src/test/java/com/allog/dallog/category/domain/CategoryRepositoryTest.java
@@ -2,32 +2,41 @@ package com.allog.dallog.category.domain;
 
 import static com.allog.dallog.common.fixtures.CategoryFixtures.PAGE_NUMBER;
 import static com.allog.dallog.common.fixtures.CategoryFixtures.PAGE_SIZE;
+import static com.allog.dallog.common.fixtures.MemberFixtures.MEMBER;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+import com.allog.dallog.global.config.JpaConfig;
+import com.allog.dallog.member.domain.MemberRepository;
 import java.util.Objects;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 
 @DataJpaTest
+@Import(JpaConfig.class)
 class CategoryRepositoryTest {
 
     @Autowired
     private CategoryRepository categoryRepository;
 
+    @Autowired
+    private MemberRepository memberRepository;
+
     @DisplayName("페이지와 사이즈를 받아 해당하는 구간의 카테고리를 조회한다.")
     @Test
     void 페이지와_사이즈를_받아_해당하는_구간의_카테고리를_조회한다() {
         // given
-        categoryRepository.save(new Category("BE 공식일정"));
-        categoryRepository.save(new Category("FE 공식일정"));
-        categoryRepository.save(new Category("알록달록 회의"));
-        categoryRepository.save(new Category("지원플랫폼 근로"));
-        categoryRepository.save(new Category("파랑의 코틀린 스터디"));
+        memberRepository.save(MEMBER);
+        categoryRepository.save(new Category("BE 공식일정", MEMBER));
+        categoryRepository.save(new Category("FE 공식일정", MEMBER));
+        categoryRepository.save(new Category("알록달록 회의", MEMBER));
+        categoryRepository.save(new Category("지원플랫폼 근로", MEMBER));
+        categoryRepository.save(new Category("파랑의 코틀린 스터디", MEMBER));
 
         PageRequest pageRequest = PageRequest.of(PAGE_NUMBER, PAGE_SIZE);
 

--- a/backend/src/test/java/com/allog/dallog/category/domain/CategoryTest.java
+++ b/backend/src/test/java/com/allog/dallog/category/domain/CategoryTest.java
@@ -1,5 +1,6 @@
 package com.allog.dallog.category.domain;
 
+import static com.allog.dallog.common.fixtures.MemberFixtures.MEMBER;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
@@ -18,7 +19,7 @@ class CategoryTest {
         String name = "BE 공식일정";
 
         // when & then
-        assertDoesNotThrow(() -> new Category(name));
+        assertDoesNotThrow(() -> new Category(name, MEMBER));
     }
 
     @DisplayName("카테고리 이름이 공백인 경우 예외를 던진다.")
@@ -28,7 +29,7 @@ class CategoryTest {
         String name = "";
 
         // when & then
-        assertThatThrownBy(() -> new Category(name))
+        assertThatThrownBy(() -> new Category(name, MEMBER))
                 .isInstanceOf(InvalidCategoryException.class);
     }
 
@@ -38,7 +39,7 @@ class CategoryTest {
             "알록달록 알록달록 알록달록 알록달록 알록달록 알록달록 카테고리"})
     void 카테고리_이름의_길이가_20을_초과하는_경우_예외를_던진다(final String name) {
         // given & when & then
-        assertThatThrownBy(() -> new Category(name))
+        assertThatThrownBy(() -> new Category(name, MEMBER))
                 .isInstanceOf(InvalidCategoryException.class);
     }
 }

--- a/backend/src/test/java/com/allog/dallog/common/fixtures/CategoryFixtures.java
+++ b/backend/src/test/java/com/allog/dallog/common/fixtures/CategoryFixtures.java
@@ -1,5 +1,7 @@
 package com.allog.dallog.common.fixtures;
 
+import static com.allog.dallog.common.fixtures.MemberFixtures.MEMBER;
+
 import com.allog.dallog.category.domain.Category;
 
 public class CategoryFixtures {
@@ -9,5 +11,5 @@ public class CategoryFixtures {
     public static final int PAGE_NUMBER = 1;
     public static final int PAGE_SIZE = 2;
 
-    public static final Category CATEGORY = new Category(CATEGORY_NAME);
+    public static final Category CATEGORY = new Category(CATEGORY_NAME, MEMBER);
 }

--- a/backend/src/test/java/com/allog/dallog/member/service/MemberServiceTest.java
+++ b/backend/src/test/java/com/allog/dallog/member/service/MemberServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.allog.dallog.member.domain.Member;
 import com.allog.dallog.member.domain.SocialType;
+import com.allog.dallog.member.dto.MemberResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -24,7 +25,7 @@ class MemberServiceTest {
         Member member = new Member("devhudi@gmail.com", "/image.png", "후디", SocialType.GOOGLE);
 
         // when
-        Member actual = memberService.save(member);
+        MemberResponse actual = memberService.save(member);
 
         // then
         assertThat(actual).isNotNull();
@@ -38,7 +39,7 @@ class MemberServiceTest {
         String profileImageUrl = "/image.png";
         String displayName = "후디";
         Member member = new Member(email, profileImageUrl, displayName, SocialType.GOOGLE);
-        Member savedMember = memberService.save(member);
+        MemberResponse savedMember = memberService.save(member);
 
         // when
         Member foundMember = memberService.findByEmail(email);

--- a/backend/src/test/java/com/allog/dallog/subscription/service/SubscriptionServiceTest.java
+++ b/backend/src/test/java/com/allog/dallog/subscription/service/SubscriptionServiceTest.java
@@ -1,5 +1,6 @@
 package com.allog.dallog.subscription.service;
 
+import static com.allog.dallog.common.fixtures.MemberFixtures.MEMBER;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -7,7 +8,6 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import com.allog.dallog.category.dto.request.CategoryCreateRequest;
 import com.allog.dallog.category.dto.response.CategoryResponse;
 import com.allog.dallog.category.service.CategoryService;
-import com.allog.dallog.common.fixtures.MemberFixtures;
 import com.allog.dallog.member.domain.Member;
 import com.allog.dallog.member.service.MemberService;
 import com.allog.dallog.subscription.dto.request.SubscriptionCreateRequest;
@@ -39,7 +39,7 @@ class SubscriptionServiceTest {
     @Test
     void 새로운_구독을_생성한다() {
         // given
-        Member member = memberService.save(MemberFixtures.MEMBER);
+        Member member = memberService.save(MEMBER);
         CategoryResponse categoryResponse = categoryService.save(member.getId(), new CategoryCreateRequest("BE 일정"));
         String color = "#ffffff";
 
@@ -57,7 +57,7 @@ class SubscriptionServiceTest {
     @ValueSource(strings = {"#111", "#1111", "#11111", "123456", "#**1234", "##12345", "334172#"})
     void 색_정보_형식이_잘못된_경우_예외를_던진다(final String color) {
         // given
-        Member member = memberService.save(MemberFixtures.MEMBER);
+        Member member = memberService.save(MEMBER);
         CategoryResponse categoryResponse = categoryService.save(member.getId(), new CategoryCreateRequest("BE 일정"));
 
         // when & then
@@ -69,7 +69,7 @@ class SubscriptionServiceTest {
     @Test
     void 구독_id를_기반으로_단건_조회한다() {
         // given
-        Member member = memberService.save(MemberFixtures.MEMBER);
+        Member member = memberService.save(MEMBER);
         CategoryResponse categoryResponse = categoryService.save(member.getId(), new CategoryCreateRequest("BE 일정"));
         String color = "#ffffff";
         SubscriptionResponse subscriptionResponse = subscriptionService.save(member.getId(), categoryResponse.getId(),

--- a/backend/src/test/java/com/allog/dallog/subscription/service/SubscriptionServiceTest.java
+++ b/backend/src/test/java/com/allog/dallog/subscription/service/SubscriptionServiceTest.java
@@ -8,7 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import com.allog.dallog.category.dto.request.CategoryCreateRequest;
 import com.allog.dallog.category.dto.response.CategoryResponse;
 import com.allog.dallog.category.service.CategoryService;
-import com.allog.dallog.member.domain.Member;
+import com.allog.dallog.member.dto.MemberResponse;
 import com.allog.dallog.member.service.MemberService;
 import com.allog.dallog.subscription.dto.request.SubscriptionCreateRequest;
 import com.allog.dallog.subscription.dto.response.SubscriptionResponse;
@@ -39,7 +39,7 @@ class SubscriptionServiceTest {
     @Test
     void 새로운_구독을_생성한다() {
         // given
-        Member member = memberService.save(MEMBER);
+        MemberResponse member = memberService.save(MEMBER);
         CategoryResponse categoryResponse = categoryService.save(member.getId(), new CategoryCreateRequest("BE 일정"));
         String color = "#ffffff";
 
@@ -57,7 +57,7 @@ class SubscriptionServiceTest {
     @ValueSource(strings = {"#111", "#1111", "#11111", "123456", "#**1234", "##12345", "334172#"})
     void 색_정보_형식이_잘못된_경우_예외를_던진다(final String color) {
         // given
-        Member member = memberService.save(MEMBER);
+        MemberResponse member = memberService.save(MEMBER);
         CategoryResponse categoryResponse = categoryService.save(member.getId(), new CategoryCreateRequest("BE 일정"));
 
         // when & then
@@ -69,7 +69,7 @@ class SubscriptionServiceTest {
     @Test
     void 구독_id를_기반으로_단건_조회한다() {
         // given
-        Member member = memberService.save(MEMBER);
+        MemberResponse member = memberService.save(MEMBER);
         CategoryResponse categoryResponse = categoryService.save(member.getId(), new CategoryCreateRequest("BE 일정"));
         String color = "#ffffff";
         SubscriptionResponse subscriptionResponse = subscriptionService.save(member.getId(), categoryResponse.getId(),

--- a/backend/src/test/java/com/allog/dallog/subscription/service/SubscriptionServiceTest.java
+++ b/backend/src/test/java/com/allog/dallog/subscription/service/SubscriptionServiceTest.java
@@ -40,7 +40,7 @@ class SubscriptionServiceTest {
     void 새로운_구독을_생성한다() {
         // given
         Member member = memberService.save(MemberFixtures.MEMBER);
-        CategoryResponse categoryResponse = categoryService.save(new CategoryCreateRequest("BE 일정"));
+        CategoryResponse categoryResponse = categoryService.save(member.getId(), new CategoryCreateRequest("BE 일정"));
         String color = "#ffffff";
 
         // when
@@ -58,7 +58,7 @@ class SubscriptionServiceTest {
     void 색_정보_형식이_잘못된_경우_예외를_던진다(final String color) {
         // given
         Member member = memberService.save(MemberFixtures.MEMBER);
-        CategoryResponse categoryResponse = categoryService.save(new CategoryCreateRequest("BE 일정"));
+        CategoryResponse categoryResponse = categoryService.save(member.getId(), new CategoryCreateRequest("BE 일정"));
 
         // when & then
         assertThatThrownBy(() -> subscriptionService.save(member.getId(), categoryResponse.getId(),
@@ -70,7 +70,7 @@ class SubscriptionServiceTest {
     void 구독_id를_기반으로_단건_조회한다() {
         // given
         Member member = memberService.save(MemberFixtures.MEMBER);
-        CategoryResponse categoryResponse = categoryService.save(new CategoryCreateRequest("BE 일정"));
+        CategoryResponse categoryResponse = categoryService.save(member.getId(), new CategoryCreateRequest("BE 일정"));
         String color = "#ffffff";
         SubscriptionResponse subscriptionResponse = subscriptionService.save(member.getId(), categoryResponse.getId(),
                 new SubscriptionCreateRequest(color));


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 💻 git rebase를 사용했나요?
- [x] 🌈 알록달록한가요?

## 작업 내용

- 카테고리 엔티티에 카테고리 생성한 유저 필드 추가
- 카테고리 생성시 유저 정보 저장하도록 수정
- 테스트 수정

Closes #95
