### PR TITLE
구글 OAuth 요청 uri 생성 시 prompt 설정을 제거한다.

### DIFF
--- a/backend/src/main/java/com/allog/dallog/global/config/properties/GoogleProperties.java
+++ b/backend/src/main/java/com/allog/dallog/global/config/properties/GoogleProperties.java
@@ -16,11 +16,10 @@ public class GoogleProperties {
     private final List<String> scopes;
     private final String tokenUri;
     private final String accessType;
-    private final String prompt;
 
     public GoogleProperties(final String clientId, final String clientSecret, final String redirectUri,
                             final String oAuthEndPoint, final String responseType, final List<String> scopes,
-                            final String tokenUri, final String accessType, final String prompt) {
+                            final String tokenUri, final String accessType) {
         this.clientId = clientId;
         this.clientSecret = clientSecret;
         this.redirectUri = redirectUri;
@@ -29,7 +28,6 @@ public class GoogleProperties {
         this.scopes = scopes;
         this.tokenUri = tokenUri;
         this.accessType = accessType;
-        this.prompt = prompt;
     }
 
     public String getClientId() {
@@ -62,9 +60,5 @@ public class GoogleProperties {
 
     public String getAccessType() {
         return accessType;
-    }
-
-    public String getPrompt() {
-        return prompt;
     }
 }

--- a/backend/src/main/java/com/allog/dallog/infrastructure/oauth/uri/GoogleOAuthUri.java
+++ b/backend/src/main/java/com/allog/dallog/infrastructure/oauth/uri/GoogleOAuthUri.java
@@ -20,7 +20,6 @@ public class GoogleOAuthUri implements OAuthUri {
                 + "redirect_uri=" + redirectUri + "&"
                 + "response_type=code&"
                 + "scope=" + String.join(" ", properties.getScopes()) + "&"
-                + "access_type=" + properties.getAccessType() + "&"
-                + "prompt=" + properties.getPrompt();
+                + "access_type=" + properties.getAccessType();
     }
 }


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 💻 git rebase를 사용했나요?
- [x] 🌈 알록달록한가요?

## 작업 내용

google OAuth 인증 요청을 위한 uri 생성 시 매 로그인시 마다 동의를 요청하지 않도록 prompt 설정을 제거한다.

## 스크린샷

## 주의사항

 * local 및 dev 환경에서 테스트할 때 refresh token을 발급 받지 못할 수 있습니다. 관련하여 이야기 나눈 뒤 해당 PR 반영하겠습니다.
 * 서브모듈이 수정되었습니다. merge가 될 경우 서브모듈을 적절히 최신화 시켜야 합니다. 

Closes #518 
