### PR TITLE
[feat] Request Body를 생략하고 요청하면 Internal Server Error가 발생하는 버그를 해결한다.

### DIFF
--- a/backend/src/main/java/com/allog/dallog/global/presentation/ControllerAdvice.java
+++ b/backend/src/main/java/com/allog/dallog/global/presentation/ControllerAdvice.java
@@ -15,6 +15,7 @@ import com.allog.dallog.global.dto.ErrorResponse;
 import com.allog.dallog.infrastructure.oauth.exception.OAuthException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -57,6 +58,12 @@ public class ControllerAdvice {
     public ResponseEntity<ErrorResponse> handleOAuthException() {
         ErrorResponse errorResponse = new ErrorResponse("OAuth 통신 과정에서 에러가 발생했습니다.");
         return ResponseEntity.internalServerError().body(errorResponse);
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ErrorResponse> handleInvalidRequestBody() {
+        ErrorResponse errorResponse = new ErrorResponse("잘못된 형식의 Request Body 입니다.");
+        return ResponseEntity.badRequest().body(errorResponse);
     }
 
     @ExceptionHandler(Exception.class)


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 💻 git rebase를 사용했나요?
- [x] 🌈 알록달록한가요?

## 작업 내용

`ControllerAdvice`에 `HttpMessageNotReadableException`의 핸들러를 추가하였습니다.

> 참고: https://docs.spring.io/spring-framework/docs/3.0.6.RELEASE_to_3.1.0.BUILD-SNAPSHOT/3.1.0.BUILD-SNAPSHOT/org/springframework/http/converter/HttpMessageConverter.html

## 스크린샷

## 주의사항

Closes #176 
