### PR TITLE
[refactor] REST docs의 코드 스타일을 통일한다.

### DIFF
--- a/backend/src/docs/asciidoc/auth.adoc
+++ b/backend/src/docs/asciidoc/auth.adoc
@@ -2,58 +2,50 @@
 
 === OAuth 로그인 링크 생성
 
-==== Request
+==== HTTP Request
 
-include::{snippets}/auth/link/http-request.adoc[]
+include::{snippets}/auth/generateLink/http-request.adoc[]
 
 ==== Path Parameters
 
-include::{snippets}/auth/link/path-parameters.adoc[]
+include::{snippets}/auth/generateLink/path-parameters.adoc[]
 
 ==== Request Parameters
 
-include::{snippets}/auth/link/request-parameters.adoc[]
+include::{snippets}/auth/generateLink/request-parameters.adoc[]
 
-==== Response
+==== HTTP Response
 
-include::{snippets}/auth/link/http-response.adoc[]
+include::{snippets}/auth/generateLink/http-response.adoc[]
 
-==== ResponseFields
+==== Response Fields
 
-include::{snippets}/auth/link/response-fields.adoc[]
+include::{snippets}/auth/generateLink/response-fields.adoc[]
 
 === OAuth 로그인
 
-==== Request
+==== HTTP Request
 
-include::{snippets}/auth/token/http-request.adoc[]
+include::{snippets}/auth/generateToken/http-request.adoc[]
 
-==== PathParameters
+==== Path Parameters
 
-include::{snippets}/auth/token/path-parameters.adoc[]
+include::{snippets}/auth/generateToken/path-parameters.adoc[]
 
-==== RequestFields
+==== Request Fields
 
-include::{snippets}/auth/token/request-fields.adoc[]
+include::{snippets}/auth/generateToken/request-fields.adoc[]
 
-==== Response
+==== HTTP Response
 
-include::{snippets}/auth/token/http-response.adoc[]
+include::{snippets}/auth/generateToken/http-response.adoc[]
 
-=== OAuth 로그인 : Resource Server 에러
+==== Response Fields
 
-==== Request
+include::{snippets}/auth/generateToken/response-fields.adoc[]
 
-include::{snippets}/auth/exception/token/http-request.adoc[]
+=== OAuth 로그인 (Resource Server 에러)
 
-==== PathParameters
+==== HTTP Response
 
-include::{snippets}/auth/exception/token/path-parameters.adoc[]
-
-==== RequestFields
-
-include::{snippets}/auth/exception/token/request-fields.adoc[]
-
-==== Response
-
-include::{snippets}/auth/exception/token/http-response.adoc[]
+include::{snippets}/auth/generateToken/failByResourceServerError/http-response.adoc[]

--- a/backend/src/docs/asciidoc/category.adoc
+++ b/backend/src/docs/asciidoc/category.adoc
@@ -2,144 +2,132 @@
 
 === 카테고리 생성
 
-==== Request
+==== HTTP Request
 
-include::{snippets}/categories/save/http-request.adoc[]
+include::{snippets}/category/save/http-request.adoc[]
 
-==== Response
+==== Request Fields
 
-include::{snippets}/categories/save/http-response.adoc[]
+include::{snippets}/category/save/request-fields.adoc[]
+
+==== HTTP Response
+
+include::{snippets}/category/save/http-response.adoc[]
+
+==== Response Fields
+
+include::{snippets}/category/save/response-fields.adoc[]
 
 === 카테고리 생성 (유효하지 않은 카테고리 이름)
 
-==== Request
+==== HTTP Response
 
-include::{snippets}/categories/save/badRequest/http-request.adoc[]
-
-==== Response
-
-include::{snippets}/categories/save/badRequest/http-response.adoc[]
+include::{snippets}/category/save/failByInvalidNameFormat/http-response.adoc[]
 
 === 전체 카테고리 조회
 
 ==== Request
 
-include::{snippets}/categories/findAll/http-request.adoc[]
+include::{snippets}/category/findAllByName/allByNoName/http-request.adoc[]
 
-==== RequestParameters
+==== Request Parameters
 
-include::{snippets}/categories/findAll/request-parameters.adoc[]
+include::{snippets}/category/findAllByName/allByNoName/request-parameters.adoc[]
 
-==== Response
+==== HTTP Response
 
-include::{snippets}/categories/findAll/http-response.adoc[]
+include::{snippets}/category/findAllByName/allByNoName/http-response.adoc[]
 
-=== 카테고리 제목 조회
+=== 전체 카테고리 목록 이름으로 필터링
 
-==== Request
+==== HTTP Request
 
-include::{snippets}/categories/findAllLikeName/http-request.adoc[]
+include::{snippets}/category/findAllByName/fileterByName/http-request.adoc[]
 
-==== RequestParameters
+==== Request Parameters
 
-include::{snippets}/categories/findAllLikeName/request-parameters.adoc[]
+include::{snippets}/category/findAllByName/fileterByName/request-parameters.adoc[]
 
-==== Response
+==== HTTP Response
 
-include::{snippets}/categories/findAllLikeName/http-response.adoc[]
+include::{snippets}/category/findAllByName/fileterByName/http-response.adoc[]
 
 === 자신이 생성한 카테고리 조회
 
-==== Request
+==== HTTP Request
 
-include::{snippets}/categories/findMine/http-request.adoc[]
+include::{snippets}/category/findMineByName/allByNoName/http-request.adoc[]
 
-==== RequestParameters
+==== Request Parameters
 
-include::{snippets}/categories/findMine/request-parameters.adoc[]
+include::{snippets}/category/findMineByName/allByNoName/request-parameters.adoc[]
 
-==== Response
+==== HTTP Response
 
-include::{snippets}/categories/findMine/response-body.adoc[]
+include::{snippets}/category/findMineByName/allByNoName/http-response.adoc[]
 
 === ID를 통한 카테고리 단건 조회
 
-==== Request
+==== HTTP Request
 
-include::{snippets}/categories/findById/http-request.adoc[]
+include::{snippets}/category/findById/http-request.adoc[]
 
-==== PathParameters
+==== Path Parameters
 
-include::{snippets}/categories/findById/path-parameters.adoc[]
+include::{snippets}/category/findById/path-parameters.adoc[]
 
-==== Response
+==== HTTP Response
 
-include::{snippets}/categories/findById/http-response.adoc[]
+include::{snippets}/category/findById/http-response.adoc[]
 
 === ID를 통한 카테고리 단건 조회 (존재하지 않는 경우)
 
-==== Request
+==== HTTP Response
 
-include::{snippets}/categories/findById/notFound/http-request.adoc[]
-
-==== Response
-
-include::{snippets}/categories/findById/notFound/http-response.adoc[]
+include::{snippets}/category/findById/failByNoCategory/http-response.adoc[]
 
 === 카테고리 수정
 
-==== Request
+==== HTTP Request
 
-include::{snippets}/categories/update/http-request.adoc[]
+include::{snippets}/category/update/http-request.adoc[]
 
-==== PathParameters
+==== Path Parameters
 
-include::{snippets}/categories/update/path-parameters.adoc[]
+include::{snippets}/category/update/path-parameters.adoc[]
 
-==== Response
+==== HTTP Response
 
-include::{snippets}/categories/update/http-response.adoc[]
+include::{snippets}/category/update/http-response.adoc[]
 
 === 카테고리 수정 (존재하지 않는 경우)
 
-==== Request
+==== HTTP Response
 
-include::{snippets}/categories/update/notFound/http-request.adoc[]
-
-==== Response
-
-include::{snippets}/categories/update/notFound/http-response.adoc[]
+include::{snippets}/category/update/failByNoCategory/http-response.adoc[]
 
 === 카테고리 수정 (유효하지 않은 카테고리 이름)
 
-==== Request
+==== HTTP Response
 
-include::{snippets}/categories/update/badRequest/http-request.adoc[]
-
-==== Response
-
-include::{snippets}/categories/update/badRequest/http-response.adoc[]
+include::{snippets}/category/update/failByInvalidNameFormat/http-response.adoc[]
 
 === 카테고리 삭제
 
-==== Request
+==== HTTP Request
 
-include::{snippets}/categories/delete/http-request.adoc[]
+include::{snippets}/category/delete/http-request.adoc[]
 
-==== PathParameters
+==== Path Parameters
 
-include::{snippets}/categories/delete/path-parameters.adoc[]
+include::{snippets}/category/delete/path-parameters.adoc[]
 
-==== Response
+==== HTTP Response
 
-include::{snippets}/categories/delete/http-response.adoc[]
+include::{snippets}/category/delete/http-response.adoc[]
 
 === 카테고리 삭제 (존재하지 않는 경우)
 
-==== Request
+==== HTTP Response
 
-include::{snippets}/categories/delete/notFound/http-request.adoc[]
-
-==== Response
-
-include::{snippets}/categories/delete/notFound/http-response.adoc[]
+include::{snippets}/category/delete/failByNoCategory/http-response.adoc[]

--- a/backend/src/docs/asciidoc/external-calendar.adoc
+++ b/backend/src/docs/asciidoc/external-calendar.adoc
@@ -2,46 +2,38 @@
 
 === 자신의 외부 캘린더 조회
 
-==== Request
+==== HTTP Request
 
-include::{snippets}/external-calendars/get/http-request.adoc[]
+include::{snippets}/externalCalendar/getExternalCalendar/http-request.adoc[]
 
-==== Response
+==== HTTP Response
 
-include::{snippets}/external-calendars/get/http-response.adoc[]
+include::{snippets}/externalCalendar/getExternalCalendar/http-response.adoc[]
 
 === 자신의 외부 캘린더 저장
 
-==== Request
+==== HTTP Request
 
-include::{snippets}/external-calendars/save/http-request.adoc[]
+include::{snippets}/externalCalendar/save/http-request.adoc[]
 
-==== Request Headers
+==== Request Fields
 
-include::{snippets}/external-calendars/save/request-headers.adoc[]
+include::{snippets}/externalCalendar/save/request-fields.adoc[]
 
-==== Request Body
+==== HTTP Response
 
-include::{snippets}/external-calendars/save/request-fields.adoc[]
-
-==== Response
-
-include::{snippets}/external-calendars/save/http-response.adoc[]
+include::{snippets}/externalCalendar/save/http-response.adoc[]
 
 === 자신의 외부 캘린더 중복 저장 시 예외 발생
 
-==== Request
+==== HTTP Request
 
-include::{snippets}/external-calendars/duplicated-save/http-request.adoc[]
+include::{snippets}/externalCalendar/save/failByDuplicate/http-request.adoc[]
 
-==== Request Headers
+==== Request Fields
 
-include::{snippets}/external-calendars/duplicated-save/request-headers.adoc[]
+include::{snippets}/externalCalendar/save/failByDuplicate/request-fields.adoc[]
 
-==== Request Body
+==== HTTP Response
 
-include::{snippets}/external-calendars/duplicated-save/request-fields.adoc[]
-
-==== Response
-
-include::{snippets}/external-calendars/duplicated-save/http-response.adoc[]
+include::{snippets}/externalCalendar/save/failByDuplicate/http-response.adoc[]

--- a/backend/src/docs/asciidoc/external-calendar.adoc
+++ b/backend/src/docs/asciidoc/external-calendar.adoc
@@ -24,15 +24,7 @@ include::{snippets}/externalCalendar/save/request-fields.adoc[]
 
 include::{snippets}/externalCalendar/save/http-response.adoc[]
 
-=== 자신의 외부 캘린더 중복 저장 시 예외 발생
-
-==== HTTP Request
-
-include::{snippets}/externalCalendar/save/failByDuplicate/http-request.adoc[]
-
-==== Request Fields
-
-include::{snippets}/externalCalendar/save/failByDuplicate/request-fields.adoc[]
+=== 자신의 외부 캘린더 저장 (중복 저장할 경우)
 
 ==== HTTP Response
 

--- a/backend/src/docs/asciidoc/member.adoc
+++ b/backend/src/docs/asciidoc/member.adoc
@@ -2,52 +2,44 @@
 
 === 내 정보 조회
 
-==== Request
+==== HTTP Request
 
-include::{snippets}/members/me/http-request.adoc[]
+include::{snippets}/member/findMe/http-request.adoc[]
 
-==== RequestHeaders
+==== HTTP Response
 
-include::{snippets}/members/me/request-headers.adoc[]
+include::{snippets}/member/findMe/http-response.adoc[]
 
-==== Response
+==== Response Fields
 
-include::{snippets}/members/me/http-response.adoc[]
+include::{snippets}/member/findMe/response-fields.adoc[]
 
-=== 삭제된 회원 정보 조회
+=== 내 정보 조회 (존재하지 않는 회원 조회 시)
 
-==== Request
+==== HTTP Response
 
-include::{snippets}/members/exception/notfound/http-request.adoc[]
-
-==== Response
-
-include::{snippets}/members/exception/notfound/http-response.adoc[]
+include::{snippets}/member/findMe/failNoMember/http-response.adoc[]
 
 === 내 정보 수정
 
-==== Request
+==== HTTP Request
 
-include::{snippets}/members/update/http-request.adoc[]
+include::{snippets}/member/update/http-request.adoc[]
 
-==== RequestHeaders
+==== Request Fields
 
-include::{snippets}/members/update/request-headers.adoc[]
+include::{snippets}/member/update/request-fields.adoc[]
 
-==== Request Parameters
+==== HTTP Response
 
-include::{snippets}/members/update/request-body.adoc[]
-
-==== Response
-
-include::{snippets}/members/update/http-response.adoc[]
+include::{snippets}/member/update/http-response.adoc[]
 
 === 회원 탈퇴
 
-==== Request
+==== HTTP Request
 
-include::{snippets}/members/delete/http-request.adoc[]
+include::{snippets}/member/delete/http-request.adoc[]
 
-==== Response
+==== HTTP Response
 
-include::{snippets}/members/delete/http-response.adoc[]
+include::{snippets}/member/delete/http-response.adoc[]

--- a/backend/src/docs/asciidoc/schedule.adoc
+++ b/backend/src/docs/asciidoc/schedule.adoc
@@ -2,121 +2,107 @@
 
 === 회원 일정 목록 조회
 
-==== Request
+==== HTTP Request
 
-include::{snippets}/schedules/findAllByMember/http-request.adoc[]
+include::{snippets}/schedule/findSchedulesByMemberId/http-request.adoc[]
 
-==== RequestParameters
+==== Request Parameters
 
-include::{snippets}/schedules/findAllByMember/request-parameters.adoc[]
+include::{snippets}/schedule/findSchedulesByMemberId/request-parameters.adoc[]
 
-==== Response
+==== HTTP Response
 
-include::{snippets}/schedules/findAllByMember/http-response.adoc[]
-
-=== 회원 일정 및 외부 일정 목록 조회
-
-==== Request
-
-include::{snippets}/schedules/findAllByMemberWithExternalSchedule/http-request.adoc[]
-
-==== RequestParameters
-
-include::{snippets}/schedules/findAllByMemberWithExternalSchedule/request-parameters.adoc[]
-
-==== Response
-
-include::{snippets}/schedules/findAllByMemberWithExternalSchedule/http-response.adoc[]
+include::{snippets}/schedule/findSchedulesByMemberId/http-response.adoc[]
 
 === 일정 등록
 
-==== Request
+==== HTTP Request
 
-include::{snippets}/schedules/save/http-request.adoc[]
+include::{snippets}/schedule/save/http-request.adoc[]
 
-==== Response
+==== HTTP Response
 
-include::{snippets}/schedules/save/http-response.adoc[]
+include::{snippets}/schedule/save/http-response.adoc[]
 
-=== 일정 생성 (카테고리 권한 없음)
+=== 일정 등록 (카테고리 권한이 없을 때)
 
-==== Response
+==== HTTP Response
 
-include::{snippets}/schedules/save/forbidden/http-response.adoc[]
+include::{snippets}/schedule/save/failByNoPermission/http-response.adoc[]
 
 === 일정 생성 (카테고리가 존재하지 않음)
 
-==== Response
+==== HTTP Response
 
-include::{snippets}/schedules/save/notfound/http-response.adoc[]
+include::{snippets}/schedule/save/failByNoCategory/http-response.adoc[]
 
 === 일정 단건 조회
 
-==== Request
+==== HTTP Request
 
-include::{snippets}/schedules/findone/http-request.adoc[]
+include::{snippets}/schedule/findById/http-request.adoc[]
 
-==== Response
+==== HTTP Response
 
-include::{snippets}/schedules/findone/http-response.adoc[]
+include::{snippets}/schedule/findById/http-response.adoc[]
 
-=== 일정 단건 조회 (일정이 존재하지 않음)
+=== 일정 단건 조회 (일정이 존재하지 않을 때)
 
-==== Response
+==== HTTP Response
 
-include::{snippets}/schedules/findone/notfound/http-response.adoc[]
+include::{snippets}/schedule/findById/failByNoSchedule/http-response.adoc[]
 
 === 일정 수정
 
-==== Request
+==== HTTP Request
 
-include::{snippets}/schedules/update/http-request.adoc[]
+include::{snippets}/schedule/update/http-request.adoc[]
 
-==== Path Variable
+==== Path Parameters
 
-include::{snippets}/schedules/update/path-parameters.adoc[]
+include::{snippets}/schedule/update/path-parameters.adoc[]
 
-==== Response
+==== HTTP Response
 
-include::{snippets}/schedules/update/http-response.adoc[]
+include::{snippets}/schedule/update/http-response.adoc[]
 
-=== 일정 수정 (카테고리 권한 없음)
+=== 일정 수정 (카테고리 권한이 없을 때)
 
-==== Response
+==== HTTP Response
 
-include::{snippets}/schedules/update/forbidden/http-response.adoc[]
+include::{snippets}/schedule/update/failByNoPermission/http-response.adoc[]
 
-=== 일정 수정 (카테고리가 존재하지 않음)
+=== 일정 수정 (카테고리가 존재하지 않을 때)
 
-==== Response
+==== HTTP Response
 
-include::{snippets}/schedules/update/notfound/http-response.adoc[]
+include::{snippets}/schedule/update/failByNoSchedule/http-response.adoc[]
 
 === 일정 제거
 
-==== Request
+==== HTTP Request
 
-include::{snippets}/schedules/delete/http-request.adoc[]
+include::{snippets}/schedule/delete/http-request.adoc[]
 
-==== Path Variable
+==== Path Parameters
 
-include::{snippets}/schedules/delete/path-parameters.adoc[]
+include::{snippets}/schedule/delete/path-parameters.adoc[]
 
-==== Response
+==== HTTP Response
 
-include::{snippets}/schedules/delete/http-response.adoc[]
+include::{snippets}/schedule/delete/http-response.adoc[]
 
-=== 일정 제거 (카테고리 권한 없음)
+=== 일정 제거 (카테고리 권한이 없을 때)
 
-==== Response
+==== HTTP Response
 
-include::{snippets}/schedules/delete/forbidden/http-response.adoc[]
+include::{snippets}/schedule/delete/failByNoPermission/http-response.adoc[]
 
 === 일정 제거 (카테고리가 존재하지 않음)
 
-==== Response
+==== HTTP Response
 
-include::{snippets}/schedules/delete/notfound/http-response.adoc[]
+include::{snippets}/schedule/delete/failByNoSchedule/http-response.adoc[]
 
 === 일정 조율
 
@@ -124,14 +110,16 @@ include::{snippets}/schedules/delete/notfound/http-response.adoc[]
 
 ==== Request
 
-include::{snippets}/scheduler/category/available-periods/http-request.adoc[]
+include::{snippets}/scheduler/scheduleByCategory/http-request.adoc[]
 
-==== Parameters
+==== Path Parameters
 
-include::{snippets}/scheduler/category/available-periods/path-parameters.adoc[]
+include::{snippets}/scheduler/scheduleByCategory/path-parameters.adoc[]
 
-include::{snippets}/scheduler/category/available-periods/request-parameters.adoc[]
+==== Request Parameters
+
+include::{snippets}/scheduler/scheduleByCategory/request-parameters.adoc[]
 
 ==== Response
 
-include::{snippets}/scheduler/category/available-periods/http-response.adoc[]
+include::{snippets}/scheduler/scheduleByCategory/http-response.adoc[]

--- a/backend/src/docs/asciidoc/subscription.adoc
+++ b/backend/src/docs/asciidoc/subscription.adoc
@@ -2,7 +2,7 @@
 
 === 구독 등록
 
-==== Request
+==== HTTP Request
 
 include::{snippets}/subscription/save/http-request.adoc[]
 
@@ -10,63 +10,35 @@ include::{snippets}/subscription/save/http-request.adoc[]
 
 include::{snippets}/subscription/save/path-parameters.adoc[]
 
-==== Request Headers
-
-include::{snippets}/subscription/save/request-headers.adoc[]
-
-==== Response
+==== HTTP Response
 
 include::{snippets}/subscription/save/http-response.adoc[]
 
+=== 구독 등록 (중복된 구독을 등록할 때)
+
+==== HTTP Response
+
+include::{snippets}/subscription/save/failByAlreadyExisting/http-response.adoc[]
+
+=== 구독 등록 (3자의 개인 카테고리 구독 요청시)
+
+==== HTTP Response
+
+include::{snippets}/subscription/save/failBySubscribingPrivateCategoryOfOther/http-response.adoc[]
+
 === 자신의 구독 목록 조회
 
-==== Request
+==== HTTP Request
 
 include::{snippets}/subscription/findMine/http-request.adoc[]
 
-==== Response
+==== HTTP Response
 
 include::{snippets}/subscription/findMine/http-response.adoc[]
 
-=== 중복된 구독 등록
-
-==== Request
-
-include::{snippets}/subscription/exist/http-request.adoc[]
-
-==== Path Parameters
-
-include::{snippets}/subscription/exist/path-parameters.adoc[]
-
-==== Request Headers
-
-include::{snippets}/subscription/exist/request-headers.adoc[]
-
-==== Response
-
-include::{snippets}/subscription/exist/http-response.adoc[]
-
-==== Request
-
-include::{snippets}/subscription/me/http-request.adoc[]
-
-==== Request Headers
-
-include::{snippets}/subscription/me/request-headers.adoc[]
-
-==== Response
-
-include::{snippets}/subscription/me/http-response.adoc[]
-
-=== 3자의 개인 카테고리 구독 요청시
-
-==== Response
-
-include::{snippets}/subscription/private-category/http-response.adoc[]
-
 === 내 구독 정보 수정
 
-==== Request
+==== HTTP Request
 
 include::{snippets}/subscription/update/http-request.adoc[]
 
@@ -82,13 +54,13 @@ include::{snippets}/subscription/update/request-headers.adoc[]
 
 include::{snippets}/subscription/update/request-body.adoc[]
 
-==== Response
+==== HTTP Response
 
 include::{snippets}/subscription/update/http-response.adoc[]
 
-=== 내 구독 정보 삭제
+=== 구독 삭제
 
-==== Request
+==== HTTP Request
 
 include::{snippets}/subscription/delete/http-request.adoc[]
 
@@ -96,28 +68,12 @@ include::{snippets}/subscription/delete/http-request.adoc[]
 
 include::{snippets}/subscription/delete/path-parameters.adoc[]
 
-==== Request Headers
-
-include::{snippets}/subscription/delete/request-headers.adoc[]
-
-==== Response
+==== HTTP Response
 
 include::{snippets}/subscription/delete/http-response.adoc[]
 
-=== 내 구독 정보가 아닌 구독 삭제
+=== 구독 삭제 (내 구독이 아닐 때)
 
-==== Request
+==== HTTP Response
 
-include::{snippets}/subscription/permission/http-request.adoc[]
-
-==== Path Parameters
-
-include::{snippets}/subscription/permission/path-parameters.adoc[]
-
-==== Request Headers
-
-include::{snippets}/subscription/permission/request-headers.adoc[]
-
-==== Response
-
-include::{snippets}/subscription/permission/http-response.adoc[]
+include::{snippets}/subscription/delete/failByNoPermission/http-response.adoc[]

--- a/backend/src/test/java/com/allog/dallog/presentation/AuthControllerTest.java
+++ b/backend/src/test/java/com/allog/dallog/presentation/AuthControllerTest.java
@@ -1,5 +1,6 @@
 package com.allog.dallog.presentation;
 
+import static com.allog.dallog.common.fixtures.AuthFixtures.GOOGLE_PROVIDER;
 import static com.allog.dallog.common.fixtures.AuthFixtures.MEMBER_인증_코드_토큰_요청;
 import static com.allog.dallog.common.fixtures.AuthFixtures.MEMBER_인증_코드_토큰_응답;
 import static com.allog.dallog.common.fixtures.AuthFixtures.OAUTH_PROVIDER;
@@ -44,14 +45,14 @@ class AuthControllerTest extends ControllerTest {
         given(authService.generateGoogleLink(any())).willReturn(OAuth_로그인_링크);
 
         // when & then
-        mockMvc.perform(get("/api/auth/{oauthProvider}/oauth-uri?redirectUri={redirectUri}", OAUTH_PROVIDER,
+        mockMvc.perform(get("/api/auth/{oauthProvider}/oauth-uri?redirectUri={redirectUri}", GOOGLE_PROVIDER,
                         "https://dallog.me/oauth"))
                 .andDo(print())
                 .andDo(document("auth/generateLink",
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint()),
                         pathParameters(
-                                parameterWithName("oauthProvider").description("OAuth 로그인 제공자")
+                                parameterWithName("oauthProvider").description("OAuth 로그인 제공자 (GOOGLE)")
                         ),
                         requestParameters(
                                 parameterWithName("redirectUri").description("OAuth Redirect URI")
@@ -85,6 +86,9 @@ class AuthControllerTest extends ControllerTest {
                                 fieldWithPath("code").type(JsonFieldType.STRING).description("OAuth 로그인 인증 코드"),
                                 fieldWithPath("redirectUri").type(JsonFieldType.STRING)
                                         .description("OAuth Redirect URI")
+                        ),
+                        responseFields(
+                                fieldWithPath("accessToken").type(JsonFieldType.STRING).description("달록 Access Token")
                         )
                 ))
                 .andExpect(status().isOk());

--- a/backend/src/test/java/com/allog/dallog/presentation/AuthControllerTest.java
+++ b/backend/src/test/java/com/allog/dallog/presentation/AuthControllerTest.java
@@ -67,7 +67,6 @@ class AuthControllerTest extends ControllerTest {
     @Test
     void OAuth_로그인을_하면_token과_상태코드_200을_반환한다() throws Exception {
         // given
-//        TokenRequest tokenRequest = new TokenRequest(STUB_MEMBER_인증_코드, "https://dallog.me/oauth");
         given(authService.generateToken(any())).willReturn(MEMBER_인증_코드_토큰_응답());
 
         // when & then

--- a/backend/src/test/java/com/allog/dallog/presentation/AuthControllerTest.java
+++ b/backend/src/test/java/com/allog/dallog/presentation/AuthControllerTest.java
@@ -47,7 +47,7 @@ class AuthControllerTest extends ControllerTest {
         mockMvc.perform(get("/api/auth/{oauthProvider}/oauth-uri?redirectUri={redirectUri}", OAUTH_PROVIDER,
                         "https://dallog.me/oauth"))
                 .andDo(print())
-                .andDo(document("auth/link",
+                .andDo(document("auth/generateLink",
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint()),
                         pathParameters(
@@ -76,7 +76,7 @@ class AuthControllerTest extends ControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(MEMBER_인증_코드_토큰_요청())))
                 .andDo(print())
-                .andDo(document("auth/token",
+                .andDo(document("auth/generateToken",
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint()),
                         pathParameters(

--- a/backend/src/test/java/com/allog/dallog/presentation/AuthControllerTest.java
+++ b/backend/src/test/java/com/allog/dallog/presentation/AuthControllerTest.java
@@ -102,7 +102,7 @@ class AuthControllerTest extends ControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(MEMBER_인증_코드_토큰_요청())))
                 .andDo(print())
-                .andDo(document("auth/exception/token",
+                .andDo(document("auth/generateToken/failByResourceServerError",
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint()),
                         pathParameters(

--- a/backend/src/test/java/com/allog/dallog/presentation/CategoryControllerTest.java
+++ b/backend/src/test/java/com/allog/dallog/presentation/CategoryControllerTest.java
@@ -25,6 +25,9 @@ import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuild
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.restdocs.request.RequestDocumentation.requestParameters;
@@ -87,7 +90,22 @@ class CategoryControllerTest extends ControllerTest {
                                 preprocessRequest(prettyPrint()),
                                 preprocessResponse(prettyPrint()),
                                 requestHeaders(
-                                        headerWithName("Authorization").description("JWT 토큰"))
+                                        headerWithName("Authorization").description("JWT 토큰")),
+                                requestFields(
+                                        fieldWithPath("name").description("카테고리 이름 (최대 20글자)"),
+                                        fieldWithPath("categoryType").description("카테고리 타입 (NORMAL | PERSONAL | GOOGLE)")
+                                ),
+                                responseFields(
+                                        fieldWithPath("id").description("카테고리 ID"),
+                                        fieldWithPath("name").description("카테고리 이름"),
+                                        fieldWithPath("categoryType").description("카테고리 타입 (NORMAL | PERSONAL | GOOGLE)"),
+                                        fieldWithPath("creator.id").description("카테고리 생성자 ID"),
+                                        fieldWithPath("creator.email").description("카테고리 생성자 이메일"),
+                                        fieldWithPath("creator.displayName").description("카테고리 생성자 이름"),
+                                        fieldWithPath("creator.profileImageUrl").description("카테고리 생성자 프로필 이미지 URL"),
+                                        fieldWithPath("creator.socialType").description("카테고리 생성자의 소셜 타입"),
+                                        fieldWithPath("createdAt").description("카테고리 생성일자")
+                                )
                         )
                 )
                 .andExpect(status().isCreated());
@@ -157,7 +175,7 @@ class CategoryControllerTest extends ControllerTest {
         int page = 0;
         int size = 10;
 
-        List<Category> 일정_목록 = List.of(공통_일정(관리자()), BE_일정(관리자()), FE_일정(관리자()));
+        List<Category> 일정_목록 = List.of(BE_일정(관리자()), FE_일정(관리자()));
         CategoriesResponse categoriesResponse = new CategoriesResponse(page, 일정_목록);
         given(categoryService.findNormalByName(any(), any())).willReturn(categoriesResponse);
 

--- a/backend/src/test/java/com/allog/dallog/presentation/CategoryControllerTest.java
+++ b/backend/src/test/java/com/allog/dallog/presentation/CategoryControllerTest.java
@@ -83,7 +83,7 @@ class CategoryControllerTest extends ControllerTest {
                         .content(objectMapper.writeValueAsString(BE_일정_생성_요청))
                 )
                 .andDo(print())
-                .andDo(document("categories/save",
+                .andDo(document("category/save",
                                 preprocessRequest(prettyPrint()),
                                 preprocessResponse(prettyPrint()),
                                 requestHeaders(
@@ -111,7 +111,7 @@ class CategoryControllerTest extends ControllerTest {
                         .content(objectMapper.writeValueAsString(잘못된_카테고리_생성_요청))
                 )
                 .andDo(print())
-                .andDo(document("categories/save/badRequest",
+                .andDo(document("category/save/failByInvalidNameFormat",
                                 preprocessRequest(prettyPrint()),
                                 preprocessResponse(prettyPrint()),
                                 requestHeaders(
@@ -138,7 +138,7 @@ class CategoryControllerTest extends ControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                 )
                 .andDo(print())
-                .andDo(document("categories/findAll",
+                .andDo(document("categories/findAllByName/allByNoName",
                                 preprocessRequest(prettyPrint()),
                                 preprocessResponse(prettyPrint()),
                                 requestParameters(
@@ -167,7 +167,7 @@ class CategoryControllerTest extends ControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                 )
                 .andDo(print())
-                .andDo(document("categories/findAllLikeName",
+                .andDo(document("category/findAllByName/fileterByName",
                                 preprocessRequest(prettyPrint()),
                                 preprocessResponse(prettyPrint()),
                                 requestParameters(
@@ -198,7 +198,7 @@ class CategoryControllerTest extends ControllerTest {
                         .header(AUTHORIZATION_HEADER_NAME, AUTHORIZATION_HEADER_VALUE)
                 )
                 .andDo(print())
-                .andDo(document("categories/findMine",
+                .andDo(document("category/findMineByName/allByNoName",
                                 preprocessRequest(prettyPrint()),
                                 preprocessResponse(prettyPrint()),
                                 requestParameters(
@@ -229,7 +229,7 @@ class CategoryControllerTest extends ControllerTest {
                         .header(AUTHORIZATION_HEADER_NAME, AUTHORIZATION_HEADER_VALUE)
                 )
                 .andDo(print())
-                .andDo(document("categories/findMineLikeName",
+                .andDo(document("category/findMineByName/fileterByName",
                                 preprocessRequest(prettyPrint()),
                                 preprocessResponse(prettyPrint()),
                                 requestParameters(
@@ -256,7 +256,7 @@ class CategoryControllerTest extends ControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                 )
                 .andDo(print())
-                .andDo(document("categories/findById",
+                .andDo(document("category/findById",
                                 preprocessRequest(prettyPrint()),
                                 preprocessResponse(prettyPrint()),
                                 pathParameters(
@@ -281,7 +281,7 @@ class CategoryControllerTest extends ControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                 )
                 .andDo(print())
-                .andDo(document("categories/findById/notFound",
+                .andDo(document("category/findById/failByNoCategory",
                                 preprocessRequest(prettyPrint()),
                                 preprocessResponse(prettyPrint()),
                                 pathParameters(
@@ -310,7 +310,7 @@ class CategoryControllerTest extends ControllerTest {
                         .content(objectMapper.writeValueAsString(카테고리_수정_요청))
                 )
                 .andDo(print())
-                .andDo(document("categories/update",
+                .andDo(document("category/update",
                                 preprocessRequest(prettyPrint()),
                                 preprocessResponse(prettyPrint()),
                                 pathParameters(
@@ -340,7 +340,7 @@ class CategoryControllerTest extends ControllerTest {
                         .content(objectMapper.writeValueAsString(카테고리_수정_요청))
                 )
                 .andDo(print())
-                .andDo(document("categories/update/notFound",
+                .andDo(document("category/update/failByNoCategory",
                                 preprocessRequest(prettyPrint()),
                                 preprocessResponse(prettyPrint()),
                                 pathParameters(
@@ -370,7 +370,7 @@ class CategoryControllerTest extends ControllerTest {
                         .content(objectMapper.writeValueAsString(카테고리_수정_요청))
                 )
                 .andDo(print())
-                .andDo(document("categories/update/badRequest",
+                .andDo(document("category/update/failByInvalidNameFormat",
                                 preprocessRequest(prettyPrint()),
                                 preprocessResponse(prettyPrint()),
                                 pathParameters(
@@ -397,7 +397,7 @@ class CategoryControllerTest extends ControllerTest {
                         .header(AUTHORIZATION_HEADER_NAME, AUTHORIZATION_HEADER_VALUE)
                 )
                 .andDo(print())
-                .andDo(document("categories/delete",
+                .andDo(document("category/delete",
                                 preprocessRequest(prettyPrint()),
                                 preprocessResponse(prettyPrint()),
                                 pathParameters(
@@ -425,7 +425,7 @@ class CategoryControllerTest extends ControllerTest {
                         .header(AUTHORIZATION_HEADER_NAME, AUTHORIZATION_HEADER_VALUE)
                 )
                 .andDo(print())
-                .andDo(document("categories/delete/notFound",
+                .andDo(document("category/delete/failByNoCategory",
                                 preprocessRequest(prettyPrint()),
                                 preprocessResponse(prettyPrint()),
                                 pathParameters(

--- a/backend/src/test/java/com/allog/dallog/presentation/CategoryControllerTest.java
+++ b/backend/src/test/java/com/allog/dallog/presentation/CategoryControllerTest.java
@@ -138,7 +138,7 @@ class CategoryControllerTest extends ControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                 )
                 .andDo(print())
-                .andDo(document("categories/findAllByName/allByNoName",
+                .andDo(document("category/findAllByName/allByNoName",
                                 preprocessRequest(prettyPrint()),
                                 preprocessResponse(prettyPrint()),
                                 requestParameters(

--- a/backend/src/test/java/com/allog/dallog/presentation/ExternalCalendarControllerTest.java
+++ b/backend/src/test/java/com/allog/dallog/presentation/ExternalCalendarControllerTest.java
@@ -103,7 +103,7 @@ class ExternalCalendarControllerTest extends ControllerTest {
                 .andExpect(status().isCreated());
     }
 
-    @DisplayName("외부 캘린더를 중복하여 저장하면 상태코드 201을 반환한다.")
+    @DisplayName("외부 캘린더를 중복하여 저장하면 상태코드 400을 반환한다.")
     @Test
     void 외부_캘린더를_중복하여_저장하면_상태코드_400을_반환한다() throws Exception {
         // given
@@ -119,7 +119,7 @@ class ExternalCalendarControllerTest extends ControllerTest {
                         .content(objectMapper.writeValueAsString(우아한테크코스_생성_요청))
                 )
                 .andDo(print())
-                .andDo(document("externalCalendar/save/successOnDuplicate",
+                .andDo(document("externalCalendar/save/failByDuplicate",
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint()),
                         requestHeaders(

--- a/backend/src/test/java/com/allog/dallog/presentation/ExternalCalendarControllerTest.java
+++ b/backend/src/test/java/com/allog/dallog/presentation/ExternalCalendarControllerTest.java
@@ -65,7 +65,7 @@ class ExternalCalendarControllerTest extends ControllerTest {
                         .accept(MediaType.APPLICATION_JSON)
                 )
                 .andDo(print())
-                .andDo(document("external-calendars/get",
+                .andDo(document("externalCalendar/getExternalCalendar",
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint()),
                         requestHeaders(
@@ -90,7 +90,7 @@ class ExternalCalendarControllerTest extends ControllerTest {
                         .content(objectMapper.writeValueAsString(우아한테크코스_생성_요청))
                 )
                 .andDo(print())
-                .andDo(document("external-calendars/save",
+                .andDo(document("externalCalendar/save",
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint()),
                         requestHeaders(
@@ -103,7 +103,7 @@ class ExternalCalendarControllerTest extends ControllerTest {
                 .andExpect(status().isCreated());
     }
 
-    @DisplayName("외부 캘린더를 카테고리로 저장하면 상태코드 201을 반환한다.")
+    @DisplayName("외부 캘린더를 중복하여 저장하면 상태코드 201을 반환한다.")
     @Test
     void 외부_캘린더를_중복하여_저장하면_상태코드_400을_반환한다() throws Exception {
         // given
@@ -119,7 +119,7 @@ class ExternalCalendarControllerTest extends ControllerTest {
                         .content(objectMapper.writeValueAsString(우아한테크코스_생성_요청))
                 )
                 .andDo(print())
-                .andDo(document("external-calendars/duplicated-save",
+                .andDo(document("externalCalendar/save/successOnDuplicate",
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint()),
                         requestHeaders(

--- a/backend/src/test/java/com/allog/dallog/presentation/MemberControllerTest.java
+++ b/backend/src/test/java/com/allog/dallog/presentation/MemberControllerTest.java
@@ -15,6 +15,7 @@ import static org.springframework.restdocs.operation.preprocess.Preprocessors.pr
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -62,6 +63,13 @@ class MemberControllerTest extends ControllerTest {
                         preprocessResponse(prettyPrint()),
                         requestHeaders(
                                 headerWithName("Authorization").description("JWT 토큰")
+                        ),
+                        responseFields(
+                                fieldWithPath("id").description("회원 ID"),
+                                fieldWithPath("email").description("회원 이메일"),
+                                fieldWithPath("displayName").description("회원 이름"),
+                                fieldWithPath("profileImageUrl").description("회원 프로필 이미지 URL"),
+                                fieldWithPath("socialType").description("회원 소셜 타입")
                         )
                 ))
                 .andExpect(status().isOk());

--- a/backend/src/test/java/com/allog/dallog/presentation/MemberControllerTest.java
+++ b/backend/src/test/java/com/allog/dallog/presentation/MemberControllerTest.java
@@ -57,7 +57,7 @@ class MemberControllerTest extends ControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                 )
                 .andDo(print())
-                .andDo(document("members/me",
+                .andDo(document("member/findMe",
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint()),
                         requestHeaders(
@@ -80,7 +80,7 @@ class MemberControllerTest extends ControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                 )
                 .andDo(print())
-                .andDo(document("members/exception/notfound",
+                .andDo(document("member/findMe/failNoMember",
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint()),
                         requestHeaders(
@@ -107,7 +107,7 @@ class MemberControllerTest extends ControllerTest {
                         .content(objectMapper.writeValueAsString(회원_수정_요청))
                 )
                 .andDo(print())
-                .andDo(document("members/update",
+                .andDo(document("member/update",
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint()),
                         requestHeaders(
@@ -133,7 +133,7 @@ class MemberControllerTest extends ControllerTest {
                         .header(AUTHORIZATION_HEADER_NAME, AUTHORIZATION_HEADER_VALUE)
                 )
                 .andDo(print())
-                .andDo(document("members/delete",
+                .andDo(document("member/delete",
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint()),
                         requestHeaders(

--- a/backend/src/test/java/com/allog/dallog/presentation/ScheduleControllerTest.java
+++ b/backend/src/test/java/com/allog/dallog/presentation/ScheduleControllerTest.java
@@ -90,7 +90,7 @@ class ScheduleControllerTest extends ControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andDo(print())
-                .andDo(document("schedules/save",
+                .andDo(document("schedule/save",
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint())
                 ))
@@ -113,7 +113,7 @@ class ScheduleControllerTest extends ControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andDo(print())
-                .andDo(document("schedules/save/forbidden",
+                .andDo(document("schedule/save/failByNoPermission",
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint())
                 ))
@@ -136,7 +136,7 @@ class ScheduleControllerTest extends ControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andDo(print())
-                .andDo(document("schedules/save/notfound",
+                .andDo(document("schedule/save/failByNoCategory",
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint())
                 ))
@@ -156,7 +156,7 @@ class ScheduleControllerTest extends ControllerTest {
                         .header(AUTHORIZATION_HEADER_NAME, AUTHORIZATION_HEADER_VALUE)
                         .accept(MediaType.APPLICATION_JSON))
                 .andDo(print())
-                .andDo(document("schedules/findone",
+                .andDo(document("schedule/findById",
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint())
                 ))
@@ -176,7 +176,7 @@ class ScheduleControllerTest extends ControllerTest {
                         .header(AUTHORIZATION_HEADER_NAME, AUTHORIZATION_HEADER_VALUE)
                         .accept(MediaType.APPLICATION_JSON))
                 .andDo(print())
-                .andDo(document("schedules/findone/notfound",
+                .andDo(document("schedule/findById/failByNoSchedule",
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint())
                 ))
@@ -200,7 +200,7 @@ class ScheduleControllerTest extends ControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(수정_요청)))
                 .andDo(print())
-                .andDo(document("schedules/update",
+                .andDo(document("schedule/update",
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint()),
                         pathParameters(
@@ -226,7 +226,7 @@ class ScheduleControllerTest extends ControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(수정_요청)))
                 .andDo(print())
-                .andDo(document("schedules/update/forbidden",
+                .andDo(document("schedule/update/failByNoPermission",
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint())
                 ))
@@ -249,7 +249,7 @@ class ScheduleControllerTest extends ControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(수정_요청)))
                 .andDo(print())
-                .andDo(document("schedules/update/notfound",
+                .andDo(document("schedule/update/failByNoSchedule",
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint())
                 ))
@@ -269,7 +269,7 @@ class ScheduleControllerTest extends ControllerTest {
         mockMvc.perform(RestDocumentationRequestBuilders.delete("/api/schedules/{scheduleId}", scheduleId)
                         .header(AUTHORIZATION_HEADER_NAME, AUTHORIZATION_HEADER_VALUE))
                 .andDo(print())
-                .andDo(document("schedules/delete",
+                .andDo(document("schedule/delete",
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint()),
                         pathParameters(
@@ -292,7 +292,7 @@ class ScheduleControllerTest extends ControllerTest {
         mockMvc.perform(delete("/api/schedules/{scheduleId}", scheduleId)
                         .header(AUTHORIZATION_HEADER_NAME, AUTHORIZATION_HEADER_VALUE))
                 .andDo(print())
-                .andDo(document("schedules/delete/forbidden",
+                .andDo(document("schedule/delete/failByNoPermission",
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint())
                 ))
@@ -312,7 +312,7 @@ class ScheduleControllerTest extends ControllerTest {
         mockMvc.perform(delete("/api/schedules/{scheduleId}", scheduleId)
                         .header(AUTHORIZATION_HEADER_NAME, AUTHORIZATION_HEADER_VALUE))
                 .andDo(print())
-                .andDo(document("schedules/delete/notfound",
+                .andDo(document("schedule/delete/failByNoSchedule",
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint())
                 ))
@@ -355,7 +355,7 @@ class ScheduleControllerTest extends ControllerTest {
                         get("/api/members/me/schedules?startDateTime={startDate}&endDateTime={endDate}", startDate, endDate)
                                 .header(AUTHORIZATION_HEADER_NAME, AUTHORIZATION_HEADER_VALUE))
                 .andDo(print())
-                .andDo(document("schedules/findAllByMember",
+                .andDo(document("schedule/findSchedulesByMemberId",
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint()),
                         requestParameters(

--- a/backend/src/test/java/com/allog/dallog/presentation/SchedulerControllerTest.java
+++ b/backend/src/test/java/com/allog/dallog/presentation/SchedulerControllerTest.java
@@ -64,7 +64,7 @@ class SchedulerControllerTest extends ControllerTest {
                                 1L, startDateTime, endDateTime)
                         .header(AUTHORIZATION_HEADER_NAME, AUTHORIZATION_HEADER_VALUE))
                 .andDo(print())
-                .andDo(document("scheduler/category/available-periods",
+                .andDo(document("scheduler/scheduleByCategory",
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint()),
                         pathParameters(

--- a/backend/src/test/java/com/allog/dallog/presentation/SubscriptionControllerTest.java
+++ b/backend/src/test/java/com/allog/dallog/presentation/SubscriptionControllerTest.java
@@ -85,30 +85,6 @@ class SubscriptionControllerTest extends ControllerTest {
                 .andExpect(status().isCreated());
     }
 
-    @DisplayName("자신의 구독 목록을 가져온다.")
-    @Test
-    void 자신의_구독_목록을_가져온다() throws Exception {
-        // given
-        CategoryResponse 공통_일정_응답 = 공통_일정_응답(관리자_응답);
-
-        SubscriptionsResponse subscriptionsResponse = new SubscriptionsResponse(
-                List.of(색상1_구독_응답(공통_일정_응답), 색상2_구독_응답(공통_일정_응답), 색상3_구독_응답(공통_일정_응답)));
-
-        given(subscriptionService.findByMemberId(any()))
-                .willReturn(subscriptionsResponse);
-
-        // when & then
-        mockMvc.perform(get("/api/members/me/subscriptions", 공통_일정_응답.getId())
-                        .header(AUTHORIZATION_HEADER_NAME, AUTHORIZATION_HEADER_VALUE)
-                        .accept(MediaType.APPLICATION_JSON))
-                .andDo(print())
-                .andDo(document("subscription/findMine",
-                        preprocessRequest(prettyPrint()),
-                        preprocessResponse(prettyPrint())
-                ))
-                .andExpect(status().isOk());
-    }
-
     @DisplayName("회원이 이미 카테고리를 구독한 경우 예외를 던진다.")
     @Test
     void 회원이_이미_카테고리를_구독한_경우_예외를_던진다() throws Exception {
@@ -182,7 +158,7 @@ class SubscriptionControllerTest extends ControllerTest {
                         .accept(MediaType.APPLICATION_JSON)
                         .contentType(MediaType.APPLICATION_JSON))
                 .andDo(print())
-                .andDo(document("subscription/me",
+                .andDo(document("subscription/findMine",
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint()),
                         requestHeaders(
@@ -268,7 +244,7 @@ class SubscriptionControllerTest extends ControllerTest {
                         .header(AUTHORIZATION_HEADER_NAME, AUTHORIZATION_HEADER_VALUE)
                         .contentType(MediaType.APPLICATION_JSON))
                 .andDo(print())
-                .andDo(document("subscription/delete/failByNotMine",
+                .andDo(document("subscription/delete/failByNoPermission",
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint()),
                         pathParameters(

--- a/backend/src/test/java/com/allog/dallog/presentation/SubscriptionControllerTest.java
+++ b/backend/src/test/java/com/allog/dallog/presentation/SubscriptionControllerTest.java
@@ -122,7 +122,7 @@ class SubscriptionControllerTest extends ControllerTest {
                                 .header(AUTHORIZATION_HEADER_NAME, AUTHORIZATION_HEADER_VALUE)
                                 .accept(MediaType.APPLICATION_JSON))
                 .andDo(print())
-                .andDo(document("subscription/exist",
+                .andDo(document("subscription/save/failByAlreadyExisting",
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint()),
                         pathParameters(
@@ -147,7 +147,7 @@ class SubscriptionControllerTest extends ControllerTest {
                                 .header(AUTHORIZATION_HEADER_NAME, AUTHORIZATION_HEADER_VALUE)
                                 .accept(MediaType.APPLICATION_JSON))
                 .andDo(print())
-                .andDo(document("subscription/private-category",
+                .andDo(document("subscription/save/failBySubscribingPrivateCategoryOfOther",
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint()),
                         pathParameters(
@@ -253,9 +253,9 @@ class SubscriptionControllerTest extends ControllerTest {
                 .andExpect(status().isNoContent());
     }
 
-    @DisplayName("자신이 가지고 있지 않은 구독 정보인 경우 예외를 던진다.")
+    @DisplayName("구독 제거시 자신이 가지고 있지 않은 구독 정보인 경우 예외를 던진다.")
     @Test
-    void 자신이_가지고_있지_않은_구독_정보인_경우_예외를_던진다() throws Exception {
+    void 구독_제거시_자신이_가지고_있지_않은_구독_정보인_경우_예외를_던진다() throws Exception {
         // given
         given(authService.extractMemberId(any())).willReturn(매트_응답.getId());
         willThrow(new NoPermissionException())
@@ -268,7 +268,7 @@ class SubscriptionControllerTest extends ControllerTest {
                         .header(AUTHORIZATION_HEADER_NAME, AUTHORIZATION_HEADER_VALUE)
                         .contentType(MediaType.APPLICATION_JSON))
                 .andDo(print())
-                .andDo(document("subscription/permission",
+                .andDo(document("subscription/delete/failByNotMine",
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint()),
                         pathParameters(


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 💻 git rebase를 사용했나요?
- [x] 🌈 알록달록한가요?

## 작업 내용

### identifier 통일

```java
mockMvc.perform( ... )
// ...
                .andDo(document("subscription/save", // <-- 여기
```

identifier란 위와 같이 MockMvc `andDo(document())` 에 전달하는 REST Docs 문서 조각에 대한 식별자입니다. 이에 대한 통일이 이뤄지지 않았는데, 아래 형식으로 통일하려 합니다.

```
컨트롤러 이름/컨트롤러 메소드 이름/{설명}
```

`컨트롤러 이름`과 `컨트롤러 메소드 이름` 은 필수고 `설명` 은 선택 사항입니다. _'어떠한 이유로 실패했다'_, 혹은 _'어떤 기준으로 필터링 한다'_ 등 API에 대한 부연설명이 필요한 경우 작성해주시면 됩니다.

### Asciidoc 형식 통일

- 제목 통일
  - Path Parameters를 `PathParameters`, `Path Parameter` 등 으로 통일되지 않게 작성되어있는 부분을 통일합니다.
  - 통일 기준은 adoc snippet 파일 명 기준입니다. 만약 파일명이 `.../request-fields.adoc` 이라면, 제목은 `Request Fields` 로 작성합니다.
- 아래 adoc 스니펫은 API에서 사용되지 않을 경우를 제외하고 필수로 문서에 포함해야 합니다. (생략해도 큰 문제가 없다면, 생략합니다.)
  - **요청**
    - `http-request` : HTTP Request Message
    - `request-headers` : Request 헤더 (`requestHeaders()`) (필요한 헤더가 `Authorization` 뿐이라면 생략합니다.)
    - `path-parameters` : URL 매개변수 (`pathParameters()`)
    - `request-parameters` : URL 쿼리 스트링 (`requestParameters()`)
    - `request-fields` : Request Body 각 필드에 대한 설명 (`requestFields()`)
  - **응답** 
    - `http-response` : HTTP Response Message
    - `response-fields` : Response body 각 필드에 대한 설명
- 유효하지 않은 API 요청에 대한 문서화 시 Response에 대한 스니펫만 추가합니다.
- 그외 필요시 직접 adoc 문서에 텍스트로 부연설명 하면 됩니다.

 > `request-body` 와 `response-body` 는 각각 `http-request` 와 `http-response` 에 포함되므로 사용하지 않습니다. 또한, `curl-request` 와 `httpie-request` 도 사용할일이 없으므로 사용하지 않습니다.

## 스크린샷

## 주의사항

Closes #560 
