### PR TITLE
[feat] 일정을 수정 할 때, 일정의 카테고리도 수정 가능하도록 변경한다.

### DIFF
--- a/backend/src/docs/asciidoc/schedule.adoc
+++ b/backend/src/docs/asciidoc/schedule.adoc
@@ -18,15 +18,15 @@ include::{snippets}/schedules/findAllByMember/http-response.adoc[]
 
 ==== Request
 
-include::{snippets}/schedules/findAllByMemberWithExternalSchedule/http-request.adoc[]
+include::{snippets}/schedules/findAllByMember/http-request.adoc[]
 
 ==== RequestParameters
 
-include::{snippets}/schedules/findAllByMemberWithExternalSchedule/request-parameters.adoc[]
+include::{snippets}/schedules/findAllByMember/request-parameters.adoc[]
 
 ==== Response
 
-include::{snippets}/schedules/findAllByMemberWithExternalSchedule/http-response.adoc[]
+include::{snippets}/schedules/findAllByMember/http-response.adoc[]
 
 === 일정 등록
 

--- a/backend/src/main/java/com/allog/dallog/domain/category/domain/Category.java
+++ b/backend/src/main/java/com/allog/dallog/domain/category/domain/Category.java
@@ -95,6 +95,10 @@ public class Category extends BaseEntity {
         return categoryType == GOOGLE;
     }
 
+    public boolean isNotSameCategory(final long otherCategoryId) {
+        return this.id != otherCategoryId;
+    }
+
     public Long getId() {
         return id;
     }

--- a/backend/src/main/java/com/allog/dallog/domain/schedule/application/ScheduleService.java
+++ b/backend/src/main/java/com/allog/dallog/domain/schedule/application/ScheduleService.java
@@ -54,9 +54,12 @@ public class ScheduleService {
     @Transactional
     public void update(final Long id, final Long memberId, final ScheduleUpdateRequest request) {
         Schedule schedule = getSchedule(id);
-        categoryService.validateCreatorBy(memberId, schedule.getCategory());
-        Category categoryForUpdate = categoryService.getCategory(request.getCategoryId());
-        schedule.change(categoryForUpdate, request.getTitle(), request.getStartDateTime(),
+        Category category = schedule.getCategory();
+        categoryService.validateCreatorBy(memberId, category);
+        if (category.isNotSameCategory(request.getCategoryId())) {
+            category = categoryService.getCategory(request.getCategoryId());
+        }
+        schedule.change(category, request.getTitle(), request.getStartDateTime(),
                 request.getEndDateTime(), request.getMemo());
     }
 

--- a/backend/src/main/java/com/allog/dallog/domain/schedule/application/ScheduleService.java
+++ b/backend/src/main/java/com/allog/dallog/domain/schedule/application/ScheduleService.java
@@ -34,7 +34,7 @@ public class ScheduleService {
         return new ScheduleResponse(schedule);
     }
 
-    private static void validateCategoryType(final Category category) {
+    private void validateCategoryType(final Category category) {
         if (category.isExternal()) {
             throw new NoPermissionException("외부 연동 카테고리에는 일정을 추가할 수 없습니다.");
         }
@@ -55,7 +55,9 @@ public class ScheduleService {
     public void update(final Long id, final Long memberId, final ScheduleUpdateRequest request) {
         Schedule schedule = getSchedule(id);
         categoryService.validateCreatorBy(memberId, schedule.getCategory());
-        schedule.change(request.getTitle(), request.getStartDateTime(), request.getEndDateTime(), request.getMemo());
+        Category categoryForUpdate = categoryService.getCategory(request.getCategoryId());
+        schedule.change(categoryForUpdate, request.getTitle(), request.getStartDateTime(),
+                request.getEndDateTime(), request.getMemo());
     }
 
     @Transactional

--- a/backend/src/main/java/com/allog/dallog/domain/schedule/domain/Schedule.java
+++ b/backend/src/main/java/com/allog/dallog/domain/schedule/domain/Schedule.java
@@ -1,5 +1,6 @@
 package com.allog.dallog.domain.schedule.domain;
 
+import com.allog.dallog.domain.auth.exception.NoPermissionException;
 import com.allog.dallog.domain.category.domain.Category;
 import com.allog.dallog.domain.common.BaseEntity;
 import com.allog.dallog.domain.schedule.exception.InvalidScheduleException;
@@ -57,15 +58,23 @@ public class Schedule extends BaseEntity {
         this.memo = memo;
     }
 
-    public void change(final String title, final LocalDateTime startDateTime, final LocalDateTime endDateTime,
-                       final String memo) {
+    public void change(final Category category, final String title, final LocalDateTime startDateTime,
+                       final LocalDateTime endDateTime, final String memo) {
+        validateCategoryType(category);
         validateTitleLength(title);
         validatePeriod(startDateTime, endDateTime);
         validateMemoLength(memo);
+        this.category = category;
         this.title = title;
         this.startDateTime = startDateTime;
         this.endDateTime = endDateTime;
         this.memo = memo;
+    }
+
+    private void validateCategoryType(final Category category) {
+        if (category.isExternal()) {
+            throw new InvalidScheduleException("일정의 카테고리를 외부 연동 카테고리로 변경 할 수 없습니다.");
+        }
     }
 
     private void validateTitleLength(final String title) {

--- a/backend/src/main/java/com/allog/dallog/domain/schedule/dto/request/ScheduleUpdateRequest.java
+++ b/backend/src/main/java/com/allog/dallog/domain/schedule/dto/request/ScheduleUpdateRequest.java
@@ -1,11 +1,13 @@
 package com.allog.dallog.domain.schedule.dto.request;
 
 import java.time.LocalDateTime;
-import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import org.springframework.format.annotation.DateTimeFormat;
 
 public class ScheduleUpdateRequest {
+
+    @NotNull(message = "Null일 수 없습니다.")
+    private long categoryId;
 
     @NotNull(message = "Null일 수 없습니다.")
     private String title;
@@ -22,12 +24,17 @@ public class ScheduleUpdateRequest {
     private ScheduleUpdateRequest() {
     }
 
-    public ScheduleUpdateRequest(final String title, final LocalDateTime startDateTime, final LocalDateTime endDateTime,
-                                 final String memo) {
+    public ScheduleUpdateRequest(final long categoryId, final String title, final LocalDateTime startDateTime,
+                                 final LocalDateTime endDateTime, final String memo) {
+        this.categoryId = categoryId;
         this.title = title;
         this.startDateTime = startDateTime;
         this.endDateTime = endDateTime;
         this.memo = memo;
+    }
+
+    public long getCategoryId() {
+        return categoryId;
     }
 
     public String getTitle() {

--- a/backend/src/test/java/com/allog/dallog/acceptance/ScheduleAcceptanceTest.java
+++ b/backend/src/test/java/com/allog/dallog/acceptance/ScheduleAcceptanceTest.java
@@ -65,7 +65,8 @@ class ScheduleAcceptanceTest extends AcceptanceTest {
         CategoryResponse 공통_일정_응답 = 새로운_카테고리를_등록한다(accessToken, 공통_일정_생성_요청).as(CategoryResponse.class);
         ScheduleResponse 알록달록_회의 = 새로운_일정을_등록한다(accessToken, 공통_일정_응답.getId()).as(ScheduleResponse.class);
 
-        ScheduleUpdateRequest 일정_수정_요청 = new ScheduleUpdateRequest(레벨_인터뷰_제목, 레벨_인터뷰_시작일시, 레벨_인터뷰_종료일시, 레벨_인터뷰_메모);
+        ScheduleUpdateRequest 일정_수정_요청 = new ScheduleUpdateRequest(공통_일정_응답.getId(), 레벨_인터뷰_제목, 레벨_인터뷰_시작일시,
+                레벨_인터뷰_종료일시, 레벨_인터뷰_메모);
 
         // when
         ExtractableResponse<Response> response = 일정을_수정한다(accessToken, 알록달록_회의.getId(), 일정_수정_요청);

--- a/backend/src/test/java/com/allog/dallog/domain/schedule/application/ScheduleServiceTest.java
+++ b/backend/src/test/java/com/allog/dallog/domain/schedule/application/ScheduleServiceTest.java
@@ -1,6 +1,7 @@
 package com.allog.dallog.domain.schedule.application;
 
 import static com.allog.dallog.common.fixtures.CategoryFixtures.BE_일정_생성_요청;
+import static com.allog.dallog.common.fixtures.CategoryFixtures.FE_일정_생성_요청;
 import static com.allog.dallog.common.fixtures.ExternalCategoryFixtures.대한민국_공휴일_생성_요청;
 import static com.allog.dallog.common.fixtures.MemberFixtures.리버;
 import static com.allog.dallog.common.fixtures.MemberFixtures.후디;
@@ -209,6 +210,35 @@ class ScheduleServiceTest extends ServiceTest {
         assertAll(
                 () -> {
                     assertThat(actual.getId()).isEqualTo(기존_일정.getId());
+                    assertThat(actual.getTitle()).isEqualTo(레벨_인터뷰_제목);
+                    assertThat(actual.getStartDateTime()).isEqualTo(레벨_인터뷰_시작일시);
+                    assertThat(actual.getEndDateTime()).isEqualTo(레벨_인터뷰_종료일시);
+                    assertThat(actual.getMemo()).isEqualTo(레벨_인터뷰_메모);
+                }
+        );
+    }
+
+    @DisplayName("일정의 카테고리도 수정한다.")
+    @Test
+    void 일정의_카테고리도_수정한다() {
+        // given
+        MemberResponse 후디 = memberService.save(후디());
+        CategoryResponse BE_일정 = categoryService.save(후디.getId(), BE_일정_생성_요청);
+        ScheduleResponse 기존_일정 = scheduleService.save(후디.getId(), BE_일정.getId(), 알록달록_회의_생성_요청);
+
+        CategoryResponse FE_일정 = categoryService.save(후디.getId(), FE_일정_생성_요청);
+        ScheduleUpdateRequest 일정_수정_요청 = new ScheduleUpdateRequest(FE_일정.getId(), 레벨_인터뷰_제목, 레벨_인터뷰_시작일시, 레벨_인터뷰_종료일시,
+                레벨_인터뷰_메모);
+
+        // when
+        scheduleService.update(기존_일정.getId(), 후디.getId(), 일정_수정_요청);
+
+        // then
+        ScheduleResponse actual = scheduleService.findById(기존_일정.getId());
+        assertAll(
+                () -> {
+                    assertThat(actual.getId()).isEqualTo(기존_일정.getId());
+                    assertThat(actual.getCategoryType()).isEqualTo(FE_일정.getCategoryType());
                     assertThat(actual.getTitle()).isEqualTo(레벨_인터뷰_제목);
                     assertThat(actual.getStartDateTime()).isEqualTo(레벨_인터뷰_시작일시);
                     assertThat(actual.getEndDateTime()).isEqualTo(레벨_인터뷰_종료일시);

--- a/backend/src/test/java/com/allog/dallog/domain/schedule/application/ScheduleServiceTest.java
+++ b/backend/src/test/java/com/allog/dallog/domain/schedule/application/ScheduleServiceTest.java
@@ -198,7 +198,8 @@ class ScheduleServiceTest extends ServiceTest {
         CategoryResponse BE_일정 = categoryService.save(후디.getId(), BE_일정_생성_요청);
         ScheduleResponse 기존_일정 = scheduleService.save(후디.getId(), BE_일정.getId(), 알록달록_회의_생성_요청);
 
-        ScheduleUpdateRequest 일정_수정_요청 = new ScheduleUpdateRequest(레벨_인터뷰_제목, 레벨_인터뷰_시작일시, 레벨_인터뷰_종료일시, 레벨_인터뷰_메모);
+        ScheduleUpdateRequest 일정_수정_요청 = new ScheduleUpdateRequest(BE_일정.getId(), 레벨_인터뷰_제목, 레벨_인터뷰_시작일시, 레벨_인터뷰_종료일시,
+                레벨_인터뷰_메모);
 
         // when
         scheduleService.update(기존_일정.getId(), 후디.getId(), 일정_수정_요청);
@@ -225,7 +226,8 @@ class ScheduleServiceTest extends ServiceTest {
         CategoryResponse BE_일정 = categoryService.save(후디.getId(), BE_일정_생성_요청);
         ScheduleResponse 기존_일정 = scheduleService.save(후디.getId(), BE_일정.getId(), 알록달록_회의_생성_요청);
 
-        ScheduleUpdateRequest 일정_수정_요청 = new ScheduleUpdateRequest(레벨_인터뷰_제목, 레벨_인터뷰_시작일시, 레벨_인터뷰_종료일시, 레벨_인터뷰_메모);
+        ScheduleUpdateRequest 일정_수정_요청 = new ScheduleUpdateRequest(BE_일정.getId(), 레벨_인터뷰_제목, 레벨_인터뷰_시작일시, 레벨_인터뷰_종료일시,
+                레벨_인터뷰_메모);
 
         // when & then
         assertThatThrownBy(() -> scheduleService.update(기존_일정.getId(), 리버.getId(), 일정_수정_요청))
@@ -240,7 +242,8 @@ class ScheduleServiceTest extends ServiceTest {
         CategoryResponse BE_일정 = categoryService.save(후디.getId(), BE_일정_생성_요청);
         ScheduleResponse 기존_일정 = scheduleService.save(후디.getId(), BE_일정.getId(), 알록달록_회의_생성_요청);
 
-        ScheduleUpdateRequest 일정_수정_요청 = new ScheduleUpdateRequest(레벨_인터뷰_제목, 레벨_인터뷰_시작일시, 레벨_인터뷰_종료일시, 레벨_인터뷰_메모);
+        ScheduleUpdateRequest 일정_수정_요청 = new ScheduleUpdateRequest(BE_일정.getId(), 레벨_인터뷰_제목, 레벨_인터뷰_시작일시, 레벨_인터뷰_종료일시,
+                레벨_인터뷰_메모);
 
         // when & then
         assertThatThrownBy(() -> scheduleService.update(기존_일정.getId() + 1, 후디.getId(), 일정_수정_요청))

--- a/backend/src/test/java/com/allog/dallog/domain/schedule/domain/ScheduleTest.java
+++ b/backend/src/test/java/com/allog/dallog/domain/schedule/domain/ScheduleTest.java
@@ -10,6 +10,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import com.allog.dallog.domain.category.domain.Category;
+import com.allog.dallog.domain.category.domain.CategoryType;
 import com.allog.dallog.domain.schedule.exception.InvalidScheduleException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -50,6 +51,20 @@ public class ScheduleTest {
 
         // when & then
         assertThatThrownBy(() -> new Schedule(BE_일정_카테고리, 알록달록_회의_제목, 알록달록_회의_시작일시, 알록달록_회의_종료일시, 잘못된_메모))
+                .isInstanceOf(InvalidScheduleException.class);
+    }
+
+    @DisplayName("일정의 카테고리를 외부연동 카테고리로 변경 하려는 경우 예외를 던진다.")
+    @Test
+    void 일정의_카테고리를_외부연동_카테고리로_변경_하려는_경우_예외를_던진다() {
+        // given
+        Category BE_일정_카테고리 = BE_일정(관리자());
+        Schedule BE_일정 = new Schedule(BE_일정_카테고리, 알록달록_회의_제목, 알록달록_회의_시작일시, 알록달록_회의_종료일시, 알록달록_회의_메모);
+
+        Category 외부_연동_카테고리 = new Category("외부 카테고리", 관리자(), CategoryType.GOOGLE);
+
+        // when & then
+        assertThatThrownBy(() -> BE_일정.change(외부_연동_카테고리, 알록달록_회의_제목, 알록달록_회의_시작일시, 알록달록_회의_종료일시, 알록달록_회의_메모))
                 .isInstanceOf(InvalidScheduleException.class);
     }
 }

--- a/backend/src/test/java/com/allog/dallog/presentation/ScheduleControllerTest.java
+++ b/backend/src/test/java/com/allog/dallog/presentation/ScheduleControllerTest.java
@@ -188,8 +188,10 @@ class ScheduleControllerTest extends ControllerTest {
     @Test
     void 일정을_수정하는데_성공하면_204를_반환한다() throws Exception {
         // given
+        Long categoryId = 1L;
         Long scheduleId = 1L;
-        ScheduleUpdateRequest 수정_요청 = new ScheduleUpdateRequest(레벨_인터뷰_제목, 레벨_인터뷰_시작일시, 레벨_인터뷰_종료일시, 레벨_인터뷰_메모);
+        ScheduleUpdateRequest 수정_요청 = new ScheduleUpdateRequest(categoryId, 레벨_인터뷰_제목, 레벨_인터뷰_시작일시, 레벨_인터뷰_종료일시,
+                레벨_인터뷰_메모);
         willDoNothing()
                 .given(scheduleService)
                 .update(any(), any(), any());
@@ -214,8 +216,10 @@ class ScheduleControllerTest extends ControllerTest {
     @Test
     void 일정을_수정하는데_해당_일정의_카테고리에_대한_권한이_없다면_403을_반환한다() throws Exception {
         // given
+        Long categoryId = 1L;
         Long scheduleId = 1L;
-        ScheduleUpdateRequest 수정_요청 = new ScheduleUpdateRequest(레벨_인터뷰_제목, 레벨_인터뷰_시작일시, 레벨_인터뷰_종료일시, 레벨_인터뷰_메모);
+        ScheduleUpdateRequest 수정_요청 = new ScheduleUpdateRequest(categoryId, 레벨_인터뷰_제목, 레벨_인터뷰_시작일시, 레벨_인터뷰_종료일시,
+                레벨_인터뷰_메모);
         willThrow(new NoPermissionException())
                 .given(scheduleService)
                 .update(any(), any(), any());
@@ -237,8 +241,10 @@ class ScheduleControllerTest extends ControllerTest {
     @Test
     void 일정을_수정하는데_일정이_존재하지_않는_경우_404를_반환한다() throws Exception {
         // given
+        Long categoryId = 1L;
         Long scheduleId = 1L;
-        ScheduleUpdateRequest 수정_요청 = new ScheduleUpdateRequest(레벨_인터뷰_제목, 레벨_인터뷰_시작일시, 레벨_인터뷰_종료일시, 레벨_인터뷰_메모);
+        ScheduleUpdateRequest 수정_요청 = new ScheduleUpdateRequest(categoryId, 레벨_인터뷰_제목, 레벨_인터뷰_시작일시, 레벨_인터뷰_종료일시,
+                레벨_인터뷰_메모);
         willThrow(new NoSuchScheduleException())
                 .given(scheduleService)
                 .update(any(), any(), any());


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 💻 git rebase를 사용했나요?
- [x] 🌈 알록달록한가요?

## 작업 내용

- 일정을 수정 할 때 `ScheduleUpdateRequest`가 수정할 `categoryId`를 받아오도록 수정
- `ScheduleUpdateRequest`의 `categoryId`와 일치하는 `Category`가 외부연동 카테고리면 예외 발생
- 개인 또는 내부 카테고리이면 카테고리 수정

## 주의사항
`ScheduleService.update()에서 if문 부분이 고민이 많이 됐어요.
if문 검증을 `CategoryService`에서 처리해야 할지 아니면 update() 메서드 내부에서 처리할지 고민했는데요.
굳이 `CategoryService`를 거칠 필요가 없다고 느껴져서 옮기지 않았습니다🙂
의견남겨주시면 감사해요~

Closes #548 
