### PR TITLE
[feat] 실행 환경에 따른 로깅 전략을 설정한다.

### DIFF
--- a/backend/src/main/resources/logback-spring.xml
+++ b/backend/src/main/resources/logback-spring.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<configuration>
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+    <include resource="org/springframework/boot/logging/logback/console-appender.xml"/>
+
+    <property name="LOG_PATH" value="./logs"/>
+    <property name="LOG_FILE" value="${LOG_PATH}/dallog-%d{yyyy-MM-dd}-%i.log"/>
+
+    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <encoder>
+            <pattern>${FILE_LOG_PATTERN}</pattern>
+        </encoder>
+        <file>${LOG_PATH}/dallog.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>${LOG_FILE}</fileNamePattern>
+            <maxFileSize>10MB</maxFileSize>
+            <maxHistory>10</maxHistory>
+            <totalSizeCap>100MB</totalSizeCap>
+        </rollingPolicy>
+    </appender>
+
+    <springProfile name="local">
+        <root level="INFO">
+            <appender-ref ref="CONSOLE"/>
+        </root>
+    </springProfile>
+
+    <springProfile name="dev">
+        <root level="INFO">
+            <appender-ref ref="FILE"/>
+        </root>
+    </springProfile>
+
+    <springProfile name="prod">
+        <root level="WARN">
+            <appender-ref ref="FILE"/>
+        </root>
+    </springProfile>
+</configuration>


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 💻 git rebase를 사용했나요?
- [x] 🌈 알록달록한가요?

## 작업 내용

실행 환경에 따른 로깅 전략을 설정한다.

## 참고사항

```xml
<?xml version="1.0" encoding="UTF-8" ?>
<configuration>
    <include resource="org/springframework/boot/logging/logback/defaults.xml"/> // 1
    <include resource="org/springframework/boot/logging/logback/console-appender.xml"/> // 2

    <property name="LOG_PATH" value="./logs"/> // 3
    <property name="LOG_FILE" value="${LOG_PATH}/dallog-%d{yyyy-MM-dd}-%i.log"/> // 4

    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender"> // 5
        <encoder>
            <pattern>${FILE_LOG_PATTERN}</pattern>
        </encoder>
        <file>${LOG_PATH}/dallog.log</file>
        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
            <fileNamePattern>${LOG_FILE}</fileNamePattern>
            <maxFileSize>10MB</maxFileSize>
            <maxHistory>10</maxHistory>
            <totalSizeCap>100MB</totalSizeCap>
        </rollingPolicy>
    </appender>

    <springProfile name="local"> // 6
        <root level="INFO">
            <appender-ref ref="CONSOLE"/>
        </root>
    </springProfile>

    <springProfile name="dev"> // 7
        <root level="INFO">
            <appender-ref ref="FILE"/>
        </root>
    </springProfile>

    <springProfile name="prod"> // 8
        <root level="WARN">
            <appender-ref ref="FILE"/>
        </root>
    </springProfile>
</configuration>
```

 * `1`: spring boot에서 기본적으로 제공해주는 설정 및 property가 담겨 있습니다. 저희가 console에 찍히는 로그의 형식은 `default.xml`에 명시된 것을 따라갑니다.
 * `2`: spring boot에서 기본적으로 제공해주는 `ConsoleAppender` 설정이 담겨 있습니다. 저희가 작성한 log도 동일한 형식을 따르기 위해 의존성을 추가하였습니다.
 * `3`: 저희 로그 파일이 저장되는 디렉토리 위치를 property로 추출하였습니다. 추후에 `${LOG_PATH}`와 같은 형태로 사용이 가능합니다.
 * `4`: 저희 로그 파일의 형식을 지정합니다.
 * `5`: 로그 파일 관리를 위한 Appender를 추가합니다. 
     * `file`: 현재 쌓이는 로그의 타겟 파일입니다.
     * `fileNamePattern`: rollover된 파일의 이름을 정의합니다.
     * `maxFileSize`: rollover된 파일의 최대 크기입니다. 최대 10MB까지 저장됩니다.
     * `maxHistory`: 최대로 보관하는 파일의 개수입니다.
     * `totalSizeCap`: 아카이빙한 로그 파일의 최대 사이즈입니다. 로그 파일은 총 100MB까지 저장됩니다.

 * `6`: profile local일 때 설정입니다. INFO 레벨의 로그만 console로 출력됩니다.
 * `7`: profile dev일 때 설정입니다. INFO 레벨의 로그만 console로 출력됩니다.
 * `8`: profile prod일 때 설정입니다. WARN 레벨의 로그만 console로 출력됩니다. 

## 주의사항

서브모듈이 수정되었습니다! merge 이후 `fetch + rebase` 이후 `git submodule update --init --remote` 진행해주시면 감사하겠습니다!

Closes #299 
