### PR TITLE
[fix] 컬러 코드 대소문자 에러를 해결한다.

### DIFF
--- a/backend/src/main/java/com/allog/dallog/domain/subscription/domain/Color.java
+++ b/backend/src/main/java/com/allog/dallog/domain/subscription/domain/Color.java
@@ -42,7 +42,7 @@ public enum Color {
 
     public static Color from(final String colorCode) {
         return Arrays.stream(Color.values())
-                .filter(color -> color.getColorCode().equals(colorCode))
+                .filter(color -> color.getColorCode().equals(colorCode.toUpperCase()))
                 .findFirst()
                 .orElseThrow(() -> new InvalidSubscriptionException("(" + colorCode + ")는 사용할 수 없는 색상입니다."));
     }

--- a/backend/src/main/resources/data.sql
+++ b/backend/src/main/resources/data.sql
@@ -23,9 +23,9 @@ VALUES ('공통 일정', 1, NOW(), NOW(), false),
        ('운동', 2, NOW(), NOW(), true);
 
 INSERT INTO subscriptions (members_id, categories_id, color, checked, created_at, updated_at)
-VALUES (2, 1, '#868e96', true, NOW(), NOW()),
-       (2, 3, '#ffdeeb', true, NOW(), NOW()),
-       (3, 1, '#d0bfff', true, NOW(), NOW()),
-       (3, 3, '#4263eb', true, NOW(), NOW()),
-       (4, 1, '#ffffff', true, NOW(), NOW()),
-       (4, 2, '#000000', true, NOW(), NOW());
+VALUES (2, 1, '#AD1457', true, NOW(), NOW()),
+       (2, 3, '#D81B60', true, NOW(), NOW()),
+       (3, 1, '#D50000', true, NOW(), NOW()),
+       (3, 3, '#E67C73', true, NOW(), NOW()),
+       (4, 1, '#F4511E', true, NOW(), NOW()),
+       (4, 2, '#EF6C00', true, NOW(), NOW());

--- a/backend/src/test/java/com/allog/dallog/domain/subscription/domain/ColorTest.java
+++ b/backend/src/test/java/com/allog/dallog/domain/subscription/domain/ColorTest.java
@@ -31,6 +31,17 @@ class ColorTest {
         assertThat(Color.from(color.getColorCode())).isEqualTo(color);
     }
 
+    @DisplayName("소문자로 들어온 color code도 가져온다.")
+    @ParameterizedTest
+    @EnumSource
+    void 소문자로_들어온_color_code도_가져온다(final Color color) {
+        // given
+        String lowerColorCode = color.getColorCode().toLowerCase();
+
+        // when & then
+        assertThat(Color.from(lowerColorCode)).isEqualTo(color);
+    }
+
     @DisplayName("존재하지 않는 color code인 경우 예외가 발생한다.")
     @ParameterizedTest
     @ValueSource(strings = {"#asdfe", "#adfqwerse"})


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 💻 git rebase를 사용했나요?
- [x] 🌈 알록달록한가요?

## 작업 내용

- 프론트에서 받은 컬러 코드를 대소문자 구분없이 찾을 수 있도록 수정
- data.sql에 수정된 컬러 코드 반영

Closes #371 
