### PR TITLE
[fix] 구독 정보가 있는 카테고리 삭제가 되지 않는 이슈를 해결한다.

### DIFF
--- a/backend/src/main/java/com/allog/dallog/domain/category/domain/Category.java
+++ b/backend/src/main/java/com/allog/dallog/domain/category/domain/Category.java
@@ -4,6 +4,7 @@ import com.allog.dallog.domain.category.exception.InvalidCategoryException;
 import com.allog.dallog.domain.common.BaseEntity;
 import com.allog.dallog.domain.member.domain.Member;
 import com.allog.dallog.domain.schedule.domain.Schedule;
+import com.allog.dallog.domain.subscription.domain.Subscription;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -38,6 +39,9 @@ public class Category extends BaseEntity {
 
     @OneToMany(mappedBy = "category")
     private List<Schedule> schedules = new ArrayList<>();
+
+    @OneToMany(mappedBy = "category", orphanRemoval = true)
+    private List<Subscription> subscriptions = new ArrayList<>();
 
     protected Category() {
     }


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 💻 git rebase를 사용했나요?
- [x] 🌈 알록달록한가요?

## 작업 내용

`Category`에 `Subscription` 에 대한 매핑을 추가하고, `orphanRemoval = true`를 추가하여, 카테고리 제거시 관련된 구독도 모두 제거되도록 개선하였습니다.

## 스크린샷

## 주의사항

Closes #252 
