### PR TITLE
[ci] 젠킨스에서 프론트엔드 프로젝트 빌드시 npm 대신 yarn 을 사용하도록 변경한다.

### DIFF
--- a/jenkins/frontend-dev.jenkinsfile
+++ b/jenkins/frontend-dev.jenkinsfile
@@ -14,7 +14,9 @@ pipeline {
                 dir('frontend') {
                     sh "echo 'API_URL = ${API_URL}' > .env"
                     nodejs(nodeJSInstallationName: 'NodeJS 16.14.0') {
-                        sh 'npm cache clean --force && npm install && npm run build'
+                        sh "npm install -g yarn"
+                        sh "yarn"
+                        sh "yarn prod-build"
                     }
                 }
             }

--- a/jenkins/frontend-prod.jenkinsfile
+++ b/jenkins/frontend-prod.jenkinsfile
@@ -14,7 +14,9 @@ pipeline {
                 dir('frontend') {
                     sh "echo 'API_URL = ${API_URL}' > .env"
                     nodejs(nodeJSInstallationName: 'NodeJS 16.14.0') {
-                        sh 'npm cache clean --force && npm install && npm run build'
+                        sh "npm install -g yarn"
+                        sh "yarn"
+                        sh "yarn prod-build"
                     }
                 }
             }


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 💻 git rebase를 사용했나요?
- [x] 🌈 알록달록한가요?

## 작업 내용

젠킨스에서 프론트엔드 프로젝트 빌드시 npm 대신 yarn 을 사용하도록 변경합니다.

## 스크린샷

## 주의사항

Closes #443 
