### PR TITLE
[refactor] ScheduleService의 save 메소드가 Response DTO를 반환하도록 개선한다. 

### DIFF
--- a/backend/src/main/java/com/allog/dallog/domain/schedule/application/ScheduleService.java
+++ b/backend/src/main/java/com/allog/dallog/domain/schedule/application/ScheduleService.java
@@ -35,11 +35,11 @@ public class ScheduleService {
     }
 
     @Transactional
-    public Long save(final Long memberId, final Long categoryId, final ScheduleCreateRequest request) {
+    public ScheduleResponse save(final Long memberId, final Long categoryId, final ScheduleCreateRequest request) {
         Category category = categoryService.getCategory(categoryId);
         categoryService.validateCreatorBy(memberId, category);
         Schedule schedule = scheduleRepository.save(request.toEntity(category));
-        return schedule.getId();
+        return new ScheduleResponse(schedule);
     }
 
     public ScheduleResponse findById(final Long id) {

--- a/backend/src/main/java/com/allog/dallog/presentation/ScheduleController.java
+++ b/backend/src/main/java/com/allog/dallog/presentation/ScheduleController.java
@@ -32,11 +32,11 @@ public class ScheduleController {
     }
 
     @PostMapping("/categories/{categoryId}/schedules")
-    public ResponseEntity<Void> save(@AuthenticationPrincipal final LoginMember loginMember,
-                                     @PathVariable final Long categoryId,
-                                     @Valid @RequestBody final ScheduleCreateRequest request) {
-        Long id = scheduleService.save(loginMember.getId(), categoryId, request);
-        return ResponseEntity.created(URI.create("/api/schedules/" + id)).build();
+    public ResponseEntity<ScheduleResponse> save(@AuthenticationPrincipal final LoginMember loginMember,
+                                                 @PathVariable final Long categoryId,
+                                                 @Valid @RequestBody final ScheduleCreateRequest request) {
+        ScheduleResponse response = scheduleService.save(loginMember.getId(), categoryId, request);
+        return ResponseEntity.created(URI.create("/api/schedules/" + response.getId())).body(response);
     }
 
     @GetMapping("/members/me/schedules")

--- a/backend/src/test/java/com/allog/dallog/acceptance/ScheduleAcceptanceTest.java
+++ b/backend/src/test/java/com/allog/dallog/acceptance/ScheduleAcceptanceTest.java
@@ -19,6 +19,7 @@ import static com.allog.dallog.common.fixtures.ScheduleFixtures.레벨_인터뷰
 
 import com.allog.dallog.domain.category.dto.response.CategoryResponse;
 import com.allog.dallog.domain.schedule.dto.request.ScheduleUpdateRequest;
+import com.allog.dallog.domain.schedule.dto.response.ScheduleResponse;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import org.junit.jupiter.api.DisplayName;
@@ -47,11 +48,10 @@ class ScheduleAcceptanceTest extends AcceptanceTest {
         // given
         String accessToken = 자체_토큰을_생성하고_토큰을_반환한다(GOOGLE_PROVIDER, STUB_MEMBER_인증_코드);
         CategoryResponse 공통_일정_응답 = 새로운_카테고리를_등록한다(accessToken, 공통_일정_생성_요청).as(CategoryResponse.class);
-        Long 알록달록_회의_ID = Long.parseLong(새로운_일정을_등록한다(accessToken, 공통_일정_응답.getId())
-                .header("Location")
-                .split("/api/schedules/")[1]);
+        ScheduleResponse 알록달록_회의 = 새로운_일정을_등록한다(accessToken, 공통_일정_응답.getId()).as(ScheduleResponse.class);
+
         // when
-        ExtractableResponse<Response> response = 일정_아이디로_일정을_단건_조회한다(accessToken, 알록달록_회의_ID);
+        ExtractableResponse<Response> response = 일정_아이디로_일정을_단건_조회한다(accessToken, 알록달록_회의.getId());
 
         // then
         상태코드_200이_반환된다(response);
@@ -63,15 +63,12 @@ class ScheduleAcceptanceTest extends AcceptanceTest {
         // given
         String accessToken = 자체_토큰을_생성하고_토큰을_반환한다(GOOGLE_PROVIDER, STUB_MEMBER_인증_코드);
         CategoryResponse 공통_일정_응답 = 새로운_카테고리를_등록한다(accessToken, 공통_일정_생성_요청).as(CategoryResponse.class);
-        Long 알록달록_회의_ID = Long.parseLong(새로운_일정을_등록한다(accessToken, 공통_일정_응답.getId())
-                .header("Location")
-                .split("/api/schedules/")[1]);
-        // TODO:scheduleService.save()가 DTO를 반환하게 되면 수정
+        ScheduleResponse 알록달록_회의 = 새로운_일정을_등록한다(accessToken, 공통_일정_응답.getId()).as(ScheduleResponse.class);
 
         ScheduleUpdateRequest 일정_수정_요청 = new ScheduleUpdateRequest(레벨_인터뷰_제목, 레벨_인터뷰_시작일시, 레벨_인터뷰_종료일시, 레벨_인터뷰_메모);
 
         // when
-        ExtractableResponse<Response> response = 일정을_수정한다(accessToken, 알록달록_회의_ID, 일정_수정_요청);
+        ExtractableResponse<Response> response = 일정을_수정한다(accessToken, 알록달록_회의.getId(), 일정_수정_요청);
 
         // then
         상태코드_204가_반환된다(response);
@@ -83,13 +80,10 @@ class ScheduleAcceptanceTest extends AcceptanceTest {
         // given
         String accessToken = 자체_토큰을_생성하고_토큰을_반환한다(GOOGLE_PROVIDER, STUB_MEMBER_인증_코드);
         CategoryResponse 공통_일정_응답 = 새로운_카테고리를_등록한다(accessToken, 공통_일정_생성_요청).as(CategoryResponse.class);
-        Long 알록달록_회의_ID = Long.parseLong(새로운_일정을_등록한다(accessToken, 공통_일정_응답.getId())
-                .header("Location")
-                .split("/api/schedules/")[1]);
-        // TODO:scheduleService.save()가 DTO를 반환하게 되면 수정
+        ScheduleResponse 알록달록_회의 = 새로운_일정을_등록한다(accessToken, 공통_일정_응답.getId()).as(ScheduleResponse.class);
 
         // when
-        ExtractableResponse<Response> response = 일정을_삭제한다(accessToken, 알록달록_회의_ID);
+        ExtractableResponse<Response> response = 일정을_삭제한다(accessToken, 알록달록_회의.getId());
 
         // then
         상태코드_204가_반환된다(response);

--- a/backend/src/test/java/com/allog/dallog/common/fixtures/ScheduleFixtures.java
+++ b/backend/src/test/java/com/allog/dallog/common/fixtures/ScheduleFixtures.java
@@ -33,6 +33,8 @@ public class ScheduleFixtures {
     public static final String 알록달록_회의_메모 = "알록달록 회의가 있어요";
     public static final ScheduleCreateRequest 알록달록_회의_생성_요청 = new ScheduleCreateRequest(알록달록_회의_제목, 알록달록_회의_시작일시,
             알록달록_회의_종료일시, 알록달록_회의_메모);
+    public static final ScheduleResponse 알록달록_회의_응답 = new ScheduleResponse(1L, 1L, 알록달록_회의_제목, 알록달록_회의_시작일시,
+            알록달록_회의_종료일시, 알록달록_회의_메모);
 
     /* 알록달록 회식 */
     public static final String 알록달록_회식_제목 = "알록달록 회식";
@@ -63,9 +65,5 @@ public class ScheduleFixtures {
 
     public static Schedule 레벨_인터뷰(final Category category) {
         return new Schedule(category, 레벨_인터뷰_제목, 레벨_인터뷰_시작일시, 레벨_인터뷰_종료일시, 레벨_인터뷰_메모);
-    }
-
-    public static ScheduleResponse 알록달록_회의_응답() {
-        return new ScheduleResponse(1L, 1L, 알록달록_회의_제목, 알록달록_회의_시작일시, 알록달록_회의_종료일시, 알록달록_회의_메모);
     }
 }

--- a/backend/src/test/java/com/allog/dallog/domain/schedule/application/ScheduleServiceTest.java
+++ b/backend/src/test/java/com/allog/dallog/domain/schedule/application/ScheduleServiceTest.java
@@ -73,10 +73,10 @@ class ScheduleServiceTest extends ServiceTest {
         // given & when
         MemberResponse 후디 = memberService.save(후디());
         CategoryResponse BE_일정 = categoryService.save(후디.getId(), BE_일정_생성_요청);
-        Long id = scheduleService.save(후디.getId(), BE_일정.getId(), 알록달록_회의_생성_요청);
+        ScheduleResponse 알록달록_회의 = scheduleService.save(후디.getId(), BE_일정.getId(), 알록달록_회의_생성_요청);
 
         // then
-        assertThat(id).isNotNull();
+        assertThat(알록달록_회의.getTitle()).isEqualTo(알록달록_회의_제목);
     }
 
     @DisplayName("새로운 일정을 생성 할 떄 일정 제목의 길이가 50을 초과하는 경우 예외를 던진다.")
@@ -165,14 +165,14 @@ class ScheduleServiceTest extends ServiceTest {
         // given
         MemberResponse 후디 = memberService.save(후디());
         CategoryResponse BE_일정 = categoryService.save(후디.getId(), BE_일정_생성_요청);
-        Long id = scheduleService.save(후디.getId(), BE_일정.getId(), 알록달록_회의_생성_요청);
+        ScheduleResponse 알록달록_회의 = scheduleService.save(후디.getId(), BE_일정.getId(), 알록달록_회의_생성_요청);
 
         // when
-        ScheduleResponse response = scheduleService.findById(id);
+        ScheduleResponse response = scheduleService.findById(알록달록_회의.getId());
 
         // then
         assertAll(() -> {
-            assertThat(response.getId()).isEqualTo(id);
+            assertThat(response.getId()).isEqualTo(알록달록_회의.getId());
             assertThat(response.getTitle()).isEqualTo(알록달록_회의_제목);
             assertThat(response.getStartDateTime()).isEqualTo(알록달록_회의_시작일시);
             assertThat(response.getEndDateTime()).isEqualTo(알록달록_회의_종료일시);
@@ -199,18 +199,18 @@ class ScheduleServiceTest extends ServiceTest {
         // given
         MemberResponse 후디 = memberService.save(후디());
         CategoryResponse BE_일정 = categoryService.save(후디.getId(), BE_일정_생성_요청);
-        Long 기존_일정_ID = scheduleService.save(후디.getId(), BE_일정.getId(), 알록달록_회의_생성_요청);
+        ScheduleResponse 기존_일정 = scheduleService.save(후디.getId(), BE_일정.getId(), 알록달록_회의_생성_요청);
 
         ScheduleUpdateRequest 일정_수정_요청 = new ScheduleUpdateRequest(레벨_인터뷰_제목, 레벨_인터뷰_시작일시, 레벨_인터뷰_종료일시, 레벨_인터뷰_메모);
 
         // when
-        scheduleService.update(기존_일정_ID, 후디.getId(), 일정_수정_요청);
+        scheduleService.update(기존_일정.getId(), 후디.getId(), 일정_수정_요청);
 
         // then
-        ScheduleResponse actual = scheduleService.findById(기존_일정_ID);
+        ScheduleResponse actual = scheduleService.findById(기존_일정.getId());
         assertAll(
                 () -> {
-                    assertThat(actual.getId()).isEqualTo(기존_일정_ID);
+                    assertThat(actual.getId()).isEqualTo(기존_일정.getId());
                     assertThat(actual.getTitle()).isEqualTo(레벨_인터뷰_제목);
                     assertThat(actual.getStartDateTime()).isEqualTo(레벨_인터뷰_시작일시);
                     assertThat(actual.getEndDateTime()).isEqualTo(레벨_인터뷰_종료일시);
@@ -226,12 +226,12 @@ class ScheduleServiceTest extends ServiceTest {
         MemberResponse 리버 = memberService.save(리버());
         MemberResponse 후디 = memberService.save(후디());
         CategoryResponse BE_일정 = categoryService.save(후디.getId(), BE_일정_생성_요청);
-        Long 기존_일정_ID = scheduleService.save(후디.getId(), BE_일정.getId(), 알록달록_회의_생성_요청);
+        ScheduleResponse 기존_일정 = scheduleService.save(후디.getId(), BE_일정.getId(), 알록달록_회의_생성_요청);
 
         ScheduleUpdateRequest 일정_수정_요청 = new ScheduleUpdateRequest(레벨_인터뷰_제목, 레벨_인터뷰_시작일시, 레벨_인터뷰_종료일시, 레벨_인터뷰_메모);
 
         // when & then
-        assertThatThrownBy(() -> scheduleService.update(기존_일정_ID, 리버.getId(), 일정_수정_요청))
+        assertThatThrownBy(() -> scheduleService.update(기존_일정.getId(), 리버.getId(), 일정_수정_요청))
                 .isInstanceOf(NoPermissionException.class);
     }
 
@@ -241,12 +241,12 @@ class ScheduleServiceTest extends ServiceTest {
         // given
         MemberResponse 후디 = memberService.save(후디());
         CategoryResponse BE_일정 = categoryService.save(후디.getId(), BE_일정_생성_요청);
-        Long 기존_일정_ID = scheduleService.save(후디.getId(), BE_일정.getId(), 알록달록_회의_생성_요청);
+        ScheduleResponse 기존_일정 = scheduleService.save(후디.getId(), BE_일정.getId(), 알록달록_회의_생성_요청);
 
         ScheduleUpdateRequest 일정_수정_요청 = new ScheduleUpdateRequest(레벨_인터뷰_제목, 레벨_인터뷰_시작일시, 레벨_인터뷰_종료일시, 레벨_인터뷰_메모);
 
         // when & then
-        assertThatThrownBy(() -> scheduleService.update(기존_일정_ID + 1, 후디.getId(), 일정_수정_요청))
+        assertThatThrownBy(() -> scheduleService.update(기존_일정.getId() + 1, 후디.getId(), 일정_수정_요청))
                 .isInstanceOf(NoSuchScheduleException.class);
     }
 
@@ -256,13 +256,13 @@ class ScheduleServiceTest extends ServiceTest {
         // given
         MemberResponse 후디 = memberService.save(후디());
         CategoryResponse BE_일정 = categoryService.save(후디.getId(), BE_일정_생성_요청);
-        Long 알록달록_회의_ID = scheduleService.save(후디.getId(), BE_일정.getId(), 알록달록_회의_생성_요청);
+        ScheduleResponse 알록달록_회의 = scheduleService.save(후디.getId(), BE_일정.getId(), 알록달록_회의_생성_요청);
 
         // when
-        scheduleService.deleteById(알록달록_회의_ID, 후디.getId());
+        scheduleService.deleteById(알록달록_회의.getId(), 후디.getId());
 
         // then
-        assertThatThrownBy(() -> scheduleService.findById(알록달록_회의_ID))
+        assertThatThrownBy(() -> scheduleService.findById(알록달록_회의.getId()))
                 .isInstanceOf(NoSuchScheduleException.class);
     }
 
@@ -273,10 +273,10 @@ class ScheduleServiceTest extends ServiceTest {
         MemberResponse 리버 = memberService.save(리버());
         MemberResponse 후디 = memberService.save(후디());
         CategoryResponse BE_일정 = categoryService.save(후디.getId(), BE_일정_생성_요청);
-        Long 알록달록_회의_ID = scheduleService.save(후디.getId(), BE_일정.getId(), 알록달록_회의_생성_요청);
+        ScheduleResponse 알록달록_회의 = scheduleService.save(후디.getId(), BE_일정.getId(), 알록달록_회의_생성_요청);
 
         // when & then
-        assertThatThrownBy(() -> scheduleService.deleteById(알록달록_회의_ID, 리버.getId()))
+        assertThatThrownBy(() -> scheduleService.deleteById(알록달록_회의.getId(), 리버.getId()))
                 .isInstanceOf(NoPermissionException.class);
     }
 
@@ -286,10 +286,10 @@ class ScheduleServiceTest extends ServiceTest {
         // given
         MemberResponse 후디 = memberService.save(후디());
         CategoryResponse BE_일정 = categoryService.save(후디.getId(), BE_일정_생성_요청);
-        Long 알록달록_회의_ID = scheduleService.save(후디.getId(), BE_일정.getId(), 알록달록_회의_생성_요청);
+        ScheduleResponse 알록달록_회의 = scheduleService.save(후디.getId(), BE_일정.getId(), 알록달록_회의_생성_요청);
 
         // when & then
-        assertThatThrownBy(() -> scheduleService.deleteById(알록달록_회의_ID + 1, 후디.getId()))
+        assertThatThrownBy(() -> scheduleService.deleteById(알록달록_회의.getId() + 1, 후디.getId()))
                 .isInstanceOf(NoSuchScheduleException.class);
     }
 

--- a/backend/src/test/java/com/allog/dallog/presentation/ScheduleControllerTest.java
+++ b/backend/src/test/java/com/allog/dallog/presentation/ScheduleControllerTest.java
@@ -74,7 +74,7 @@ class ScheduleControllerTest extends ControllerTest {
         Long categoryId = 1L;
         ScheduleCreateRequest request = new ScheduleCreateRequest(알록달록_회의_제목, 알록달록_회의_시작일시, 알록달록_회의_종료일시, 알록달록_회의_메모);
 
-        given(scheduleService.save(any(), any(), any())).willReturn(1L);
+        given(scheduleService.save(any(), any(), any())).willReturn(알록달록_회의_응답);
 
         // when & then
         mockMvc.perform(post("/api/categories/{categoryId}/schedules", categoryId)
@@ -142,7 +142,7 @@ class ScheduleControllerTest extends ControllerTest {
         // given
         Long scheduleId = 1L;
 
-        given(scheduleService.findById(scheduleId)).willReturn(알록달록_회의_응답());
+        given(scheduleService.findById(scheduleId)).willReturn(알록달록_회의_응답);
 
         // when & then
         mockMvc.perform(get("/api/schedules/{scheduleId}", scheduleId)


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 💻 git rebase를 사용했나요?
- [x] 🌈 알록달록한가요?

## 작업 내용

ScheduleService의 save 메소드가 ID대신 Response DTO를 반환하도록 개선하였습니다. 

## 스크린샷

## 주의사항

Closes #227
