### PR TITLE
[fix] 외부 연동 카테고리는 일반 일정을 등록하거나 전체 조회할 수 없다. 

### DIFF
--- a/backend/src/main/java/com/allog/dallog/domain/category/application/CategoryService.java
+++ b/backend/src/main/java/com/allog/dallog/domain/category/application/CategoryService.java
@@ -49,7 +49,7 @@ public class CategoryService {
     public CategoryResponse save(final Long memberId, final CategoryCreateRequest request) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(NoSuchMemberException::new);
-        Category newCategory = new Category(request.getName(), member, CategoryType.valueOf(request.getCategoryType()));
+        Category newCategory = new Category(request.getName(), member, CategoryType.valueOf(request.getCategoryType().toUpperCase()));
         categoryRepository.save(newCategory);
         return new CategoryResponse(newCategory);
     }

--- a/backend/src/main/java/com/allog/dallog/domain/category/application/CategoryService.java
+++ b/backend/src/main/java/com/allog/dallog/domain/category/application/CategoryService.java
@@ -1,5 +1,7 @@
 package com.allog.dallog.domain.category.application;
 
+import static com.allog.dallog.domain.category.domain.CategoryType.NORMAL;
+
 import com.allog.dallog.domain.auth.exception.NoPermissionException;
 import com.allog.dallog.domain.category.domain.Category;
 import com.allog.dallog.domain.category.domain.CategoryRepository;
@@ -65,8 +67,9 @@ public class CategoryService {
         return categoryResponse;
     }
 
-    public CategoriesResponse findAllByName(final String name, final Pageable pageable) {
-        List<Category> categories = categoryRepository.findAllLikeCategoryName(name, pageable).getContent();
+    public CategoriesResponse findNormalByName(final String name, final Pageable pageable) {
+        List<Category> categories
+                = categoryRepository.findAllLikeCategoryNameAndCategoryType(name, NORMAL, pageable).getContent();
 
         return new CategoriesResponse(pageable.getPageNumber(), categories);
     }

--- a/backend/src/main/java/com/allog/dallog/domain/category/application/CategoryService.java
+++ b/backend/src/main/java/com/allog/dallog/domain/category/application/CategoryService.java
@@ -69,7 +69,7 @@ public class CategoryService {
 
     public CategoriesResponse findNormalByName(final String name, final Pageable pageable) {
         List<Category> categories
-                = categoryRepository.findAllLikeCategoryNameAndCategoryType(name, NORMAL, pageable).getContent();
+                = categoryRepository.findByNameContainingAndCategoryType(name, NORMAL, pageable).getContent();
 
         return new CategoriesResponse(pageable.getPageNumber(), categories);
     }

--- a/backend/src/main/java/com/allog/dallog/domain/category/domain/CategoryRepository.java
+++ b/backend/src/main/java/com/allog/dallog/domain/category/domain/CategoryRepository.java
@@ -11,7 +11,7 @@ public interface CategoryRepository extends JpaRepository<Category, Long> {
     @Query("SELECT c "
             + "FROM Category c "
             + "WHERE c.name LIKE %:name% AND c.categoryType = :categoryType")
-    Slice<Category> findAllLikeCategoryNameAndCategoryType(final String name, final CategoryType categoryType, final Pageable pageable);
+    Slice<Category> findByNameContainingAndCategoryType(final String name, final CategoryType categoryType, final Pageable pageable);
 
     @Query("SELECT c "
             + "FROM Category c "

--- a/backend/src/main/java/com/allog/dallog/domain/category/domain/CategoryRepository.java
+++ b/backend/src/main/java/com/allog/dallog/domain/category/domain/CategoryRepository.java
@@ -10,8 +10,8 @@ public interface CategoryRepository extends JpaRepository<Category, Long> {
 
     @Query("SELECT c "
             + "FROM Category c "
-            + "WHERE c.name LIKE %:name% AND c.categoryType <> com.allog.dallog.domain.category.domain.CategoryType.PERSONAL")
-    Slice<Category> findAllLikeCategoryName(final String name, final Pageable pageable);
+            + "WHERE c.name LIKE %:name% AND c.categoryType = :categoryType")
+    Slice<Category> findAllLikeCategoryNameAndCategoryType(final String name, final CategoryType categoryType, final Pageable pageable);
 
     @Query("SELECT c "
             + "FROM Category c "

--- a/backend/src/main/java/com/allog/dallog/domain/category/domain/CategoryType.java
+++ b/backend/src/main/java/com/allog/dallog/domain/category/domain/CategoryType.java
@@ -1,6 +1,16 @@
 package com.allog.dallog.domain.category.domain;
 
+import com.allog.dallog.domain.category.exception.InvalidCategoryException;
+
 public enum CategoryType {
 
-    NORMAL, PERSONAL, GOOGLE
+    NORMAL, PERSONAL, GOOGLE;
+
+    public static CategoryType from(final String value) {
+        try {
+            return CategoryType.valueOf(value.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new InvalidCategoryException("(" + value + ")는 존재하지 않는 카테고리 타입입니다.");
+        }
+    }
 }

--- a/backend/src/main/java/com/allog/dallog/domain/category/domain/CategoryType.java
+++ b/backend/src/main/java/com/allog/dallog/domain/category/domain/CategoryType.java
@@ -1,6 +1,6 @@
 package com.allog.dallog.domain.category.domain;
 
-import com.allog.dallog.domain.category.exception.InvalidCategoryException;
+import com.allog.dallog.domain.category.exception.NoSuchCategoryException;
 
 public enum CategoryType {
 
@@ -10,7 +10,7 @@ public enum CategoryType {
         try {
             return CategoryType.valueOf(value.toUpperCase());
         } catch (IllegalArgumentException e) {
-            throw new InvalidCategoryException("(" + value + ")는 존재하지 않는 카테고리 타입입니다.");
+            throw new NoSuchCategoryException("(" + value + ")는 존재하지 않는 카테고리 타입입니다.");
         }
     }
 }

--- a/backend/src/main/java/com/allog/dallog/domain/category/dto/request/CategoryCreateRequest.java
+++ b/backend/src/main/java/com/allog/dallog/domain/category/dto/request/CategoryCreateRequest.java
@@ -8,6 +8,7 @@ public class CategoryCreateRequest {
     @NotBlank(message = "공백일 수 없습니다.")
     private String name;
 
+    @NotBlank(message = "공백일 수 없습니다.")
     private String categoryType;
 
     private CategoryCreateRequest() {

--- a/backend/src/main/java/com/allog/dallog/domain/schedule/application/ScheduleService.java
+++ b/backend/src/main/java/com/allog/dallog/domain/schedule/application/ScheduleService.java
@@ -1,5 +1,6 @@
 package com.allog.dallog.domain.schedule.application;
 
+import com.allog.dallog.domain.auth.exception.NoPermissionException;
 import com.allog.dallog.domain.category.application.CategoryService;
 import com.allog.dallog.domain.category.domain.Category;
 import com.allog.dallog.domain.schedule.domain.Schedule;
@@ -27,8 +28,16 @@ public class ScheduleService {
     public ScheduleResponse save(final Long memberId, final Long categoryId, final ScheduleCreateRequest request) {
         Category category = categoryService.getCategory(categoryId);
         categoryService.validateCreatorBy(memberId, category);
+        validateExternal(category);
+
         Schedule schedule = scheduleRepository.save(request.toEntity(category));
         return new ScheduleResponse(schedule);
+    }
+
+    private static void validateExternal(final Category category) {
+        if (category.isExternal()) {
+            throw new NoPermissionException("외부 연동 카테고리에는 일정을 추가할 수 없습니다.");
+        }
     }
 
     public ScheduleResponse findById(final Long id) {

--- a/backend/src/main/java/com/allog/dallog/domain/schedule/application/ScheduleService.java
+++ b/backend/src/main/java/com/allog/dallog/domain/schedule/application/ScheduleService.java
@@ -28,13 +28,13 @@ public class ScheduleService {
     public ScheduleResponse save(final Long memberId, final Long categoryId, final ScheduleCreateRequest request) {
         Category category = categoryService.getCategory(categoryId);
         categoryService.validateCreatorBy(memberId, category);
-        validateExternalType(category);
+        validateCategoryType(category);
 
         Schedule schedule = scheduleRepository.save(request.toEntity(category));
         return new ScheduleResponse(schedule);
     }
 
-    private static void validateExternalType(final Category category) {
+    private static void validateCategoryType(final Category category) {
         if (category.isExternal()) {
             throw new NoPermissionException("외부 연동 카테고리에는 일정을 추가할 수 없습니다.");
         }

--- a/backend/src/main/java/com/allog/dallog/domain/schedule/application/ScheduleService.java
+++ b/backend/src/main/java/com/allog/dallog/domain/schedule/application/ScheduleService.java
@@ -28,13 +28,13 @@ public class ScheduleService {
     public ScheduleResponse save(final Long memberId, final Long categoryId, final ScheduleCreateRequest request) {
         Category category = categoryService.getCategory(categoryId);
         categoryService.validateCreatorBy(memberId, category);
-        validateExternal(category);
+        validateExternalType(category);
 
         Schedule schedule = scheduleRepository.save(request.toEntity(category));
         return new ScheduleResponse(schedule);
     }
 
-    private static void validateExternal(final Category category) {
+    private static void validateExternalType(final Category category) {
         if (category.isExternal()) {
             throw new NoPermissionException("외부 연동 카테고리에는 일정을 추가할 수 없습니다.");
         }

--- a/backend/src/main/java/com/allog/dallog/presentation/CategoryController.java
+++ b/backend/src/main/java/com/allog/dallog/presentation/CategoryController.java
@@ -45,7 +45,7 @@ public class CategoryController {
     @GetMapping
     public ResponseEntity<CategoriesResponse> findAllByName(@RequestParam(defaultValue = "") final String name,
                                                             final Pageable pageable) {
-        return ResponseEntity.ok(categoryService.findAllByName(name, pageable));
+        return ResponseEntity.ok(categoryService.findNormalByName(name, pageable));
     }
 
     @GetMapping("/me")

--- a/backend/src/test/java/com/allog/dallog/common/fixtures/CategoryFixtures.java
+++ b/backend/src/test/java/com/allog/dallog/common/fixtures/CategoryFixtures.java
@@ -65,6 +65,10 @@ public class CategoryFixtures {
         return new Category(내_일정_이름, creator, PERSONAL);
     }
 
+    public static Category 우아한테크코스_일정(final Member creator) {
+        return new Category(우아한테크코스_이름, creator, GOOGLE);
+    }
+
     public static CategoryResponse 공통_일정_응답(final MemberResponse creatorResponse) {
         return new CategoryResponse(1L, 공통_일정_이름, creatorResponse, LocalDateTime.now());
     }

--- a/backend/src/test/java/com/allog/dallog/domain/category/application/CategoryServiceTest.java
+++ b/backend/src/test/java/com/allog/dallog/domain/category/application/CategoryServiceTest.java
@@ -147,7 +147,7 @@ class CategoryServiceTest extends ServiceTest {
         PageRequest request = PageRequest.of(0, 3);
 
         // when
-        CategoriesResponse response = categoryService.findAllByName("일", request);
+        CategoriesResponse response = categoryService.findNormalByName("일", request);
 
         // then
         assertThat(response.getCategories())
@@ -165,7 +165,7 @@ class CategoryServiceTest extends ServiceTest {
         categoryService.save(후디.getId(), 내_일정_생성_요청);
 
         // when
-        CategoriesResponse response = categoryService.findAllByName("", PageRequest.of(0, 10));
+        CategoriesResponse response = categoryService.findNormalByName("", PageRequest.of(0, 10));
 
         // then
         assertThat(response.getCategories()).hasSize(0);

--- a/backend/src/test/java/com/allog/dallog/domain/category/domain/CategoryRepositoryTest.java
+++ b/backend/src/test/java/com/allog/dallog/domain/category/domain/CategoryRepositoryTest.java
@@ -6,7 +6,7 @@ import static com.allog.dallog.common.fixtures.CategoryFixtures.FE_일정;
 import static com.allog.dallog.common.fixtures.CategoryFixtures.FE_일정_이름;
 import static com.allog.dallog.common.fixtures.CategoryFixtures.공통_일정;
 import static com.allog.dallog.common.fixtures.CategoryFixtures.공통_일정_이름;
-import static com.allog.dallog.common.fixtures.CategoryFixtures.구글_연동_일정;
+import static com.allog.dallog.common.fixtures.CategoryFixtures.우아한테크코스_일정;
 import static com.allog.dallog.common.fixtures.CategoryFixtures.내_일정;
 import static com.allog.dallog.common.fixtures.CategoryFixtures.매트_아고라;
 import static com.allog.dallog.common.fixtures.CategoryFixtures.후디_JPA_스터디;
@@ -46,12 +46,12 @@ class CategoryRepositoryTest extends RepositoryTest {
         categoryRepository.save(매트_아고라(관리자));
         categoryRepository.save(후디_JPA_스터디(관리자));
         categoryRepository.save(내_일정(관리자));
-        categoryRepository.save(구글_연동_일정(관리자));
+        categoryRepository.save(우아한테크코스_일정(관리자));
 
         PageRequest pageRequest = PageRequest.of(0, 5);
 
         // when
-        Slice<Category> actual = categoryRepository.findAllLikeCategoryNameAndCategoryType("일", NORMAL, pageRequest);
+        Slice<Category> actual = categoryRepository.findByNameContainingAndCategoryType("일", NORMAL, pageRequest);
 
         // then
         assertThat(actual.getContent()).hasSize(3)
@@ -73,7 +73,7 @@ class CategoryRepositoryTest extends RepositoryTest {
         PageRequest pageRequest = PageRequest.of(0, 5);
 
         // when
-        Slice<Category> actual = categoryRepository.findAllLikeCategoryNameAndCategoryType("파랑", NORMAL, pageRequest);
+        Slice<Category> actual = categoryRepository.findByNameContainingAndCategoryType("파랑", NORMAL, pageRequest);
 
         // then
         assertThat(actual.getContent()).hasSize(0);

--- a/backend/src/test/java/com/allog/dallog/domain/category/domain/CategoryRepositoryTest.java
+++ b/backend/src/test/java/com/allog/dallog/domain/category/domain/CategoryRepositoryTest.java
@@ -6,10 +6,13 @@ import static com.allog.dallog.common.fixtures.CategoryFixtures.FE_일정;
 import static com.allog.dallog.common.fixtures.CategoryFixtures.FE_일정_이름;
 import static com.allog.dallog.common.fixtures.CategoryFixtures.공통_일정;
 import static com.allog.dallog.common.fixtures.CategoryFixtures.공통_일정_이름;
+import static com.allog.dallog.common.fixtures.CategoryFixtures.구글_연동_일정;
+import static com.allog.dallog.common.fixtures.CategoryFixtures.내_일정;
 import static com.allog.dallog.common.fixtures.CategoryFixtures.매트_아고라;
 import static com.allog.dallog.common.fixtures.CategoryFixtures.후디_JPA_스터디;
 import static com.allog.dallog.common.fixtures.MemberFixtures.관리자;
 import static com.allog.dallog.common.fixtures.MemberFixtures.후디;
+import static com.allog.dallog.domain.category.domain.CategoryType.NORMAL;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
@@ -32,9 +35,9 @@ class CategoryRepositoryTest extends RepositoryTest {
     @Autowired
     private MemberRepository memberRepository;
 
-    @DisplayName("페이지와 사이즈와 카테고리 이름을 활용하여 해당하는 카테고리를 조회한다.")
+    @DisplayName("카테고리 이름과 타입과 페이징을 활용하여 해당하는 카테고리를 조회한다.")
     @Test
-    void 페이지와_사이즈와_카테고리_이름을_활용하여_해당하는_카테고리를_조회한다() {
+    void 카테고리_이름과_타입과_페이징을_활용하여_해당하는_카테고리를_조회한다() {
         // given
         Member 관리자 = memberRepository.save(관리자());
         categoryRepository.save(공통_일정(관리자));
@@ -42,11 +45,13 @@ class CategoryRepositoryTest extends RepositoryTest {
         categoryRepository.save(FE_일정(관리자));
         categoryRepository.save(매트_아고라(관리자));
         categoryRepository.save(후디_JPA_스터디(관리자));
+        categoryRepository.save(내_일정(관리자));
+        categoryRepository.save(구글_연동_일정(관리자));
 
         PageRequest pageRequest = PageRequest.of(0, 5);
 
         // when
-        Slice<Category> actual = categoryRepository.findAllLikeCategoryName("일", pageRequest);
+        Slice<Category> actual = categoryRepository.findAllLikeCategoryNameAndCategoryType("일", NORMAL, pageRequest);
 
         // then
         assertThat(actual.getContent()).hasSize(3)
@@ -68,7 +73,7 @@ class CategoryRepositoryTest extends RepositoryTest {
         PageRequest pageRequest = PageRequest.of(0, 5);
 
         // when
-        Slice<Category> actual = categoryRepository.findAllLikeCategoryName("파랑", pageRequest);
+        Slice<Category> actual = categoryRepository.findAllLikeCategoryNameAndCategoryType("파랑", NORMAL, pageRequest);
 
         // then
         assertThat(actual.getContent()).hasSize(0);

--- a/backend/src/test/java/com/allog/dallog/domain/category/domain/CategoryTest.java
+++ b/backend/src/test/java/com/allog/dallog/domain/category/domain/CategoryTest.java
@@ -1,6 +1,7 @@
 package com.allog.dallog.domain.category.domain;
 
 import static com.allog.dallog.common.fixtures.CategoryFixtures.BE_일정;
+import static com.allog.dallog.common.fixtures.CategoryFixtures.우아한테크코스_일정;
 import static com.allog.dallog.common.fixtures.CategoryFixtures.내_일정;
 import static com.allog.dallog.common.fixtures.MemberFixtures.관리자;
 import static com.allog.dallog.common.fixtures.MemberFixtures.후디;
@@ -79,6 +80,19 @@ class CategoryTest {
 
         // when
         boolean actual = 내_일정.isPersonal();
+
+        // then
+        assertThat(actual).isTrue();
+    }
+
+    @DisplayName("외부 연동 카테고리면 true를 반환한다.")
+    @Test
+    void 외부_연동_카테고리면_true를_반환한다() {
+        // given
+        Category 우아한테크코스_일정 = 우아한테크코스_일정(관리자());
+
+        // when
+        boolean actual = 우아한테크코스_일정.isExternal();
 
         // then
         assertThat(actual).isTrue();

--- a/backend/src/test/java/com/allog/dallog/domain/category/domain/CategoryTypeTest.java
+++ b/backend/src/test/java/com/allog/dallog/domain/category/domain/CategoryTypeTest.java
@@ -1,9 +1,12 @@
 package com.allog.dallog.domain.category.domain;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+import com.allog.dallog.domain.category.exception.NoSuchCategoryException;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
@@ -18,5 +21,16 @@ public class CategoryTypeTest {
             assertThat(CategoryType.from(categoryType.name())).isEqualTo(categoryType);
             assertThat(CategoryType.from(categoryType.name().toLowerCase())).isEqualTo(categoryType);
         });
+    }
+
+    @DisplayName("존재하지 않는 카테고리 종류인 경우 예외를 던진다.")
+    @Test
+    void 존재하지_않는_카테고리_종류인_경우_예외를_던진다() {
+        // given
+        String notExistingCategoryType = "존재하지 않는 카테고리 종류";
+
+        // when & then
+        assertThatThrownBy(() -> CategoryType.from(notExistingCategoryType))
+                .isInstanceOf(NoSuchCategoryException.class);
     }
 }

--- a/backend/src/test/java/com/allog/dallog/domain/category/domain/CategoryTypeTest.java
+++ b/backend/src/test/java/com/allog/dallog/domain/category/domain/CategoryTypeTest.java
@@ -1,0 +1,22 @@
+package com.allog.dallog.domain.category.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+public class CategoryTypeTest {
+
+    @DisplayName("카테고리 종류를 가져온다.")
+    @ParameterizedTest
+    @EnumSource
+    void 카테고리_종류를_가져온다(final CategoryType categoryType) {
+        // given & when & then
+        assertAll(() -> {
+            assertThat(CategoryType.from(categoryType.name())).isEqualTo(categoryType);
+            assertThat(CategoryType.from(categoryType.name().toLowerCase())).isEqualTo(categoryType);
+        });
+    }
+}

--- a/backend/src/test/java/com/allog/dallog/domain/schedule/application/ScheduleServiceTest.java
+++ b/backend/src/test/java/com/allog/dallog/domain/schedule/application/ScheduleServiceTest.java
@@ -1,6 +1,7 @@
 package com.allog.dallog.domain.schedule.application;
 
 import static com.allog.dallog.common.fixtures.CategoryFixtures.BE_일정_생성_요청;
+import static com.allog.dallog.common.fixtures.ExternalCategoryFixtures.대한민국_공휴일_생성_요청;
 import static com.allog.dallog.common.fixtures.MemberFixtures.리버;
 import static com.allog.dallog.common.fixtures.MemberFixtures.후디;
 import static com.allog.dallog.common.fixtures.ScheduleFixtures.날짜_2022년_7월_15일_16시_0분;
@@ -137,6 +138,22 @@ class ScheduleServiceTest extends ServiceTest {
         // when & then
         assertThatThrownBy(() -> scheduleService.save(후디.getId(), 0L, 일정_생성_요청)).
                 isInstanceOf(NoSuchCategoryException.class);
+    }
+
+    @DisplayName("일정 생성시 전달한 카테고리가 외부 연동 카테고리라면 예외를 던진다.")
+    @Test
+    void 일정_생성시_전달한_카테고리가_외부_연동_카테고리라면_예외를_던진다() {
+        // given
+        MemberResponse 후디 = memberService.save(후디());
+        CategoryResponse 대한민국_공휴일 = categoryService.save(후디.getId(), 대한민국_공휴일_생성_요청);
+
+        LocalDateTime 시작일시 = 날짜_2022년_7월_15일_16시_0분;
+        LocalDateTime 종료일시 = 날짜_2022년_7월_31일_0시_0분;
+        ScheduleCreateRequest 일정_생성_요청 = new ScheduleCreateRequest(알록달록_회의_제목, 시작일시, 종료일시, 알록달록_회의_메모);
+
+        // when & then
+        assertThatThrownBy(() -> scheduleService.save(후디.getId(), 대한민국_공휴일.getId(), 일정_생성_요청)).
+                isInstanceOf(NoPermissionException.class);
     }
 
     @DisplayName("일정의 ID로 단건 일정을 조회한다.")

--- a/backend/src/test/java/com/allog/dallog/presentation/CategoryControllerTest.java
+++ b/backend/src/test/java/com/allog/dallog/presentation/CategoryControllerTest.java
@@ -130,7 +130,7 @@ class CategoryControllerTest extends ControllerTest {
 
         List<Category> 일정_목록 = List.of(공통_일정(관리자()), BE_일정(관리자()), FE_일정(관리자()), 후디_JPA_스터디(후디()), 매트_아고라(매트()));
         CategoriesResponse categoriesResponse = new CategoriesResponse(page, 일정_목록);
-        given(categoryService.findAllByName(any(), any())).willReturn(categoriesResponse);
+        given(categoryService.findNormalByName(any(), any())).willReturn(categoriesResponse);
 
         // when & then
         mockMvc.perform(get("/api/categories?page={page}&size={size}", page, size)
@@ -159,7 +159,7 @@ class CategoryControllerTest extends ControllerTest {
 
         List<Category> 일정_목록 = List.of(공통_일정(관리자()), BE_일정(관리자()), FE_일정(관리자()));
         CategoriesResponse categoriesResponse = new CategoriesResponse(page, 일정_목록);
-        given(categoryService.findAllByName(any(), any())).willReturn(categoriesResponse);
+        given(categoryService.findNormalByName(any(), any())).willReturn(categoriesResponse);
 
         // when & then
         mockMvc.perform(get("/api/categories?name={name}&page={page}&size={size}", "E", page, size)


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 💻 git rebase를 사용했나요?
- [x] 🌈 알록달록한가요?

## 작업 내용

- 외부 연동 카테고리에는 일반 일정을 등록할 수 없도록 막는다.
- 외부 연동 카테고리를 전체 조회 목록에서 제외시킨다.

Closes #429 
