### PR TITLE
[ci] 젠킨스 파이프라인 스크립트를 형상관리할 수 있도록 개선한다. 

### DIFF
--- a/jenkins/backend-dev.jenkinsfile
+++ b/jenkins/backend-dev.jenkinsfile
@@ -1,0 +1,27 @@
+pipeline {
+   agent any
+   stages {
+       stage('Github') {
+           steps {
+               git branch: 'develop', url: 'https://github.com/woowacourse-teams/2022-dallog.git'
+           }
+       }
+       stage('Build') {
+           steps {
+               dir('backend') {
+                   sh "./gradlew bootJar"
+               }
+           }
+       }
+       stage('Deploy') {
+           steps {
+               dir('backend/build/libs') {
+                   sshagent(credentials: ['key-dallog']) {
+                        sh "scp -o StrictHostKeyChecking=no backend-0.0.1-SNAPSHOT.jar ubuntu@${env.BACKEND_DEV_IP}:/home/ubuntu"
+                        sh "ssh -o StrictHostKeyChecking=no ubuntu@${env.BACKEND_DEV_IP} 'sh run.sh' &"
+                   }
+               }
+           }
+       }
+   }
+}

--- a/jenkins/backend-prod.jenkinsfile
+++ b/jenkins/backend-prod.jenkinsfile
@@ -1,0 +1,27 @@
+pipeline {
+   agent any
+   stages {
+       stage('Github') {
+           steps {
+               git branch: 'main', url: 'https://github.com/woowacourse-teams/2022-dallog.git'
+           }
+       }
+       stage('Build') {
+           steps {
+               dir('backend') {
+                   sh "./gradlew bootJar"
+               }
+           }
+       }
+       stage('Deploy') {
+           steps {
+               dir('backend/build/libs') {
+                   sshagent(credentials: ['key-dallog']) {
+                        sh "scp -o StrictHostKeyChecking=no backend-0.0.1-SNAPSHOT.jar ubuntu@${env.BACKEND_PROD_IP}:/home/ubuntu"
+                        sh "ssh -o StrictHostKeyChecking=no ubuntu@${env.BACKEND_PROD_IP} 'sh run.sh' &"
+                   }
+               }
+           }
+       }
+   }
+}

--- a/jenkins/frontend-prod.jenkinsfile
+++ b/jenkins/frontend-prod.jenkinsfile
@@ -1,0 +1,36 @@
+pipeline {
+   agent any
+   
+   environment {
+       API_URL = "https://api.dallog.me"
+   }
+   
+   stages {
+       stage('Github') {
+           steps {
+               git branch: 'develop', url: 'https://github.com/woowacourse-teams/2022-dallog.git'
+           }
+       }
+       stage('Build') {
+           steps {
+               dir('frontend') {
+                   nodejs(nodeJSInstallationName: 'NodeJS 16.14.0') {
+                        sh 'npm install && npm run build'
+                    }
+               }
+           }
+       }
+       stage('Deploy') {
+           steps {
+               dir('frontend/dist') {
+                   sshagent(credentials: ['key-dallog']) {
+                        sh 'ls'
+                        sh "scp -o StrictHostKeyChecking=no ./index.html ubuntu@${env.FRONTEND_PROD_IP}:/home/ubuntu/"
+                        sh "scp -o StrictHostKeyChecking=no ./bundle.js ubuntu@${env.FRONTEND_PROD_IP}:/home/ubuntu/"
+                        sh "ssh -o StrictHostKeyChecking=no ubuntu@${env.FRONTEND_PROD_IP} 'sudo mv ./index.html ./html && sudo mv ./bundle.js ./html'"
+                   }
+               }
+           }
+       }
+   }
+}

--- a/jenkins/frontend-prod.jenkinsfile
+++ b/jenkins/frontend-prod.jenkinsfile
@@ -24,7 +24,6 @@ pipeline {
            steps {
                dir('frontend/dist') {
                    sshagent(credentials: ['key-dallog']) {
-                        sh 'ls'
                         sh "scp -o StrictHostKeyChecking=no ./index.html ubuntu@${env.FRONTEND_PROD_IP}:/home/ubuntu/"
                         sh "scp -o StrictHostKeyChecking=no ./bundle.js ubuntu@${env.FRONTEND_PROD_IP}:/home/ubuntu/"
                         sh "ssh -o StrictHostKeyChecking=no ubuntu@${env.FRONTEND_PROD_IP} 'sudo mv ./index.html ./html && sudo mv ./bundle.js ./html'"


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 💻 git rebase를 사용했나요?
- [x] 🌈 알록달록한가요?

## 작업 내용

젠킨스의 **Pipeline script from SCM** 기능을 활용하면, 파이프라인 스크립트를 Git 저장소에 올리고 형상관리를 할 수 있게됩니다. 이 기능을 활용하기 위해 `jenkins` 라는 디렉토리를 가장 상위에 만들고, 젠킨스 job 별로 파이프라인 스크립트를 추가하였습니다. 민감한 정보 (Private IP 등)은 추가로 젠킨스의 환경변수로 분리했습니다. 젠킨스 시스템 설정을 참고해주세요.

## 스크린샷

## 주의사항

- 현재 젠킨스 세팅을 파이프라인을 Git에서 가져오도록 변경해둔 상태로 이 PR이 머지되기 전까지는 빌드가 실패할 것 입니다.
- 현재는 `dev`, `prod` 모두 `develop` 브랜치에서 파이프라인 스크립트를 가져오도록 설정해두었습니다. `prod`의 경우 `main` 브랜치에서 파이프라인 스크립트를 가져와야겠지만, 아직 배포에 대한 정확한 논의가 되지 않았으므로 유보해두었습니다.

Closes #267 
