### PR TITLE
[feat] 일정 조율 기능을 외부 일정(구글 캘린더)도 조율 대상에 포함하도록 개선한다.

### DIFF
--- a/backend/src/docs/asciidoc/subscription.adoc
+++ b/backend/src/docs/asciidoc/subscription.adoc
@@ -18,6 +18,16 @@ include::{snippets}/subscription/save/request-headers.adoc[]
 
 include::{snippets}/subscription/save/http-response.adoc[]
 
+=== 자신의 구독 목록 조회
+
+==== Request
+
+include::{snippets}/subscription/findMine/http-request.adoc[]
+
+==== Response
+
+include::{snippets}/subscription/findMine/http-response.adoc[]
+
 === 중복된 구독 등록
 
 ==== Request

--- a/backend/src/main/java/com/allog/dallog/domain/integrationschedule/domain/IntegrationSchedule.java
+++ b/backend/src/main/java/com/allog/dallog/domain/integrationschedule/domain/IntegrationSchedule.java
@@ -6,6 +6,7 @@ import com.allog.dallog.domain.subscription.domain.Color;
 import com.allog.dallog.domain.subscription.domain.Subscription;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Objects;
 
 public class IntegrationSchedule {
 
@@ -94,5 +95,26 @@ public class IntegrationSchedule {
 
     public String getCategoryType() {
         return categoryType;
+    }
+
+    // 중복 일정을 판별하기 위한 equals & hashCode
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        IntegrationSchedule that = (IntegrationSchedule) o;
+        return Objects.equals(id, that.id) && Objects.equals(categoryId, that.categoryId)
+                && Objects.equals(title, that.title) && Objects.equals(period, that.period)
+                && Objects.equals(memo, that.memo) && Objects.equals(categoryType, that.categoryType);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, categoryId, title, period, memo, categoryType);
     }
 }

--- a/backend/src/test/java/com/allog/dallog/domain/composition/application/CalendarServiceTest.java
+++ b/backend/src/test/java/com/allog/dallog/domain/composition/application/CalendarServiceTest.java
@@ -1,7 +1,13 @@
 package com.allog.dallog.domain.composition.application;
 
 import static com.allog.dallog.common.fixtures.CategoryFixtures.BE_일정_생성_요청;
+import static com.allog.dallog.common.fixtures.CategoryFixtures.FE_일정_생성_요청;
+import static com.allog.dallog.common.fixtures.CategoryFixtures.공통_일정_생성_요청;
 import static com.allog.dallog.common.fixtures.CategoryFixtures.우아한테크코스_외부_일정_생성_요청;
+import static com.allog.dallog.common.fixtures.MemberFixtures.관리자;
+import static com.allog.dallog.common.fixtures.MemberFixtures.리버;
+import static com.allog.dallog.common.fixtures.MemberFixtures.매트;
+import static com.allog.dallog.common.fixtures.MemberFixtures.파랑;
 import static com.allog.dallog.common.fixtures.MemberFixtures.후디;
 import static com.allog.dallog.common.fixtures.ScheduleFixtures.날짜_2022년_7월_10일_0시_0분;
 import static com.allog.dallog.common.fixtures.ScheduleFixtures.날짜_2022년_7월_10일_11시_59분;
@@ -30,6 +36,7 @@ import com.allog.dallog.domain.category.domain.Category;
 import com.allog.dallog.domain.category.domain.ExternalCategoryDetail;
 import com.allog.dallog.domain.category.domain.ExternalCategoryDetailRepository;
 import com.allog.dallog.domain.category.dto.response.CategoryResponse;
+import com.allog.dallog.domain.integrationschedule.domain.IntegrationSchedule;
 import com.allog.dallog.domain.member.application.MemberService;
 import com.allog.dallog.domain.member.dto.MemberResponse;
 import com.allog.dallog.domain.schedule.application.ScheduleService;
@@ -38,6 +45,7 @@ import com.allog.dallog.domain.schedule.dto.request.ScheduleCreateRequest;
 import com.allog.dallog.domain.schedule.dto.response.MemberScheduleResponse;
 import com.allog.dallog.domain.schedule.dto.response.MemberScheduleResponses;
 import com.allog.dallog.domain.subscription.application.SubscriptionService;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -126,5 +134,58 @@ class CalendarServiceTest extends ServiceTest {
             assertThat(memberScheduleResponses.getFewHours()).extracting(MemberScheduleResponse::getTitle)
                     .contains("몇시간 첫번째", "몇시간 두번째", "몇시간 세번째", "몇시간 네번째");
         });
+    }
+
+    // TODO: 외부 일정을 잘 가져오는지를 테스트 해야함
+    @DisplayName("카테고리를 구독하는 유저들의 모든 내부 일정을 가져온다.")
+    @Test
+    void 카테고리를_구독하는_유저들의_모든_내부_일정을_가져온다() {
+        // given
+        MemberResponse 관리자 = memberService.save(관리자());
+        CategoryResponse 공통_일정 = categoryService.save(관리자.getId(), 공통_일정_생성_요청);
+        CategoryResponse BE_일정 = categoryService.save(관리자.getId(), BE_일정_생성_요청);
+        CategoryResponse FE_일정 = categoryService.save(관리자.getId(), FE_일정_생성_요청);
+
+        /* 카테고리에 일정 추가 */
+        scheduleService.save(관리자.getId(), 공통_일정.getId(),
+                new ScheduleCreateRequest("공통 일정 1", 날짜_2022년_7월_7일_16시_0분, 날짜_2022년_7월_10일_0시_0분, ""));
+        scheduleService.save(관리자.getId(), 공통_일정.getId(),
+                new ScheduleCreateRequest("공통 일정 2", 날짜_2022년_7월_10일_11시_59분, 날짜_2022년_7월_15일_16시_0분, ""));
+        scheduleService.save(관리자.getId(), 공통_일정.getId(),
+                new ScheduleCreateRequest("공통 일정 3", 날짜_2022년_7월_16일_16시_0분, 날짜_2022년_7월_16일_16시_1분, ""));
+        scheduleService.save(관리자.getId(), BE_일정.getId(),
+                new ScheduleCreateRequest("백엔드 일정 1", 날짜_2022년_7월_16일_18시_0분, 날짜_2022년_7월_16일_20시_0분, ""));
+        scheduleService.save(관리자.getId(), BE_일정.getId(),
+                new ScheduleCreateRequest("백엔드 일정 2", 날짜_2022년_7월_16일_20시_0분, 날짜_2022년_7월_20일_0시_0분, ""));
+        scheduleService.save(관리자.getId(), BE_일정.getId(),
+                new ScheduleCreateRequest("백엔드 일정 3", 날짜_2022년_7월_20일_11시_59분, 날짜_2022년_7월_27일_0시_0분, ""));
+        scheduleService.save(관리자.getId(), FE_일정.getId(),
+                new ScheduleCreateRequest("프론트엔드 일정 1", 날짜_2022년_7월_27일_11시_59분, 날짜_2022년_7월_31일_0시_0분, ""));
+        scheduleService.save(관리자.getId(), FE_일정.getId(),
+                new ScheduleCreateRequest("프론트엔드 일정 2", 날짜_2022년_7월_31일_0시_0분, 날짜_2022년_8월_15일_14시_0분, ""));
+
+        /* 카테고리 구독 */
+        MemberResponse 후디 = memberService.save(후디());
+        MemberResponse 파랑 = memberService.save(파랑());
+        MemberResponse 매트 = memberService.save(매트());
+        MemberResponse 리버 = memberService.save(리버());
+
+        subscriptionService.save(후디.getId(), 공통_일정.getId());
+        subscriptionService.save(파랑.getId(), 공통_일정.getId());
+        subscriptionService.save(매트.getId(), 공통_일정.getId());
+        subscriptionService.save(리버.getId(), 공통_일정.getId());
+
+        subscriptionService.save(매트.getId(), BE_일정.getId());
+        subscriptionService.save(매트.getId(), FE_일정.getId());
+        subscriptionService.save(리버.getId(), FE_일정.getId());
+
+        // when
+        List<IntegrationSchedule> actual = calendarService.getSchedulesOfSubscribersByCategoryId(공통_일정.getId(),
+                new DateRangeRequest("2022-07-07T16:00", "2022-08-15T14:00"));
+
+        // then
+        assertThat(actual.stream().map(IntegrationSchedule::getTitle))
+                .containsExactly("공통 일정 1", "공통 일정 2", "공통 일정 3", "백엔드 일정 1", "백엔드 일정 2", "백엔드 일정 3", "프론트엔드 일정 1",
+                        "프론트엔드 일정 2");
     }
 }

--- a/backend/src/test/java/com/allog/dallog/presentation/SubscriptionControllerTest.java
+++ b/backend/src/test/java/com/allog/dallog/presentation/SubscriptionControllerTest.java
@@ -85,6 +85,30 @@ class SubscriptionControllerTest extends ControllerTest {
                 .andExpect(status().isCreated());
     }
 
+    @DisplayName("자신의 구독 목록을 가져온다.")
+    @Test
+    void 자신의_구독_목록을_가져온다() throws Exception {
+        // given
+        CategoryResponse 공통_일정_응답 = 공통_일정_응답(관리자_응답);
+
+        SubscriptionsResponse subscriptionsResponse = new SubscriptionsResponse(
+                List.of(색상1_구독_응답(공통_일정_응답), 색상2_구독_응답(공통_일정_응답), 색상3_구독_응답(공통_일정_응답)));
+
+        given(subscriptionService.findByMemberId(any()))
+                .willReturn(subscriptionsResponse);
+
+        // when & then
+        mockMvc.perform(get("/api/members/me/subscriptions", 공통_일정_응답.getId())
+                        .header(AUTHORIZATION_HEADER_NAME, AUTHORIZATION_HEADER_VALUE)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andDo(document("subscription/findMine",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint())
+                ))
+                .andExpect(status().isOk());
+    }
+
     @DisplayName("회원이 이미 카테고리를 구독한 경우 예외를 던진다.")
     @Test
     void 회원이_이미_카테고리를_구독한_경우_예외를_던진다() throws Exception {


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 💻 git rebase를 사용했나요?
- [x] 🌈 알록달록한가요?

## 작업 내용

일정 조율 기능을 외부 일정(구글 캘린더)도 조율 대상에 포함하도록 개선했습니다. `CalendarService` 를 조금 수정했어요. 나중에 몰아서 리팩토링 해야할 것 같아요.

그리고 외부 일정 테스트는 모킹말고는 답이 없을 것 같아서 테스트 코드를 작성하지 못했어요. 내일 QA때 빡빡하게 돌려봐야 할 것 같습니다. 

## 스크린샷

## 주의사항

Closes #466 
