### PR TITLE
[fix] 닉네임 수정 버튼 클릭 시 닉네임 입력창과 계정 텍스트가 겹치는 에러를 수정한다.

### DIFF
--- a/frontend/src/components/Profile/Profile.tsx
+++ b/frontend/src/components/Profile/Profile.tsx
@@ -42,15 +42,15 @@ import {
 } from './Profile.styles';
 
 function Profile() {
+  const { accessToken } = useRecoilValue(userState);
+
+  const navigate = useNavigate();
+
   const [isEditingName, setEditingName] = useState(false);
 
   const inputRef = {
     displayName: useRef<HTMLInputElement>(null),
   };
-
-  const navigate = useNavigate();
-
-  const { accessToken } = useRecoilValue(userState);
 
   const queryClient = useQueryClient();
   const { data } = useQuery<AxiosResponse<ProfileType>, AxiosError>(CACHE_KEY.PROFILE, () =>
@@ -108,7 +108,6 @@ function Profile() {
               refProp={inputRef.displayName}
               cssProp={inputStyle}
               autoFocus={true}
-              labelText="닉네임"
             />
             <Button
               type="submit"


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 💻 git rebase를 사용했나요?
- [x] 🌈 알록달록한가요?

## 작업 내용

닉네임 UI 고민, 나아가서 프로필 UI 고민을 며칠 동안 했지만 번뜩이는 아이디어가 떠오르지 않네요...
덕분에 다소 늦었습니다 죄송합니다 🫠

'닉네임' 라벨이 닉네임 수정 시에만 나타나는 게 조금 어색하다는 생각은 계속 들더라고요...!
그래서 우선 이거에 대해서만 수정했고 에러 자체는 해결하였습니다!

## 스크린샷

### 수정 전

<img width="1624" alt="달록 프로필 수정 전" src="https://user-images.githubusercontent.com/52729559/189490590-07e04e16-0f5b-4921-96db-cc7313c4dc5c.png">

### 수정 후

<img width="1624" alt="달록 프로필 수정 후" src="https://user-images.githubusercontent.com/52729559/189490405-eb466ef8-26bf-4211-b8e5-79afae52efdc.png">

Closes #543 