### PR TITLE
[feat] 소나큐브 Ruleset를 달록 컨벤션에 맞게 수정한다.

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -122,7 +122,7 @@ sonarqube {
         property "sonar.sources", "src"
         property "sonar.language", "java"
         property "sonar.sourceEncoding", "UTF-8"
-        property "sonar.profile", "Sonar way"
+        property "sonar.profile", "Dallog Custom Java Ruleset"
         property "sonar.java.binaries", "${buildDir}/classes"
         property "sonar.test.inclusions", "**/*Test.java"
         property 'sonar.exclusions', '**/jacoco/**'


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 💻 git rebase를 사용했나요?
- [x] 🌈 알록달록한가요?

## 작업 내용

소나큐브 Ruleset을 달록 컨벤션에 맞게 수정합니다. 기존에 달록은 Sonar way라는 기본 제공 ruleset을 사용했습니다. 이것을 복제하고, 저희 프로젝트에 맞지 않는 규칙은 비활성화 시켰습니다. 비활성화한 규칙은 아래와 같습니다.

- 한글 변수, 메소드 명을 코드스멜로 간주하는 규칙
   
   > 테스트 코드의 픽스쳐에서 한글 변수, 메소드를 사용하므로 아래 규칙은 비활성화 되어야 합니다.
  - Class names should comply with a naming convention (java:S101)
  - Constant names should comply with a naming convention (java:S115)
  - Field names should comply with a naming convention (java:S116)
  - Interface names should comply with a naming convention (java:S114)
  - Local variable and method parameter names should comply with a naming convention (java:S117)
  - Method names should comply with a naming convention (java:S100)
  - Static non-final field names should comply with a naming convention (java:S3008)

- 테스트 메소드에서 반드시 assertion을 사용해야하는 규칙
  
  > 인수 테스트 등에서 `상태코드_200이_반환된다(response)`와 같이 assertion을 포함하고 있는 메소드가 assertion으로 제대로 인식되지 않습니다. 따라서 이 규칙을 비활성화 하였습니다.
  - Tests should include assertions (java:S2699)

- 소나큐브에서 Deprecated 된 규칙

  > 아래 규칙은 Deprecated 됐습니다. 관련된 내용은 https://community.sonarsource.com/t/duplicatedblock-rule-is-deprecated-but-still-part-of-sonarway/64017/7 를 참고해주세요. 
  - Source files should not have any duplicated blocks (common-java:DuplicatedBlocks)

수정 결과 200개가 넘던 코드스멜이 약 90가량으로 줄어들었습니다. 그래도 많군요.

새로 만든 규칙은 소나큐브 > Quality Profiles > Dallog Custom Java Ruleset 에서 확인할 수 있습니다.

파라미터에 final을 강제하는 규칙을 찾아봤는데 딱히 없는 것 같아서 적용하지 못했습니다 ㅠㅠ 좀 더 공부가 필요할 것 같네요.

## 스크린샷

## 주의사항

Closes #558 
