### PR TITLE
[fix] DB에 color enum 이름을 저장하도록 data.sql을 변경한다. 

### DIFF
--- a/backend/src/main/resources/data.sql
+++ b/backend/src/main/resources/data.sql
@@ -23,9 +23,9 @@ VALUES ('공통 일정', 1, NOW(), NOW(), false),
        ('운동', 2, NOW(), NOW(), true);
 
 INSERT INTO subscriptions (members_id, categories_id, color, checked, created_at, updated_at)
-VALUES (2, 1, '#AD1457', true, NOW(), NOW()),
-       (2, 3, '#D81B60', true, NOW(), NOW()),
-       (3, 1, '#D50000', true, NOW(), NOW()),
-       (3, 3, '#E67C73', true, NOW(), NOW()),
-       (4, 1, '#F4511E', true, NOW(), NOW()),
-       (4, 2, '#EF6C00', true, NOW(), NOW());
+VALUES (2, 1, 'COLOR_1', true, NOW(), NOW()),
+       (2, 3, 'COLOR_2', true, NOW(), NOW()),
+       (3, 1, 'COLOR_3', true, NOW(), NOW()),
+       (3, 3, 'COLOR_4', true, NOW(), NOW()),
+       (4, 1, 'COLOR_5', true, NOW(), NOW()),
+       (4, 2, 'COLOR_6', true, NOW(), NOW());


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 💻 git rebase를 사용했나요?
- [x] 🌈 알록달록한가요?

## 작업 내용

DB에 color enum 이름을 저장하도록 data.sql을 변경한다. 

Closes #376 
