### PR TITLE
[ci] 백엔드 코드 커버러지가 일정 수준 이하라면 빌드가 실패하도록 Jacoco를 설정한다.

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -54,7 +54,7 @@ test {
 }
 
 jacoco {
-    toolVersion = "0.8.7"
+    toolVersion = "0.8.8"
 }
 
 jacocoTestReport {
@@ -64,7 +64,54 @@ jacocoTestReport {
         html.enabled true
 
         xml.destination file("${buildDir}/jacoco/index.xml")
+        csv.destination file("${buildDir}/jacoco/index.csv")
         html.destination file("${buildDir}/jacoco/index.html")
+    }
+
+    afterEvaluate {
+        classDirectories.setFrom(
+                files(classDirectories.files.collect {
+                    fileTree(dir: it, excludes: [
+                            '**/*Application*',
+                            '**/*Exception*',
+                            '**/dto/**',
+                            '**/infrastructure/**',
+                            '**/global/config/**',
+                            '**/BaseEntity*',
+                            '**/ControllerAdvice*',
+                            '**/AuthorizationExtractor*'
+                    ])
+                })
+        )
+    }
+
+    finalizedBy 'jacocoTestCoverageVerification'
+}
+
+jacocoTestCoverageVerification {
+    violationRules {
+        rule {
+            enabled = true
+            element = "CLASS"
+
+            // 모든 클래스 각각 라인 커버리지 75% 만족시 빌드 성공
+            limit {
+                counter = 'LINE'
+                value = 'COVEREDRATIO'
+                minimum = 0.75
+            }
+
+            excludes = [
+                    '*.*Application',
+                    '*.*Exception',
+                    '*.dto.*',
+                    '*.infrastructure.*',
+                    '*.global.config.*',
+                    '*.BaseEntity',
+                    '*.ControllerAdvice',
+                    '*.AuthorizationExtractor'
+            ]
+        }
     }
 }
 


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 💻 git rebase를 사용했나요?
- [x] 🌈 알록달록한가요?

## 작업 내용

백엔드 코드 커버러지가 일정 수준 이하라면 빌드가 실패하도록 Jacoco를 설정했습니다.

`DallogApplication`, 예외 객체, DTO 등은 커버리지 체크 대상에서 제외하였습니다. 

이 PR이 병합된 이후 개별 클래스의 라인 커버리지가 75% 이하로 떨어지면 빌드가 실패합니다. 자세한 내용은 코멘트로 달아두겠습니다.

## 스크린샷

## 주의사항

Closes #401 
