### PR TITLE
[fix] DTO의 필드의 유효성 검증을 통과하지 못할경우 Internal Server Error가 발생하는 버그를 해결한다.

### DIFF
--- a/backend/src/main/java/com/allog/dallog/domain/category/dto/request/CategoryCreateRequest.java
+++ b/backend/src/main/java/com/allog/dallog/domain/category/dto/request/CategoryCreateRequest.java
@@ -4,7 +4,7 @@ import javax.validation.constraints.NotBlank;
 
 public class CategoryCreateRequest {
 
-    @NotBlank
+    @NotBlank(message = "공백일 수 없습니다.")
     private String name;
 
     private boolean personal;

--- a/backend/src/main/java/com/allog/dallog/domain/category/dto/request/CategoryUpdateRequest.java
+++ b/backend/src/main/java/com/allog/dallog/domain/category/dto/request/CategoryUpdateRequest.java
@@ -4,7 +4,7 @@ import javax.validation.constraints.NotBlank;
 
 public class CategoryUpdateRequest {
 
-    @NotBlank
+    @NotBlank(message = "공백일 수 없습니다.")
     private String name;
 
     private CategoryUpdateRequest() {

--- a/backend/src/main/java/com/allog/dallog/domain/schedule/dto/request/ScheduleCreateRequest.java
+++ b/backend/src/main/java/com/allog/dallog/domain/schedule/dto/request/ScheduleCreateRequest.java
@@ -8,7 +8,7 @@ import org.springframework.format.annotation.DateTimeFormat;
 
 public class ScheduleCreateRequest {
 
-    @NotBlank
+    @NotBlank(message = "공백일 수 없습니다.")
     private String title;
 
     @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm")

--- a/backend/src/main/java/com/allog/dallog/domain/schedule/dto/request/ScheduleUpdateRequest.java
+++ b/backend/src/main/java/com/allog/dallog/domain/schedule/dto/request/ScheduleUpdateRequest.java
@@ -6,7 +6,7 @@ import org.springframework.format.annotation.DateTimeFormat;
 
 public class ScheduleUpdateRequest {
 
-    @NotBlank
+    @NotBlank(message = "공백일 수 없습니다.")
     private String title;
 
     @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm")

--- a/backend/src/main/java/com/allog/dallog/domain/schedule/dto/request/ScheduleUpdateRequest.java
+++ b/backend/src/main/java/com/allog/dallog/domain/schedule/dto/request/ScheduleUpdateRequest.java
@@ -15,7 +15,6 @@ public class ScheduleUpdateRequest {
     @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm")
     private LocalDateTime endDateTime;
 
-    @NotBlank
     private String memo;
 
     private ScheduleUpdateRequest() {

--- a/backend/src/main/java/com/allog/dallog/global/error/ControllerAdvice.java
+++ b/backend/src/main/java/com/allog/dallog/global/error/ControllerAdvice.java
@@ -21,6 +21,8 @@ import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
@@ -29,6 +31,7 @@ import org.springframework.web.method.annotation.MethodArgumentTypeMismatchExcep
 public class ControllerAdvice {
 
     private static final Logger log = LoggerFactory.getLogger(ControllerAdvice.class);
+    private static final String INVALID_DTO_FIELD_ERROR_MESSAGE_FORMAT = "%s 필드는 %s (전달된 값: %s)";
 
     @ExceptionHandler({
             InvalidCategoryException.class,
@@ -77,6 +80,16 @@ public class ControllerAdvice {
     @ExceptionHandler(HttpMessageNotReadableException.class)
     public ResponseEntity<ErrorResponse> handleInvalidRequestBody() {
         ErrorResponse errorResponse = new ErrorResponse("잘못된 형식의 Request Body 입니다.");
+        return ResponseEntity.badRequest().body(errorResponse);
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleInvalidDtoField(final MethodArgumentNotValidException e) {
+        FieldError firstFieldError = e.getFieldErrors().get(0);
+        String errorMessage = String.format(INVALID_DTO_FIELD_ERROR_MESSAGE_FORMAT, firstFieldError.getField(),
+                firstFieldError.getDefaultMessage(), firstFieldError.getRejectedValue());
+
+        ErrorResponse errorResponse = new ErrorResponse(errorMessage);
         return ResponseEntity.badRequest().body(errorResponse);
     }
 


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 💻 git rebase를 사용했나요?
- [x] 🌈 알록달록한가요?

## 작업 내용

DTO의 필드의 유효성 검증 (@NotBlank 등)을 통과하지 못할경우 Internal Server Error가 발생하는 문제를 해결합니다. 500 대신 400 Bad Request 를 반환하며, 에러가 발생한 필드와 원인에 대해 메시지를 함께 반환합니다.

## 스크린샷
<img width="458" alt="스크린샷 2022-08-11 오후 4 12 19" src="https://user-images.githubusercontent.com/11745691/184082280-ebde4081-26fc-4013-9435-b8fecaed0f01.png">

## 주의사항

Closes #177 
