### PR TITLE
[feat] 유저별 생성 카테고리 수정 기능을 구현한다.

### DIFF
--- a/frontend/src/api/category.ts
+++ b/frontend/src/api/category.ts
@@ -38,6 +38,18 @@ const categoryApi = {
     return response;
   },
 
+  patch: async (
+    accessToken: string | null,
+    categoryId: number,
+    body: Pick<CategoryType, 'name'>
+  ) => {
+    const response = await dallogApi.patch(`${categoryApi.endpoint.entire}/${categoryId}`, body, {
+      headers: { ...categoryApi.headers, Authorization: `Bearer ${accessToken}` },
+    });
+
+    return response;
+  },
+
   delete: async (accessToken: string | null, categoryId: number) => {
     const response = await dallogApi.delete(`${categoryApi.endpoint.entire}/${categoryId}`, {
       headers: { ...categoryApi.headers, Authorization: `Bearer ${accessToken}` },

--- a/frontend/src/components/CategoryAddModal/CategoryAddModal.tsx
+++ b/frontend/src/components/CategoryAddModal/CategoryAddModal.tsx
@@ -37,7 +37,7 @@ function CategoryAddModal({ closeModal }: CategoryAddModalProps) {
   const { accessToken } = useRecoilValue(userState);
 
   const queryClient = useQueryClient();
-  const { mutate: postCategory } = useMutation<
+  const { mutate } = useMutation<
     AxiosResponse<Pick<CategoryType, 'name'>>,
     AxiosError,
     Pick<CategoryType, 'name'>,
@@ -61,7 +61,7 @@ function CategoryAddModal({ closeModal }: CategoryAddModalProps) {
       return;
     }
 
-    postCategory(body);
+    mutate(body);
   };
 
   const onSuccessPostCategory = () => {

--- a/frontend/src/components/CategoryModifyModal/CategoryModifyModal.styles.ts
+++ b/frontend/src/components/CategoryModifyModal/CategoryModifyModal.styles.ts
@@ -1,0 +1,70 @@
+import { css, Theme } from '@emotion/react';
+
+const modal = ({ colors, flex }: Theme) => css`
+  ${flex.column}
+
+  width: 120rem;
+  height: 90rem;
+  padding: 12.5rem;
+  border-radius: 12px;
+  justify-content: space-between;
+
+  background: ${colors.WHITE};
+`;
+
+const title = ({ colors }: Theme) => css`
+  font-size: 8rem;
+  font-weight: bold;
+  color: ${colors.GRAY_700};
+`;
+
+const form = ({ flex }: Theme) => css`
+  ${flex.column};
+
+  width: 100%;
+  height: 100%;
+  justify-content: space-between;
+`;
+
+const content = ({ flex }: Theme) => css`
+  ${flex.column};
+
+  width: 100%;
+  height: 100%;
+
+  justify-content: center;
+`;
+
+const controlButtons = ({ flex }: Theme) => css`
+  ${flex.row}
+
+  align-self: flex-end;
+  gap: 5rem;
+`;
+
+const cancelButton = ({ colors }: Theme) => css`
+  width: 22.5rem;
+  height: 10rem;
+  border: 2px solid ${colors.GRAY_500};
+  border-radius: 8px;
+  filter: drop-shadow(0 2px 2px ${colors.GRAY_400});
+
+  background: ${colors.WHITE};
+
+  font-size: 5rem;
+  color: ${colors.GRAY_600};
+`;
+
+const saveButton = ({ colors }: Theme) => css`
+  width: 22.5rem;
+  height: 10rem;
+  border-radius: 8px;
+  filter: drop-shadow(0px 2px 2px ${colors.GRAY_400});
+
+  background: ${colors.YELLOW_500};
+
+  font-size: 5rem;
+  color: ${colors.WHITE};
+`;
+
+export { cancelButton, content, controlButtons, form, modal, saveButton, title };

--- a/frontend/src/components/CategoryModifyModal/CategoryModifyModal.tsx
+++ b/frontend/src/components/CategoryModifyModal/CategoryModifyModal.tsx
@@ -6,8 +6,16 @@ import { useRecoilValue } from 'recoil';
 
 import { CategoryType } from '@/@types/category';
 
+import { userState } from '@/recoil/atoms';
+
 import Button from '@/components/@common/Button/Button';
 import FieldSet from '@/components/@common/FieldSet/FieldSet';
+
+import { CACHE_KEY } from '@/constants';
+
+import { createPostBody } from '@/utils';
+
+import categoryApi from '@/api/category';
 
 import {
   cancelButton,
@@ -27,6 +35,18 @@ interface CategoryModifyModalProps {
 function CategoryModifyModal({ category, closeModal }: CategoryModifyModalProps) {
   const theme = useTheme();
 
+  const { accessToken } = useRecoilValue(userState);
+
+  const queryClient = useQueryClient();
+  const { mutate } = useMutation<
+    AxiosResponse<Pick<CategoryType, 'name'>>,
+    AxiosError,
+    Pick<CategoryType, 'name'>,
+    unknown
+  >((body) => categoryApi.patch(accessToken, category.id, body), {
+    onSuccess: () => onSuccessPatchCategory(),
+  });
+
   const inputRef = {
     name: useRef<HTMLInputElement>(null),
   };
@@ -35,10 +55,28 @@ function CategoryModifyModal({ category, closeModal }: CategoryModifyModalProps)
     e.stopPropagation();
   };
 
+  const handleSubmitCategoryModifyForm = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    const body = createPostBody(inputRef);
+
+    if (!body) {
+      return;
+    }
+
+    mutate(body);
+  };
+
+  const onSuccessPatchCategory = () => {
+    queryClient.invalidateQueries(CACHE_KEY.CATEGORIES);
+    queryClient.invalidateQueries(CACHE_KEY.MY_CATEGORIES);
+    closeModal();
+  };
+
   return (
     <div css={modal} onClick={handleClickModal}>
       <h1 css={title}>카테고리 수정</h1>
-      <form css={form}>
+      <form css={form} onSubmit={handleSubmitCategoryModifyForm}>
         <div css={content}>
           <FieldSet placeholder={category.name} autoFocus={true} refProp={inputRef.name} />
         </div>

--- a/frontend/src/components/CategoryModifyModal/CategoryModifyModal.tsx
+++ b/frontend/src/components/CategoryModifyModal/CategoryModifyModal.tsx
@@ -1,0 +1,58 @@
+import { useTheme } from '@emotion/react';
+import { AxiosError, AxiosResponse } from 'axios';
+import { useRef } from 'react';
+import { useMutation, useQueryClient } from 'react-query';
+import { useRecoilValue } from 'recoil';
+
+import { CategoryType } from '@/@types/category';
+
+import Button from '@/components/@common/Button/Button';
+import FieldSet from '@/components/@common/FieldSet/FieldSet';
+
+import {
+  cancelButton,
+  content,
+  controlButtons,
+  form,
+  modal,
+  saveButton,
+  title,
+} from './CategoryModifyModal.styles';
+
+interface CategoryModifyModalProps {
+  category: CategoryType;
+  closeModal: () => void;
+}
+
+function CategoryModifyModal({ category, closeModal }: CategoryModifyModalProps) {
+  const theme = useTheme();
+
+  const inputRef = {
+    name: useRef<HTMLInputElement>(null),
+  };
+
+  const handleClickModal = (e: React.MouseEvent) => {
+    e.stopPropagation();
+  };
+
+  return (
+    <div css={modal} onClick={handleClickModal}>
+      <h1 css={title}>카테고리 수정</h1>
+      <form css={form}>
+        <div css={content}>
+          <FieldSet placeholder={category.name} autoFocus={true} refProp={inputRef.name} />
+        </div>
+        <div css={controlButtons}>
+          <Button cssProp={cancelButton(theme)} onClick={closeModal}>
+            취소
+          </Button>
+          <Button type="submit" cssProp={saveButton(theme)}>
+            완료
+          </Button>
+        </div>
+      </form>
+    </div>
+  );
+}
+
+export default CategoryModifyModal;

--- a/frontend/src/components/CategoryModifyModal/CategoryModifyModal.tsx
+++ b/frontend/src/components/CategoryModifyModal/CategoryModifyModal.tsx
@@ -1,6 +1,6 @@
 import { useTheme } from '@emotion/react';
 import { AxiosError, AxiosResponse } from 'axios';
-import { useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import { useMutation, useQueryClient } from 'react-query';
 import { useRecoilValue } from 'recoil';
 
@@ -73,12 +73,21 @@ function CategoryModifyModal({ category, closeModal }: CategoryModifyModalProps)
     closeModal();
   };
 
+  useEffect(() => {
+    inputRef.name.current?.select();
+  }, []);
+
   return (
     <div css={modal} onClick={handleClickModal}>
-      <h1 css={title}>카테고리 수정</h1>
+      <h1 css={title}>카테고리 이름 수정</h1>
       <form css={form} onSubmit={handleSubmitCategoryModifyForm}>
         <div css={content}>
-          <FieldSet placeholder={category.name} autoFocus={true} refProp={inputRef.name} />
+          <FieldSet
+            placeholder={category.name}
+            defaultValue={category.name}
+            autoFocus={true}
+            refProp={inputRef.name}
+          />
         </div>
         <div css={controlButtons}>
           <Button cssProp={cancelButton(theme)} onClick={closeModal}>

--- a/frontend/src/components/MyCategoryItem/MyCategoryItem.tsx
+++ b/frontend/src/components/MyCategoryItem/MyCategoryItem.tsx
@@ -1,11 +1,15 @@
 import { useMutation, useQueryClient } from 'react-query';
 import { useRecoilValue } from 'recoil';
 
+import useToggle from '@/hooks/useToggle';
+
 import { CategoryType } from '@/@types/category';
 
 import { userState } from '@/recoil/atoms';
 
 import Button from '@/components/@common/Button/Button';
+import ModalPortal from '@/components/@common/ModalPortal/ModalPortal';
+import CategoryModifyModal from '@/components/CategoryModifyModal/CategoryModifyModal';
 
 import { CACHE_KEY, CONFIRM_MESSAGE } from '@/constants';
 
@@ -22,6 +26,9 @@ interface MyCategoryItemProps {
 
 function MyCategoryItem({ category }: MyCategoryItemProps) {
   const { accessToken } = useRecoilValue(userState);
+
+  const { state: isCategoryModifyModalOpen, toggleState: toggleCategoryModifyModalOpen } =
+    useToggle();
 
   const queryClient = useQueryClient();
   const { mutate } = useMutation(() => categoryApi.delete(accessToken, category.id), {
@@ -43,7 +50,10 @@ function MyCategoryItem({ category }: MyCategoryItemProps) {
     <div css={itemStyle}>
       <span css={nameStyle}>{category.name}</span>
       <div css={controlButtonsStyle}>
-        <Button cssProp={buttonStyle}>
+        <ModalPortal isOpen={isCategoryModifyModalOpen} closeModal={toggleCategoryModifyModalOpen}>
+          <CategoryModifyModal category={category} closeModal={toggleCategoryModifyModalOpen} />
+        </ModalPortal>
+        <Button cssProp={buttonStyle} onClick={toggleCategoryModifyModalOpen}>
           <FiEdit3 size={20} />
         </Button>
         <Button cssProp={buttonStyle} onClick={handleClickDeleteButton}>

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -45,6 +45,31 @@ const handlers = [
     return res(ctx.status(201));
   }),
 
+  rest.patch<Pick<CategoryType, 'name'>>(
+    `${API_URL}${categoryApi.endpoint.entire}/:id`,
+    (req, res, ctx) => {
+      const { id } = req.params;
+      const categoryId = parseInt(id as string);
+      const categoryIndex = categoryDB.categories.findIndex((el) => el.id === categoryId);
+      const myCategoryIndex = myCategoryDB.categories.findIndex((el) => el.id === categoryId);
+
+      if (categoryIndex < 0 || myCategoryIndex < 0) {
+        return res(ctx.status(404));
+      }
+
+      categoryDB.categories[categoryIndex] = {
+        ...categoryDB.categories[categoryIndex],
+        ...req.body,
+      };
+      myCategoryDB.categories[myCategoryIndex] = {
+        ...myCategoryDB.categories[myCategoryIndex],
+        ...req.body,
+      };
+
+      return res(ctx.status(201));
+    }
+  ),
+
   rest.delete<Pick<CategoryType, 'name'>>(
     `${API_URL}${categoryApi.endpoint.entire}/:id`,
     (req, res, ctx) => {


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 💻 git rebase를 사용했나요?
- [x] 🌈 알록달록한가요?

## 작업 내용

- [x] 카테고리 아이템 컴포넌트 구현
  - [x] 카테고리 수정 버튼
  - [x] 카테고리 수정 모달 컴포넌트 구현
- [x] msw mocking
- [x] api request

## 스크린샷

<img width="1624" alt="달록 카테고리 수정 모달" src="https://user-images.githubusercontent.com/52729559/182097229-4ba9ec4d-0392-421c-85a9-69cf25540004.png">

## 주의사항

`frontend/src/mocks/data.ts`의 `categoryDB`와 `myCategoryDB`를 각각 따로 관리하고 있습니다

Closes #84 
