### PR TITLE
[refactor] 내부 스케줄과 외부 스케줄 관련 로직을 리팩토링한다.

### DIFF
--- a/backend/src/main/java/com/allog/dallog/domain/auth/dto/response/OAuthAccessTokenResponse.java
+++ b/backend/src/main/java/com/allog/dallog/domain/auth/dto/response/OAuthAccessTokenResponse.java
@@ -7,34 +7,15 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 public class OAuthAccessTokenResponse {
 
     private String accessToken;
-    private String expiresIn;
-    private String scope;
-    private String tokenType;
 
     private OAuthAccessTokenResponse() {
     }
 
-    public OAuthAccessTokenResponse(final String accessToken, final String expiresIn, final String scope,
-                                    final String tokenType) {
+    public OAuthAccessTokenResponse(final String accessToken) {
         this.accessToken = accessToken;
-        this.expiresIn = expiresIn;
-        this.scope = scope;
-        this.tokenType = tokenType;
     }
 
     public String getAccessToken() {
         return accessToken;
-    }
-
-    public String getExpiresIn() {
-        return expiresIn;
-    }
-
-    public String getScope() {
-        return scope;
-    }
-
-    public String getTokenType() {
-        return tokenType;
     }
 }

--- a/backend/src/main/java/com/allog/dallog/domain/auth/dto/response/OAuthAccessTokenResponse.java
+++ b/backend/src/main/java/com/allog/dallog/domain/auth/dto/response/OAuthAccessTokenResponse.java
@@ -6,16 +6,16 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class OAuthAccessTokenResponse {
 
-    private String accessToken;
+    private String value;
 
     private OAuthAccessTokenResponse() {
     }
 
-    public OAuthAccessTokenResponse(final String accessToken) {
-        this.accessToken = accessToken;
+    public OAuthAccessTokenResponse(final String value) {
+        this.value = value;
     }
 
-    public String getAccessToken() {
-        return accessToken;
+    public String getValue() {
+        return value;
     }
 }

--- a/backend/src/main/java/com/allog/dallog/domain/category/domain/ExternalCategoryDetailRepository.java
+++ b/backend/src/main/java/com/allog/dallog/domain/category/domain/ExternalCategoryDetailRepository.java
@@ -1,5 +1,6 @@
 package com.allog.dallog.domain.category.domain;
 
+import com.allog.dallog.domain.category.exception.NoSuchExternalCategoryDetailException;
 import com.allog.dallog.domain.category.exception.ExistExternalCategoryException;
 import java.util.List;
 import java.util.Optional;
@@ -12,6 +13,11 @@ public interface ExternalCategoryDetailRepository extends JpaRepository<External
     boolean existsByExternalIdAndCategoryIn(final String externalId, final List<Category> categories);
 
     void deleteByCategoryId(final Long categoryId);
+
+    default ExternalCategoryDetail getByCategoryId(final Long categoryId) {
+        return this.findByCategoryId(categoryId)
+                .orElseThrow(NoSuchExternalCategoryDetailException::new);
+    }
 
     default void validateExistByExternalIdAndCategoryIn(final String externalId, final List<Category> externalCategories) {
         if (existsByExternalIdAndCategoryIn(externalId, externalCategories)) {

--- a/backend/src/main/java/com/allog/dallog/domain/composition/application/CalendarService.java
+++ b/backend/src/main/java/com/allog/dallog/domain/composition/application/CalendarService.java
@@ -117,7 +117,8 @@ public class CalendarService {
     private List<IntegrationSchedule> getExternalSchedules(final Long memberId, final DateRangeRequest request,
                                                            final List<ExternalCategoryDetail> externalCategories) {
         String refreshToken = getOAuthToken(memberId).getRefreshToken();
-        String accessToken = oAuthClient.getAccessToken(refreshToken).getAccessToken();
+        String accessToken = oAuthClient.getAccessToken(refreshToken)
+                .getValue();
 
         return externalCategories.stream()
                 .flatMap(externalCategory -> flatIntegrationSchedules(request, accessToken, externalCategory))

--- a/backend/src/main/java/com/allog/dallog/domain/composition/application/CalendarService.java
+++ b/backend/src/main/java/com/allog/dallog/domain/composition/application/CalendarService.java
@@ -15,7 +15,6 @@ import com.allog.dallog.domain.integrationschedule.domain.TypedSchedules;
 import com.allog.dallog.domain.schedule.dto.request.DateRangeRequest;
 import com.allog.dallog.domain.schedule.dto.response.MemberScheduleResponses;
 import com.allog.dallog.domain.subscription.application.SubscriptionService;
-import com.allog.dallog.domain.subscription.domain.Subscription;
 import com.allog.dallog.domain.subscription.domain.Subscriptions;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
@@ -59,11 +58,10 @@ public class CalendarService {
                 .collect(Collectors.toList());
     }
 
-    public MemberScheduleResponses findSchedulesByMemberId(final Long memberId,
-                                                           final DateRangeRequest dateRange) {
-        List<Subscription> subscriptions = subscriptionService.getAllByMemberId(memberId);
-        List<IntegrationSchedule> integrationSchedules = getIntegrationSchedulesByMemberIdAndSubscriptions(memberId,
-                dateRange);
+    public MemberScheduleResponses findSchedulesByMemberId(final Long memberId, final DateRangeRequest dateRange) {
+        Subscriptions subscriptions = new Subscriptions(subscriptionService.getAllByMemberId(memberId));
+        List<IntegrationSchedule> integrationSchedules =
+                getIntegrationSchedulesByMemberIdAndSubscriptions(memberId, dateRange);
         return new MemberScheduleResponses(subscriptions, new TypedSchedules(integrationSchedules));
     }
 

--- a/backend/src/main/java/com/allog/dallog/domain/composition/application/SchedulerService.java
+++ b/backend/src/main/java/com/allog/dallog/domain/composition/application/SchedulerService.java
@@ -31,7 +31,7 @@ public class SchedulerService {
 
     public List<PeriodResponse> getAvailablePeriods(final Long categoryId, final DateRangeRequest dateRange) {
         List<Long> subscriberIds = getSubscriberIds(categoryId);
-        List<IntegrationSchedule> schedules = calendarService.getSchedulesOfSubscriberIds(subscriberIds, dateRange);
+        List<IntegrationSchedule> schedules = calendarService.getSchedulesBySubscriberIds(subscriberIds, dateRange);
 
         Scheduler scheduler = new Scheduler(schedules, dateRange.getStartDateTime(), dateRange.getEndDateTime());
 

--- a/backend/src/main/java/com/allog/dallog/domain/externalcalendar/application/ExternalCalendarService.java
+++ b/backend/src/main/java/com/allog/dallog/domain/externalcalendar/application/ExternalCalendarService.java
@@ -3,7 +3,6 @@ package com.allog.dallog.domain.externalcalendar.application;
 import com.allog.dallog.domain.auth.application.OAuthClient;
 import com.allog.dallog.domain.auth.domain.OAuthToken;
 import com.allog.dallog.domain.auth.domain.OAuthTokenRepository;
-import com.allog.dallog.domain.auth.dto.response.OAuthAccessTokenResponse;
 import com.allog.dallog.domain.auth.exception.NoSuchOAuthTokenException;
 import com.allog.dallog.domain.externalcalendar.dto.ExternalCalendar;
 import com.allog.dallog.domain.externalcalendar.dto.ExternalCalendarsResponse;
@@ -30,9 +29,9 @@ public class ExternalCalendarService {
         OAuthToken oAuthToken = oAuthTokenRepository.findByMemberId(memberId)
                 .orElseThrow(NoSuchOAuthTokenException::new);
 
-        OAuthAccessTokenResponse oAuthAccessTokenResponse = oAuthClient.getAccessToken(oAuthToken.getRefreshToken());
-        String oAuthAccessToken = oAuthAccessTokenResponse.getAccessToken();
-        
+        String oAuthAccessToken = oAuthClient.getAccessToken(oAuthToken.getRefreshToken())
+                .getValue();
+
         List<ExternalCalendar> externalCalendars = externalCalendarClient.getExternalCalendars(oAuthAccessToken);
 
         return new ExternalCalendarsResponse(externalCalendars);

--- a/backend/src/main/java/com/allog/dallog/domain/integrationschedule/dao/IntegrationScheduleDao.java
+++ b/backend/src/main/java/com/allog/dallog/domain/integrationschedule/dao/IntegrationScheduleDao.java
@@ -4,7 +4,7 @@ import com.allog.dallog.domain.category.domain.CategoryType;
 import com.allog.dallog.domain.integrationschedule.domain.IntegrationSchedule;
 import com.allog.dallog.domain.integrationschedule.domain.Period;
 import java.time.LocalDateTime;
-import java.util.Collections;
+import java.util.ArrayList;
 import java.util.List;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
@@ -24,7 +24,7 @@ public class IntegrationScheduleDao {
                                                                   final LocalDateTime startDateTime,
                                                                   final LocalDateTime endDateTime) {
         if (categoryIds.isEmpty()) {
-            return Collections.emptyList();
+            return new ArrayList<>();
         }
 
         String sql = "SELECT s.id as id, c.id as categoryId, s.title as title, "

--- a/backend/src/main/java/com/allog/dallog/domain/integrationschedule/dao/IntegrationScheduleDao.java
+++ b/backend/src/main/java/com/allog/dallog/domain/integrationschedule/dao/IntegrationScheduleDao.java
@@ -1,5 +1,6 @@
 package com.allog.dallog.domain.integrationschedule.dao;
 
+import com.allog.dallog.domain.category.domain.CategoryType;
 import com.allog.dallog.domain.integrationschedule.domain.IntegrationSchedule;
 import com.allog.dallog.domain.integrationschedule.domain.Period;
 import java.time.LocalDateTime;
@@ -51,7 +52,7 @@ public class IntegrationScheduleDao {
             LocalDateTime startDateTime = resultSet.getTimestamp("startDateTime").toLocalDateTime();
             LocalDateTime endDateTime = resultSet.getTimestamp("endDateTime").toLocalDateTime();
             String memo = resultSet.getString("memo");
-            String categoryType = resultSet.getString("categoryType");
+            CategoryType categoryType = CategoryType.from((resultSet.getString("categoryType")));
 
             Period period = new Period(startDateTime, endDateTime);
 

--- a/backend/src/main/java/com/allog/dallog/domain/integrationschedule/domain/IntegrationSchedule.java
+++ b/backend/src/main/java/com/allog/dallog/domain/integrationschedule/domain/IntegrationSchedule.java
@@ -2,11 +2,8 @@ package com.allog.dallog.domain.integrationschedule.domain;
 
 import com.allog.dallog.domain.category.domain.Category;
 import com.allog.dallog.domain.category.domain.CategoryType;
-import com.allog.dallog.domain.category.exception.NoSuchCategoryException;
-import com.allog.dallog.domain.subscription.domain.Color;
 import com.allog.dallog.domain.subscription.domain.Subscription;
 import java.time.LocalDateTime;
-import java.util.List;
 import java.util.Objects;
 
 public class IntegrationSchedule {
@@ -53,15 +50,7 @@ public class IntegrationSchedule {
                 && period.calculateDayDifference() < ONE_DAY;
     }
 
-    public Color findSubscriptionColor(final List<Subscription> subscriptions) {
-        return subscriptions.stream()
-                .filter(this::isSameCategory)
-                .findAny()
-                .orElseThrow(() -> new NoSuchCategoryException("구독하지 않은 카테고리 입니다."))
-                .getColor();
-    }
-
-    private boolean isSameCategory(final Subscription subscription) {
+    public boolean isSameCategory(final Subscription subscription) {
         Category category = subscription.getCategory();
         return category.getId().equals(categoryId);
     }

--- a/backend/src/main/java/com/allog/dallog/domain/integrationschedule/domain/IntegrationSchedule.java
+++ b/backend/src/main/java/com/allog/dallog/domain/integrationschedule/domain/IntegrationSchedule.java
@@ -1,6 +1,7 @@
 package com.allog.dallog.domain.integrationschedule.domain;
 
 import com.allog.dallog.domain.category.domain.Category;
+import com.allog.dallog.domain.category.domain.CategoryType;
 import com.allog.dallog.domain.category.exception.NoSuchCategoryException;
 import com.allog.dallog.domain.subscription.domain.Color;
 import com.allog.dallog.domain.subscription.domain.Subscription;
@@ -19,16 +20,16 @@ public class IntegrationSchedule {
     private final String title;
     private final Period period;
     private final String memo;
-    private final String categoryType;
+    private final CategoryType categoryType;
 
     public IntegrationSchedule(final String id, final Long categoryId, final String title,
                                final LocalDateTime startDateTime, final LocalDateTime endDateTime, final String memo,
-                               final String categoryType) {
+                               final CategoryType categoryType) {
         this(id, categoryId, title, new Period(startDateTime, endDateTime), memo, categoryType);
     }
 
     public IntegrationSchedule(final String id, final Long categoryId, final String title, final Period period,
-                               final String memo, final String categoryType) {
+                               final String memo, final CategoryType categoryType) {
         this.id = id;
         this.categoryId = categoryId;
         this.title = title;
@@ -93,11 +94,9 @@ public class IntegrationSchedule {
         return memo;
     }
 
-    public String getCategoryType() {
+    public CategoryType getCategoryType() {
         return categoryType;
     }
-
-    // 중복 일정을 판별하기 위한 equals & hashCode
 
     @Override
     public boolean equals(final Object o) {

--- a/backend/src/main/java/com/allog/dallog/domain/integrationschedule/domain/IntegrationScheduleComparator.java
+++ b/backend/src/main/java/com/allog/dallog/domain/integrationschedule/domain/IntegrationScheduleComparator.java
@@ -5,38 +5,29 @@ import java.util.Comparator;
 
 public class IntegrationScheduleComparator implements Comparator<IntegrationSchedule> {
 
-    private static final int BEFORE = -1;
-    private static final int AFTER = 1;
-    private static final int SAME = 0;
+    private static final int SAME_CONDITION = 0;
 
     @Override
     public int compare(final IntegrationSchedule firstSchedule, final IntegrationSchedule secondSchedule) {
         LocalDateTime firstScheduleStartDateTime = firstSchedule.getStartDateTime();
         LocalDateTime secondScheduleStartDateTime = secondSchedule.getStartDateTime();
 
-        if (firstScheduleStartDateTime.isBefore(secondScheduleStartDateTime)) {
-            return BEFORE;
-        }
-        if (firstScheduleStartDateTime.isAfter(secondScheduleStartDateTime)) {
-            return AFTER;
-        }
-        if (firstScheduleStartDateTime.isEqual(secondScheduleStartDateTime)) {
+        int cmp = firstScheduleStartDateTime.compareTo(secondScheduleStartDateTime);
+        if (cmp == SAME_CONDITION) {
             return compareEndDateTime(firstSchedule, secondSchedule);
         }
-        return SAME;
+        return cmp;
     }
 
     private int compareEndDateTime(IntegrationSchedule firstSchedule, IntegrationSchedule secondSchedule) {
         LocalDateTime firstScheduleEndDateTime = firstSchedule.getEndDateTime();
         LocalDateTime secondScheduleEndDateTime = secondSchedule.getEndDateTime();
 
-        if (firstScheduleEndDateTime.isBefore(secondScheduleEndDateTime)) {
-            return AFTER;
+        int cmp = secondScheduleEndDateTime.compareTo(firstScheduleEndDateTime);
+        if (cmp == SAME_CONDITION) {
+            return compareByTitle(firstSchedule, secondSchedule);
         }
-        if (firstScheduleEndDateTime.isAfter(secondScheduleEndDateTime)) {
-            return BEFORE;
-        }
-        return compareByTitle(firstSchedule, secondSchedule);
+        return cmp;
     }
 
     private int compareByTitle(IntegrationSchedule firstSchedule, IntegrationSchedule secondSchedule) {

--- a/backend/src/main/java/com/allog/dallog/domain/integrationschedule/domain/Period.java
+++ b/backend/src/main/java/com/allog/dallog/domain/integrationschedule/domain/Period.java
@@ -47,10 +47,12 @@ public class Period {
 
     private boolean isNotOverlapped(final Period otherPeriod) {
         // other가 좌측 방향으로 멀리 떨어져 겹치지 않을때
-        boolean farFromLeftSideOfBase = otherPeriod.endDateTime.isBefore(startDateTime);
+        boolean farFromLeftSideOfBase = otherPeriod.endDateTime
+                .isBefore(startDateTime);
 
         // other가 우측 방향으로 멀리 떨어져 겹치지 않을때
-        boolean farFromRightSideOfBase = otherPeriod.startDateTime.isAfter(endDateTime);
+        boolean farFromRightSideOfBase = otherPeriod.startDateTime
+                .isAfter(endDateTime);
 
         return farFromLeftSideOfBase || farFromRightSideOfBase;
     }

--- a/backend/src/main/java/com/allog/dallog/domain/integrationschedule/domain/Period.java
+++ b/backend/src/main/java/com/allog/dallog/domain/integrationschedule/domain/Period.java
@@ -42,8 +42,17 @@ public class Period {
         if (isNotOverlapped(otherPeriod)) {
             return List.of(this);
         }
-
         return sliceByOtherPeriod(otherPeriod);
+    }
+
+    private boolean isNotOverlapped(final Period otherPeriod) {
+        // other가 좌측 방향으로 멀리 떨어져 겹치지 않을때
+        boolean farFromLeftSideOfBase = otherPeriod.endDateTime.isBefore(startDateTime);
+
+        // other가 우측 방향으로 멀리 떨어져 겹치지 않을때
+        boolean farFromRightSideOfBase = otherPeriod.startDateTime.isAfter(endDateTime);
+
+        return farFromLeftSideOfBase || farFromRightSideOfBase;
     }
 
     private List<Period> sliceByOtherPeriod(final Period otherPeriod) {
@@ -57,16 +66,6 @@ public class Period {
         }
 
         return periods;
-    }
-
-    private boolean isNotOverlapped(final Period otherPeriod) {
-        boolean farFromLeftSideOfBase = otherPeriod.endDateTime.isBefore(startDateTime);
-        // other가 좌측 방향으로 멀리 떨어져 겹치지 않을때
-
-        boolean farFromRightSideOfBase = otherPeriod.startDateTime.isAfter(endDateTime);
-        // other가 우측 방향으로 멀리 떨어져 겹치지 않을때
-
-        return farFromLeftSideOfBase || farFromRightSideOfBase;
     }
 
     public LocalDateTime getStartDateTime() {

--- a/backend/src/main/java/com/allog/dallog/domain/integrationschedule/domain/TypedSchedules.java
+++ b/backend/src/main/java/com/allog/dallog/domain/integrationschedule/domain/TypedSchedules.java
@@ -12,8 +12,8 @@ public class TypedSchedules {
         initializeValues();
         for (IntegrationSchedule integrationSchedule : integrationSchedules) {
             ScheduleType scheduleType = ScheduleType.from(integrationSchedule);
-            IntegrationSchedules sortedSchedules = values.get(scheduleType);
-            sortedSchedules.add(integrationSchedule);
+            IntegrationSchedules schedules = values.get(scheduleType);
+            schedules.add(integrationSchedule);
         }
     }
 

--- a/backend/src/main/java/com/allog/dallog/domain/schedule/dto/response/MemberScheduleResponse.java
+++ b/backend/src/main/java/com/allog/dallog/domain/schedule/dto/response/MemberScheduleResponse.java
@@ -18,7 +18,8 @@ public class MemberScheduleResponse {
     public MemberScheduleResponse(final IntegrationSchedule integrationSchedule, final Color color) {
         this(integrationSchedule.getId(), integrationSchedule.getTitle(), integrationSchedule.getStartDateTime(),
                 integrationSchedule.getEndDateTime(), integrationSchedule.getMemo(),
-                integrationSchedule.getCategoryId(), color.getColorCode(), integrationSchedule.getCategoryType());
+                integrationSchedule.getCategoryId(), color.getColorCode(),
+                integrationSchedule.getCategoryType().name());
     }
 
     public MemberScheduleResponse(final String id, final String title, final LocalDateTime startDateTime,

--- a/backend/src/main/java/com/allog/dallog/domain/schedule/dto/response/MemberScheduleResponses.java
+++ b/backend/src/main/java/com/allog/dallog/domain/schedule/dto/response/MemberScheduleResponses.java
@@ -2,13 +2,12 @@ package com.allog.dallog.domain.schedule.dto.response;
 
 import com.allog.dallog.domain.integrationschedule.domain.ScheduleType;
 import com.allog.dallog.domain.integrationschedule.domain.TypedSchedules;
-import com.allog.dallog.domain.subscription.domain.Subscription;
+import com.allog.dallog.domain.subscription.domain.Subscriptions;
 import java.util.List;
 import java.util.stream.Collectors;
 
 public class MemberScheduleResponses {
 
-    // TODO: 리팩토링
     private final List<MemberScheduleResponse> longTerms;
     private final List<MemberScheduleResponse> allDays;
     private final List<MemberScheduleResponse> fewHours;
@@ -21,19 +20,19 @@ public class MemberScheduleResponses {
         this.fewHours = fewHours;
     }
 
-    public MemberScheduleResponses(final List<Subscription> subscriptions, final TypedSchedules typedSchedules) {
+    public MemberScheduleResponses(final Subscriptions subscriptions, final TypedSchedules typedSchedules) {
         this.longTerms = getColoredScheduleResponses(ScheduleType.LONG_TERMS, subscriptions, typedSchedules);
         this.allDays = getColoredScheduleResponses(ScheduleType.ALL_DAYS, subscriptions, typedSchedules);
         this.fewHours = getColoredScheduleResponses(ScheduleType.FEW_HOURS, subscriptions, typedSchedules);
     }
 
     private List<MemberScheduleResponse> getColoredScheduleResponses(final ScheduleType scheduleType,
-                                                                     final List<Subscription> subscriptions,
+                                                                     final Subscriptions subscriptions,
                                                                      final TypedSchedules typedSchedules) {
         return typedSchedules.getSortedSchedules(scheduleType)
                 .getSortedValues()
                 .stream()
-                .map(schedule -> new MemberScheduleResponse(schedule, schedule.findSubscriptionColor(subscriptions)))
+                .map(schedule -> new MemberScheduleResponse(schedule, subscriptions.findColor(schedule)))
                 .collect(Collectors.toList());
     }
 

--- a/backend/src/main/java/com/allog/dallog/domain/subscription/application/SubscriptionService.java
+++ b/backend/src/main/java/com/allog/dallog/domain/subscription/application/SubscriptionService.java
@@ -68,11 +68,6 @@ public class SubscriptionService {
                 .collect(Collectors.toList());
     }
 
-    // TODO: 상위 Service인 CalanderService에서만 사용하는 메서드입니다. 삭제 예정
-    public List<Subscription> getAllByMemberId(final Long memberId) {
-        return subscriptionRepository.findByMemberId(memberId);
-    }
-
     @Transactional
     public void update(final Long id, final Long memberId, final SubscriptionUpdateRequest request) {
         subscriptionRepository.validateExistsByIdAndMemberId(id, memberId);

--- a/backend/src/main/java/com/allog/dallog/domain/subscription/domain/Subscriptions.java
+++ b/backend/src/main/java/com/allog/dallog/domain/subscription/domain/Subscriptions.java
@@ -1,6 +1,8 @@
 package com.allog.dallog.domain.subscription.domain;
 
 import com.allog.dallog.domain.category.domain.Category;
+import com.allog.dallog.domain.category.exception.NoSuchCategoryException;
+import com.allog.dallog.domain.integrationschedule.domain.IntegrationSchedule;
 import java.util.List;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -20,5 +22,13 @@ public class Subscriptions {
                 .filter(predicate)
                 .map(Category::getId)
                 .collect(Collectors.toList());
+    }
+
+    public Color findColor(final IntegrationSchedule schedule) {
+        return subscriptions.stream()
+                .filter(schedule::isSameCategory)
+                .findAny()
+                .orElseThrow(() -> new NoSuchCategoryException("구독하지 않은 카테고리 입니다."))
+                .getColor();
     }
 }

--- a/backend/src/main/java/com/allog/dallog/domain/subscription/domain/Subscriptions.java
+++ b/backend/src/main/java/com/allog/dallog/domain/subscription/domain/Subscriptions.java
@@ -15,7 +15,7 @@ public class Subscriptions {
         this.subscriptions = subscriptions;
     }
 
-    public List<Long> findCheckedCategoryIdsBy(Predicate<Category> predicate) {
+    public List<Long> findCheckedCategoryIdsBy(final Predicate<Category> predicate) {
         return subscriptions.stream()
                 .filter(Subscription::isChecked)
                 .map(Subscription::getCategory)

--- a/backend/src/main/java/com/allog/dallog/domain/subscription/domain/Subscriptions.java
+++ b/backend/src/main/java/com/allog/dallog/domain/subscription/domain/Subscriptions.java
@@ -1,0 +1,24 @@
+package com.allog.dallog.domain.subscription.domain;
+
+import com.allog.dallog.domain.category.domain.Category;
+import java.util.List;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+public class Subscriptions {
+
+    private final List<Subscription> subscriptions;
+
+    public Subscriptions(final List<Subscription> subscriptions) {
+        this.subscriptions = subscriptions;
+    }
+
+    public List<Long> findCheckedCategoryIdsBy(Predicate<Category> predicate) {
+        return subscriptions.stream()
+                .filter(Subscription::isChecked)
+                .map(Subscription::getCategory)
+                .filter(predicate)
+                .map(Category::getId)
+                .collect(Collectors.toList());
+    }
+}

--- a/backend/src/main/java/com/allog/dallog/infrastructure/oauth/client/GoogleExternalCalendarClient.java
+++ b/backend/src/main/java/com/allog/dallog/infrastructure/oauth/client/GoogleExternalCalendarClient.java
@@ -103,7 +103,16 @@ public class GoogleExternalCalendarClient implements ExternalCalendarClient {
         LocalDateTime startDateTime = event.getStartDateTime();
         LocalDateTime endDateTime = event.getEndDateTime();
 
+        if (isAllDay(startDateTime, endDateTime)) {
+            endDateTime = endDateTime.minusMinutes(1);
+        }
+
         return new IntegrationSchedule(event.getId(), internalCategoryId, event.getSummary(), startDateTime,
                 endDateTime, event.getDescription(), CategoryType.GOOGLE);
+    }
+
+    private boolean isAllDay(final LocalDateTime startDateTime, final LocalDateTime endDateTime) {
+        return startDateTime.getHour() == 0 && startDateTime.getMinute() == 0
+                && endDateTime.getHour() == 0 && endDateTime.getMinute() == 0;
     }
 }

--- a/backend/src/main/java/com/allog/dallog/infrastructure/oauth/client/GoogleExternalCalendarClient.java
+++ b/backend/src/main/java/com/allog/dallog/infrastructure/oauth/client/GoogleExternalCalendarClient.java
@@ -104,6 +104,6 @@ public class GoogleExternalCalendarClient implements ExternalCalendarClient {
         LocalDateTime endDateTime = event.getEndDateTime();
 
         return new IntegrationSchedule(event.getId(), internalCategoryId, event.getSummary(), startDateTime,
-                endDateTime, event.getDescription(), CategoryType.GOOGLE.name());
+                endDateTime, event.getDescription(), CategoryType.GOOGLE);
     }
 }

--- a/backend/src/main/java/com/allog/dallog/infrastructure/oauth/dto/GoogleCalendarEventResponse.java
+++ b/backend/src/main/java/com/allog/dallog/infrastructure/oauth/dto/GoogleCalendarEventResponse.java
@@ -7,36 +7,23 @@ import java.util.Objects;
 
 public class GoogleCalendarEventResponse {
 
-    private String kind;
-    private String etag;
     private String id;
-    private String status;
-    private String htmlLink;
     private String summary = "";
     private String description = "";
-    private String location;
     private GoogleDateFormat start;
     private GoogleDateFormat end;
-    private String recurringEventId;
 
     private GoogleCalendarEventResponse() {
     }
 
-    public GoogleCalendarEventResponse(final String kind, final String etag, final String id, final String status,
-                                       final String htmlLink, final String summary, final String description,
-                                       final String location, final GoogleDateFormat start, final GoogleDateFormat end,
-                                       final String recurringEventId) {
-        this.kind = kind;
-        this.etag = etag;
+    public GoogleCalendarEventResponse(final String id, final String summary, final String description,
+                                       final GoogleDateFormat start,
+                                       final GoogleDateFormat end) {
         this.id = id;
-        this.status = status;
-        this.htmlLink = htmlLink;
         this.summary = summary;
         this.description = description;
-        this.location = location;
         this.start = start;
         this.end = end;
-        this.recurringEventId = recurringEventId;
     }
 
     public LocalDateTime getStartDateTime() {
@@ -55,24 +42,8 @@ public class GoogleCalendarEventResponse {
         return LocalDateTime.of(LocalDate.parse(end.getDate()), LocalTime.MIN);
     }
 
-    public String getKind() {
-        return kind;
-    }
-
-    public String getEtag() {
-        return etag;
-    }
-
     public String getId() {
         return id;
-    }
-
-    public String getStatus() {
-        return status;
-    }
-
-    public String getHtmlLink() {
-        return htmlLink;
     }
 
     public String getSummary() {
@@ -83,19 +54,11 @@ public class GoogleCalendarEventResponse {
         return description;
     }
 
-    public String getLocation() {
-        return location;
-    }
-
     public GoogleDateFormat getStart() {
         return start;
     }
 
     public GoogleDateFormat getEnd() {
         return end;
-    }
-
-    public String getRecurringEventId() {
-        return recurringEventId;
     }
 }

--- a/backend/src/main/java/com/allog/dallog/infrastructure/oauth/dto/GoogleCalendarEventsResponse.java
+++ b/backend/src/main/java/com/allog/dallog/infrastructure/oauth/dto/GoogleCalendarEventsResponse.java
@@ -4,64 +4,13 @@ import java.util.List;
 
 public class GoogleCalendarEventsResponse {
 
-    private String kind;
-    private String etag;
-    private String summary;
-    private String description;
-    private String timeZone;
-    private String accessRole;
-    private String nextPageToken;
-    private String nextSyncToken;
     private List<GoogleCalendarEventResponse> items;
 
     private GoogleCalendarEventsResponse() {
     }
 
-    public GoogleCalendarEventsResponse(final String kind, final String etag, final String summary,
-                                        final String description, final String timeZone, final String accessRole,
-                                        final String nextPageToken, final String nextSyncToken,
-                                        final List<GoogleCalendarEventResponse> items) {
-        this.kind = kind;
-        this.etag = etag;
-        this.summary = summary;
-        this.description = description;
-        this.timeZone = timeZone;
-        this.accessRole = accessRole;
-        this.nextPageToken = nextPageToken;
-        this.nextSyncToken = nextSyncToken;
+    public GoogleCalendarEventsResponse(final List<GoogleCalendarEventResponse> items) {
         this.items = items;
-    }
-
-    public String getKind() {
-        return kind;
-    }
-
-    public String getEtag() {
-        return etag;
-    }
-
-    public String getSummary() {
-        return summary;
-    }
-
-    public String getDescription() {
-        return description;
-    }
-
-    public String getTimeZone() {
-        return timeZone;
-    }
-
-    public String getAccessRole() {
-        return accessRole;
-    }
-
-    public String getNextPageToken() {
-        return nextPageToken;
-    }
-
-    public String getNextSyncToken() {
-        return nextSyncToken;
     }
 
     public List<GoogleCalendarEventResponse> getItems() {

--- a/backend/src/main/java/com/allog/dallog/infrastructure/oauth/dto/GoogleCalendarListResponse.java
+++ b/backend/src/main/java/com/allog/dallog/infrastructure/oauth/dto/GoogleCalendarListResponse.java
@@ -4,38 +4,13 @@ import java.util.List;
 
 public class GoogleCalendarListResponse {
 
-    private String kind;
-    private String etag;
-    private String nextPageToken;
-    private String nextSyncToken;
     private List<GoogleCalendarResponse> items;
 
     private GoogleCalendarListResponse() {
     }
 
-    public GoogleCalendarListResponse(final String kind, final String etag, final String nextPageToken,
-                                      final String nextSyncToken, final List<GoogleCalendarResponse> items) {
-        this.kind = kind;
-        this.etag = etag;
-        this.nextPageToken = nextPageToken;
-        this.nextSyncToken = nextSyncToken;
+    public GoogleCalendarListResponse(final List<GoogleCalendarResponse> items) {
         this.items = items;
-    }
-
-    public String getKind() {
-        return kind;
-    }
-
-    public String getEtag() {
-        return etag;
-    }
-
-    public String getNextPageToken() {
-        return nextPageToken;
-    }
-
-    public String getNextSyncToken() {
-        return nextSyncToken;
     }
 
     public List<GoogleCalendarResponse> getItems() {

--- a/backend/src/main/java/com/allog/dallog/infrastructure/oauth/dto/GoogleCalendarResponse.java
+++ b/backend/src/main/java/com/allog/dallog/infrastructure/oauth/dto/GoogleCalendarResponse.java
@@ -2,55 +2,17 @@ package com.allog.dallog.infrastructure.oauth.dto;
 
 public class GoogleCalendarResponse {
 
-    private String kind;
-    private String etag;
     private String id;
     private String summary;
     private String description;
-    private String location;
-    private String timeZone;
-    private String summaryOverride;
-    private String colorId;
-    private String backgroundColor;
-    private String foregroundColor;
-    private boolean hidden;
-    private boolean selected;
-    private String accessRole;
-    private boolean primary;
-    private boolean deleted;
 
     private GoogleCalendarResponse() {
     }
 
-    public GoogleCalendarResponse(final String kind, final String etag, final String id, final String summary,
-                                  final String description, final String location, final String timeZone,
-                                  final String summaryOverride, final String colorId, final String backgroundColor,
-                                  final String foregroundColor, final boolean hidden, final boolean selected,
-                                  final String accessRole, final boolean primary, final boolean deleted) {
-        this.kind = kind;
-        this.etag = etag;
+    public GoogleCalendarResponse(final String id, final String summary, final String description) {
         this.id = id;
         this.summary = summary;
         this.description = description;
-        this.location = location;
-        this.timeZone = timeZone;
-        this.summaryOverride = summaryOverride;
-        this.colorId = colorId;
-        this.backgroundColor = backgroundColor;
-        this.foregroundColor = foregroundColor;
-        this.hidden = hidden;
-        this.selected = selected;
-        this.accessRole = accessRole;
-        this.primary = primary;
-        this.deleted = deleted;
-    }
-
-    public String getKind() {
-        return kind;
-    }
-
-    public String getEtag() {
-        return etag;
     }
 
     public String getId() {
@@ -63,49 +25,5 @@ public class GoogleCalendarResponse {
 
     public String getDescription() {
         return description;
-    }
-
-    public String getLocation() {
-        return location;
-    }
-
-    public String getTimeZone() {
-        return timeZone;
-    }
-
-    public String getSummaryOverride() {
-        return summaryOverride;
-    }
-
-    public String getColorId() {
-        return colorId;
-    }
-
-    public String getBackgroundColor() {
-        return backgroundColor;
-    }
-
-    public String getForegroundColor() {
-        return foregroundColor;
-    }
-
-    public boolean isHidden() {
-        return hidden;
-    }
-
-    public boolean isSelected() {
-        return selected;
-    }
-
-    public String getAccessRole() {
-        return accessRole;
-    }
-
-    public boolean isPrimary() {
-        return primary;
-    }
-
-    public boolean isDeleted() {
-        return deleted;
     }
 }

--- a/backend/src/main/java/com/allog/dallog/infrastructure/oauth/dto/GoogleDateFormat.java
+++ b/backend/src/main/java/com/allog/dallog/infrastructure/oauth/dto/GoogleDateFormat.java
@@ -4,15 +4,13 @@ public class GoogleDateFormat {
 
     private String date;
     private String dateTime;
-    private String timeZone;
 
     private GoogleDateFormat() {
     }
 
-    public GoogleDateFormat(final String date, final String dateTime, final String timeZone) {
+    public GoogleDateFormat(final String date, final String dateTime) {
         this.date = date;
         this.dateTime = dateTime;
-        this.timeZone = timeZone;
     }
 
     public String getDate() {
@@ -21,9 +19,5 @@ public class GoogleDateFormat {
 
     public String getDateTime() {
         return dateTime;
-    }
-
-    public String getTimeZone() {
-        return timeZone;
     }
 }

--- a/backend/src/main/java/com/allog/dallog/infrastructure/oauth/dto/GoogleTokenResponse.java
+++ b/backend/src/main/java/com/allog/dallog/infrastructure/oauth/dto/GoogleTokenResponse.java
@@ -6,28 +6,15 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class GoogleTokenResponse {
 
-    private String accessToken;
     private String refreshToken;
     private String idToken;
-    private String expiresIn;
-    private String tokenType;
-    private String scope;
 
     private GoogleTokenResponse() {
     }
 
-    public GoogleTokenResponse(final String accessToken, final String refreshToken, final String idToken,
-                               final String expiresIn, final String scope, final String tokenType) {
-        this.accessToken = accessToken;
+    public GoogleTokenResponse(final String refreshToken, final String idToken) {
         this.refreshToken = refreshToken;
         this.idToken = idToken;
-        this.expiresIn = expiresIn;
-        this.scope = scope;
-        this.tokenType = tokenType;
-    }
-
-    public String getAccessToken() {
-        return accessToken;
     }
 
     public String getRefreshToken() {
@@ -36,17 +23,5 @@ public class GoogleTokenResponse {
 
     public String getIdToken() {
         return idToken;
-    }
-
-    public String getExpiresIn() {
-        return expiresIn;
-    }
-
-    public String getScope() {
-        return scope;
-    }
-
-    public String getTokenType() {
-        return tokenType;
     }
 }

--- a/backend/src/main/java/com/allog/dallog/presentation/ExternalCalendarController.java
+++ b/backend/src/main/java/com/allog/dallog/presentation/ExternalCalendarController.java
@@ -31,7 +31,6 @@ public class ExternalCalendarController {
     @GetMapping
     public ResponseEntity<ExternalCalendarsResponse> getExternalCalendar(
             @AuthenticationPrincipal final LoginMember loginMember) {
-
         return ResponseEntity.ok(externalCalendarService.findByMemberId(loginMember.getId()));
     }
 

--- a/backend/src/test/java/com/allog/dallog/acceptance/fixtures/ScheduleAcceptanceFixtures.java
+++ b/backend/src/test/java/com/allog/dallog/acceptance/fixtures/ScheduleAcceptanceFixtures.java
@@ -15,7 +15,7 @@ public class ScheduleAcceptanceFixtures {
 
     public static ExtractableResponse<Response> 새로운_일정을_등록한다(final String accessToken, final Long categoryId) {
 
-        Map<String, String> params = new HashMap();
+        Map<String, String> params = new HashMap<>();
         params.put("title", 알록달록_회의_제목);
         params.put("startDateTime", "2022-07-04T13:00");
         params.put("endDateTime", "2022-07-05T16:00");

--- a/backend/src/test/java/com/allog/dallog/common/fixtures/AuthFixtures.java
+++ b/backend/src/test/java/com/allog/dallog/common/fixtures/AuthFixtures.java
@@ -34,9 +34,6 @@ public class AuthFixtures {
     public static final String 더미_시크릿_키 = "asdfasarspofjkosdfasdjkflikasndflkasndsdfjkadsnfkjasdn";
 
     public static final String STUB_OAUTH_ACCESS_TOKEN = "aaaaaaaaaa.bbbbbbbbbb.cccccccccc";
-    public static final String STUB_OAUTH_EXPIRES_IN = "3599";
-    public static final String STUB_OAUTH_SCOPE = "openid";
-    public static final String STUB_OAUTH_TOKEN_TYPE = "Bearer";
 
     public static TokenRequest 관리자_인증_코드_토큰_요청() {
         return new TokenRequest(관리자.getCode(), "https://dallog.me/oauth");

--- a/backend/src/test/java/com/allog/dallog/common/fixtures/CategoryFixtures.java
+++ b/backend/src/test/java/com/allog/dallog/common/fixtures/CategoryFixtures.java
@@ -9,6 +9,7 @@ import com.allog.dallog.domain.category.dto.request.CategoryCreateRequest;
 import com.allog.dallog.domain.category.dto.response.CategoryResponse;
 import com.allog.dallog.domain.member.domain.Member;
 import com.allog.dallog.domain.member.dto.MemberResponse;
+import java.lang.reflect.Field;
 import java.time.LocalDateTime;
 
 public class CategoryFixtures {
@@ -87,5 +88,16 @@ public class CategoryFixtures {
 
     public static CategoryResponse 후디_JPA_스터디_응답(final MemberResponse creatorResponse) {
         return new CategoryResponse(5L, 후디_JPA_스터디_이름, NORMAL.name(), creatorResponse, LocalDateTime.now());
+    }
+
+    public static Category setId(final Category category, final Long id) {
+        try {
+            Field idField = Category.class.getDeclaredField("id");
+            idField.setAccessible(true);
+            idField.set(category, id);
+            return category;
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            throw new IllegalArgumentException(e.getMessage());
+        }
     }
 }

--- a/backend/src/test/java/com/allog/dallog/common/fixtures/IntegrationScheduleFixtures.java
+++ b/backend/src/test/java/com/allog/dallog/common/fixtures/IntegrationScheduleFixtures.java
@@ -1,6 +1,8 @@
 package com.allog.dallog.common.fixtures;
 
-import com.allog.dallog.domain.category.domain.CategoryType;
+import static com.allog.dallog.domain.category.domain.CategoryType.GOOGLE;
+import static com.allog.dallog.domain.category.domain.CategoryType.NORMAL;
+
 import com.allog.dallog.domain.integrationschedule.domain.IntegrationSchedule;
 import com.allog.dallog.domain.integrationschedule.domain.Period;
 import java.time.LocalDateTime;
@@ -8,18 +10,16 @@ import java.time.LocalDateTime;
 public class IntegrationScheduleFixtures {
 
     public static final IntegrationSchedule 점심_식사 = new IntegrationSchedule("1", 2L, "점심 식사",
-            new Period(LocalDateTime.of(2022, 8, 16, 11, 00), LocalDateTime.of(2022, 8, 16, 13, 00)), "",
-            CategoryType.NORMAL.name());
+            new Period(LocalDateTime.of(2022, 8, 16, 11, 00), LocalDateTime.of(2022, 8, 16, 13, 00)), "", NORMAL);
 
     public static final IntegrationSchedule 달록_여행 = new IntegrationSchedule("2", 2L, "달록 여행",
-            new Period(LocalDateTime.of(2022, 8, 24, 00, 00), LocalDateTime.of(2022, 8, 25, 23, 59)), "",
-            CategoryType.NORMAL.name());
+            new Period(LocalDateTime.of(2022, 8, 24, 00, 00), LocalDateTime.of(2022, 8, 25, 23, 59)), "", NORMAL);
 
     public static final IntegrationSchedule 레벨3_방학 = new IntegrationSchedule("gsgadfgqwrtqwerfgasdasdasd", 1L,
             "레벨3 방학", new Period(LocalDateTime.of(2022, 8, 20, 00, 00), LocalDateTime.of(2022, 8, 20, 00, 00)), "",
-            CategoryType.GOOGLE.name());
+            GOOGLE);
 
     public static final IntegrationSchedule 포수타 = new IntegrationSchedule("asgasgasfgadfgdf", 1L,
             "포수타", new Period(LocalDateTime.of(2022, 8, 12, 14, 00), LocalDateTime.of(2022, 8, 12, 14, 30)), "",
-            CategoryType.GOOGLE.name());
+            GOOGLE);
 }

--- a/backend/src/test/java/com/allog/dallog/domain/category/domain/ExternalCategoryDetailRepositoryTest.java
+++ b/backend/src/test/java/com/allog/dallog/domain/category/domain/ExternalCategoryDetailRepositoryTest.java
@@ -1,0 +1,79 @@
+package com.allog.dallog.domain.category.domain;
+
+import static com.allog.dallog.common.fixtures.CategoryFixtures.우아한테크코스_일정;
+import static com.allog.dallog.common.fixtures.MemberFixtures.관리자;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import com.allog.dallog.common.annotation.RepositoryTest;
+import com.allog.dallog.domain.category.exception.ExistExternalCategoryException;
+import com.allog.dallog.domain.category.exception.NoSuchExternalCategoryDetailException;
+import com.allog.dallog.domain.member.domain.Member;
+import com.allog.dallog.domain.member.domain.MemberRepository;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class ExternalCategoryDetailRepositoryTest extends RepositoryTest {
+
+    @Autowired
+    private ExternalCategoryDetailRepository externalCategoryDetailRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private CategoryRepository categoryRepository;
+
+    @DisplayName("존재하지 않는 외부 카테고리 세부정보를 가져오는 경우 예외를 던진다.")
+    @Test
+    void 존재하지_않는_외부_카테고리_세부정보를_가져오는_경우_예외를_던진다() {
+        // given
+        Member 관리자 = memberRepository.save(관리자());
+
+        Category 우아한테크코스_일정 = 우아한테크코스_일정(관리자);
+        categoryRepository.save(우아한테크코스_일정);
+
+        externalCategoryDetailRepository.save(new ExternalCategoryDetail(우아한테크코스_일정, "externalId"));
+
+        // when & then
+        assertThatThrownBy(() -> externalCategoryDetailRepository.getByCategoryId(0L))
+                .isInstanceOf(NoSuchExternalCategoryDetailException.class);
+    }
+
+    @DisplayName("새로운 외부 카테고리 세부정보인 경우 예외를 던지지 않는다.")
+    @Test
+    void 새로운_외부_카테고리_세부정보인_경우_예외를_던지지_않는다() {
+        // given
+        Member 관리자 = memberRepository.save(관리자());
+
+        Category 우아한테크코스_일정 = 우아한테크코스_일정(관리자);
+        categoryRepository.save(우아한테크코스_일정);
+
+        String externalId = "externalId";
+        externalCategoryDetailRepository.save(new ExternalCategoryDetail(우아한테크코스_일정, externalId));
+
+        // when & then
+        assertDoesNotThrow(() -> externalCategoryDetailRepository
+                .validateExistByExternalIdAndCategoryIn(externalId, List.of()));
+    }
+
+    @DisplayName("이미 존재하는 외부 카테고리 세부정보인 경우 예외를 던진다.")
+    @Test
+    void 이미_존재하는_외부_카테고리_세부정보인_경우_예외를_던진다() {
+        // given
+        Member 관리자 = memberRepository.save(관리자());
+
+        Category 우아한테크코스_일정 = 우아한테크코스_일정(관리자);
+        categoryRepository.save(우아한테크코스_일정);
+
+        String externalId = "externalId";
+        externalCategoryDetailRepository.save(new ExternalCategoryDetail(우아한테크코스_일정, externalId));
+
+        // when & then
+        assertThatThrownBy(() -> externalCategoryDetailRepository
+                .validateExistByExternalIdAndCategoryIn(externalId, List.of(우아한테크코스_일정)))
+                .isInstanceOf(ExistExternalCategoryException.class);
+    }
+}

--- a/backend/src/test/java/com/allog/dallog/domain/composition/application/CalendarServiceTest.java
+++ b/backend/src/test/java/com/allog/dallog/domain/composition/application/CalendarServiceTest.java
@@ -175,7 +175,7 @@ class CalendarServiceTest extends ServiceTest {
         subscriptionService.save(리버_id, FE_일정.getId());
 
         // when
-        List<IntegrationSchedule> actual = calendarService.getSchedulesOfSubscriberIds(
+        List<IntegrationSchedule> actual = calendarService.getSchedulesBySubscriberIds(
                 List.of(후디_id, 파랑_id, 매트_id, 리버_id), new DateRangeRequest("2022-07-07T16:00", "2022-08-15T14:00"));
 
         // then

--- a/backend/src/test/java/com/allog/dallog/domain/composition/application/CategorySubscriptionServiceTest.java
+++ b/backend/src/test/java/com/allog/dallog/domain/composition/application/CategorySubscriptionServiceTest.java
@@ -6,8 +6,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.allog.dallog.common.annotation.ServiceTest;
 import com.allog.dallog.common.fixtures.AuthFixtures;
-import com.allog.dallog.domain.subscription.application.SubscriptionService;
 import com.allog.dallog.domain.subscription.domain.Subscription;
+import com.allog.dallog.domain.subscription.domain.SubscriptionRepository;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -19,7 +19,7 @@ class CategorySubscriptionServiceTest extends ServiceTest {
     private CategorySubscriptionService categorySubscriptionService;
 
     @Autowired
-    private SubscriptionService subscriptionService;
+    private SubscriptionRepository subscriptionRepository;
 
     @DisplayName("카테고리 생성 시 자동으로 구독한다.")
     @Test
@@ -30,7 +30,7 @@ class CategorySubscriptionServiceTest extends ServiceTest {
         // when
         categorySubscriptionService.save(파랑_id, 공통_일정_생성_요청);
 
-        List<Subscription> subscriptions = subscriptionService.getAllByMemberId(파랑_id);
+        List<Subscription> subscriptions = subscriptionRepository.findByMemberId(파랑_id);
 
         // then
         assertThat(subscriptions).hasSize(2);
@@ -45,7 +45,7 @@ class CategorySubscriptionServiceTest extends ServiceTest {
         // when
         categorySubscriptionService.save(파랑_id, 대한민국_공휴일_생성_요청);
 
-        List<Subscription> subscriptions = subscriptionService.getAllByMemberId(파랑_id);
+        List<Subscription> subscriptions = subscriptionRepository.findByMemberId(파랑_id);
 
         // then
         assertThat(subscriptions).hasSize(2);

--- a/backend/src/test/java/com/allog/dallog/domain/integrationschedule/domain/IntegrationScheduleTest.java
+++ b/backend/src/test/java/com/allog/dallog/domain/integrationschedule/domain/IntegrationScheduleTest.java
@@ -4,10 +4,10 @@ import static com.allog.dallog.common.fixtures.ScheduleFixtures.알록달록_회
 import static com.allog.dallog.common.fixtures.ScheduleFixtures.알록달록_회의_시작일시;
 import static com.allog.dallog.common.fixtures.ScheduleFixtures.알록달록_회의_제목;
 import static com.allog.dallog.common.fixtures.ScheduleFixtures.알록달록_회의_종료일시;
+import static com.allog.dallog.domain.category.domain.CategoryType.NORMAL;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
-import com.allog.dallog.domain.category.domain.CategoryType;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -24,7 +24,7 @@ class IntegrationScheduleTest {
         // when & then
         assertDoesNotThrow(
                 () -> new IntegrationSchedule(id, categoryId, 알록달록_회의_제목, 알록달록_회의_시작일시, 알록달록_회의_종료일시, 알록달록_회의_메모,
-                        CategoryType.NORMAL.name()));
+                        NORMAL));
     }
 
     @DisplayName("LongTerm인지 확인 할 떄, 일정의 시작일시와 종료일시가 다르면 true를 반환한다.")
@@ -35,7 +35,7 @@ class IntegrationScheduleTest {
         Long categoryId = 1L;
         IntegrationSchedule integrationSchedule = new IntegrationSchedule(id, categoryId, 알록달록_회의_제목,
                 LocalDateTime.of(2022, 7, 1, 0, 1),
-                LocalDateTime.of(2022, 7, 2, 0, 0), 알록달록_회의_메모, CategoryType.NORMAL.name());
+                LocalDateTime.of(2022, 7, 2, 0, 0), 알록달록_회의_메모, NORMAL);
 
         // when
         boolean actual = integrationSchedule.isLongTerms();
@@ -52,7 +52,7 @@ class IntegrationScheduleTest {
         Long categoryId = 1L;
         IntegrationSchedule integrationSchedule = new IntegrationSchedule(id, categoryId, 알록달록_회의_제목,
                 LocalDateTime.of(2022, 7, 1, 0, 1),
-                LocalDateTime.of(2022, 7, 1, 23, 59), 알록달록_회의_메모, CategoryType.NORMAL.name());
+                LocalDateTime.of(2022, 7, 1, 23, 59), 알록달록_회의_메모, NORMAL);
 
         // when
         boolean actual = integrationSchedule.isLongTerms();
@@ -69,7 +69,7 @@ class IntegrationScheduleTest {
         Long categoryId = 1L;
         IntegrationSchedule integrationSchedule = new IntegrationSchedule(id, categoryId, 알록달록_회의_제목,
                 LocalDateTime.of(2022, 7, 1, 0, 0),
-                LocalDateTime.of(2022, 7, 1, 23, 59), 알록달록_회의_메모, CategoryType.NORMAL.name());
+                LocalDateTime.of(2022, 7, 1, 23, 59), 알록달록_회의_메모, NORMAL);
 
         // when
         boolean actual = integrationSchedule.isAllDays();
@@ -86,7 +86,7 @@ class IntegrationScheduleTest {
         Long categoryId = 1L;
         IntegrationSchedule integrationSchedule = new IntegrationSchedule(id, categoryId, 알록달록_회의_제목,
                 LocalDateTime.of(2022, 7, 1, 0, 0),
-                LocalDateTime.of(2022, 7, 1, 11, 58), 알록달록_회의_메모, CategoryType.NORMAL.name());
+                LocalDateTime.of(2022, 7, 1, 11, 58), 알록달록_회의_메모, NORMAL);
 
         // when
         boolean actual = integrationSchedule.isAllDays();
@@ -103,7 +103,7 @@ class IntegrationScheduleTest {
         Long categoryId = 1L;
         IntegrationSchedule integrationSchedule = new IntegrationSchedule(id, categoryId, 알록달록_회의_제목,
                 LocalDateTime.of(2022, 7, 1, 0, 0),
-                LocalDateTime.of(2022, 7, 1, 11, 58), 알록달록_회의_메모, CategoryType.NORMAL.name());
+                LocalDateTime.of(2022, 7, 1, 11, 58), 알록달록_회의_메모, NORMAL);
 
         // when
         boolean actual = integrationSchedule.isFewHours();
@@ -120,7 +120,7 @@ class IntegrationScheduleTest {
         Long categoryId = 1L;
         IntegrationSchedule integrationSchedule = new IntegrationSchedule(id, categoryId, 알록달록_회의_제목,
                 LocalDateTime.of(2022, 7, 1, 0, 0),
-                LocalDateTime.of(2022, 7, 1, 23, 59), 알록달록_회의_메모, CategoryType.NORMAL.name());
+                LocalDateTime.of(2022, 7, 1, 23, 59), 알록달록_회의_메모, NORMAL);
 
         // when
         boolean actual = integrationSchedule.isFewHours();

--- a/backend/src/test/java/com/allog/dallog/domain/integrationschedule/domain/IntegrationSchedulesTest.java
+++ b/backend/src/test/java/com/allog/dallog/domain/integrationschedule/domain/IntegrationSchedulesTest.java
@@ -1,8 +1,8 @@
 package com.allog.dallog.domain.integrationschedule.domain;
 
+import static com.allog.dallog.domain.category.domain.CategoryType.NORMAL;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.allog.dallog.domain.category.domain.CategoryType;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -16,15 +16,15 @@ class IntegrationSchedulesTest {
         Long categoryId = 1L;
         IntegrationSchedule 첫번째로_정렬되어야_하는_일정 = new IntegrationSchedule("1", categoryId, "일정1",
                 LocalDateTime.of(2022, 3, 1, 0, 0),
-                LocalDateTime.of(2022, 3, 2, 0, 0), "일정1", CategoryType.NORMAL.name());
+                LocalDateTime.of(2022, 3, 2, 0, 0), "일정1", NORMAL);
 
         IntegrationSchedule 두번째로_정렬되어야_하는_일정 = new IntegrationSchedule("2", categoryId, "일정2",
                 LocalDateTime.of(2022, 3, 3, 0, 0),
-                LocalDateTime.of(2022, 3, 4, 0, 0), "일정2", CategoryType.NORMAL.name());
+                LocalDateTime.of(2022, 3, 4, 0, 0), "일정2", NORMAL);
 
         IntegrationSchedule 세번째로_정렬되어야_하는_일정 = new IntegrationSchedule("3", categoryId, "일정3",
                 LocalDateTime.of(2022, 3, 5, 0, 0),
-                LocalDateTime.of(2022, 3, 7, 0, 0), "일정3", CategoryType.NORMAL.name());
+                LocalDateTime.of(2022, 3, 7, 0, 0), "일정3", NORMAL);
 
         // when
         IntegrationSchedules integrationSchedules = new IntegrationSchedules();
@@ -45,15 +45,15 @@ class IntegrationSchedulesTest {
         Long categoryId = 1L;
         IntegrationSchedule 첫번째로_정렬되어야_하는_일정 = new IntegrationSchedule("1", categoryId, "일정1",
                 LocalDateTime.of(2022, 3, 1, 0, 0),
-                LocalDateTime.of(2022, 3, 10, 0, 0), "일정1", CategoryType.NORMAL.name());
+                LocalDateTime.of(2022, 3, 10, 0, 0), "일정1", NORMAL);
 
         IntegrationSchedule 두번째로_정렬되어야_하는_일정 = new IntegrationSchedule("2", categoryId, "일정2",
                 LocalDateTime.of(2022, 3, 1, 0, 0),
-                LocalDateTime.of(2022, 3, 7, 0, 0), "일정2", CategoryType.NORMAL.name());
+                LocalDateTime.of(2022, 3, 7, 0, 0), "일정2", NORMAL);
 
         IntegrationSchedule 세번째로_정렬되어야_하는_일정 = new IntegrationSchedule("3", categoryId, "일정3",
                 LocalDateTime.of(2022, 3, 5, 0, 0),
-                LocalDateTime.of(2022, 3, 5, 0, 0), "일정3", CategoryType.NORMAL.name());
+                LocalDateTime.of(2022, 3, 5, 0, 0), "일정3", NORMAL);
 
         // when
         IntegrationSchedules integrationSchedules = new IntegrationSchedules();
@@ -74,15 +74,15 @@ class IntegrationSchedulesTest {
         Long categoryId = 1L;
         IntegrationSchedule 첫번째로_정렬되어야_하는_일정 = new IntegrationSchedule("1", categoryId, "가",
                 LocalDateTime.of(2022, 3, 1, 0, 0),
-                LocalDateTime.of(2022, 3, 10, 0, 0), "일정1", CategoryType.NORMAL.name());
+                LocalDateTime.of(2022, 3, 10, 0, 0), "일정1", NORMAL);
 
         IntegrationSchedule 두번째로_정렬되어야_하는_일정 = new IntegrationSchedule("2", categoryId, "나",
                 LocalDateTime.of(2022, 3, 1, 0, 0),
-                LocalDateTime.of(2022, 3, 10, 0, 0), "일정2", CategoryType.NORMAL.name());
+                LocalDateTime.of(2022, 3, 10, 0, 0), "일정2", NORMAL);
 
         IntegrationSchedule 세번째로_정렬되어야_하는_일정 = new IntegrationSchedule("3", categoryId, "다",
                 LocalDateTime.of(2022, 3, 1, 0, 0),
-                LocalDateTime.of(2022, 3, 10, 0, 0), "일정3", CategoryType.NORMAL.name());
+                LocalDateTime.of(2022, 3, 10, 0, 0), "일정3", NORMAL);
 
         // when
         IntegrationSchedules integrationSchedules = new IntegrationSchedules();

--- a/backend/src/test/java/com/allog/dallog/domain/schedule/domain/scheduler/SchedulerTest.java
+++ b/backend/src/test/java/com/allog/dallog/domain/schedule/domain/scheduler/SchedulerTest.java
@@ -17,6 +17,7 @@ import static com.allog.dallog.common.fixtures.ScheduleFixtures.날짜_2022년_7
 import static com.allog.dallog.common.fixtures.ScheduleFixtures.날짜_2022년_7월_31일_0시_0분;
 import static com.allog.dallog.common.fixtures.ScheduleFixtures.날짜_2022년_7월_7일_16시_0분;
 import static com.allog.dallog.common.fixtures.ScheduleFixtures.날짜_2022년_8월_15일_14시_0분;
+import static com.allog.dallog.domain.category.domain.CategoryType.NORMAL;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
@@ -40,21 +41,21 @@ class SchedulerTest {
         String 일정_메모 = "일정 메모";
 
         IntegrationSchedule 일정1 = new IntegrationSchedule("1", 공통_일정.getId(), 일정_제목, 날짜_2022년_7월_7일_16시_0분,
-                날짜_2022년_7월_10일_0시_0분, 일정_메모, "NORMAL");
+                날짜_2022년_7월_10일_0시_0분, 일정_메모, NORMAL);
         IntegrationSchedule 일정2 = new IntegrationSchedule("2", 공통_일정.getId(), 일정_제목, 날짜_2022년_7월_10일_11시_59분,
-                날짜_2022년_7월_15일_16시_0분, 일정_메모, "NORMAL");
+                날짜_2022년_7월_15일_16시_0분, 일정_메모, NORMAL);
         IntegrationSchedule 일정3 = new IntegrationSchedule("3", 공통_일정.getId(), 일정_제목, 날짜_2022년_7월_16일_16시_0분,
-                날짜_2022년_7월_16일_16시_1분, 일정_메모, "NORMAL");
+                날짜_2022년_7월_16일_16시_1분, 일정_메모, NORMAL);
         IntegrationSchedule 일정4 = new IntegrationSchedule("4", 공통_일정.getId(), 일정_제목, 날짜_2022년_7월_16일_18시_0분,
-                날짜_2022년_7월_16일_20시_0분, 일정_메모, "NORMAL");
+                날짜_2022년_7월_16일_20시_0분, 일정_메모, NORMAL);
         IntegrationSchedule 일정5 = new IntegrationSchedule("5", 공통_일정.getId(), 일정_제목, 날짜_2022년_7월_16일_20시_0분,
-                날짜_2022년_7월_20일_0시_0분, 일정_메모, "NORMAL");
+                날짜_2022년_7월_20일_0시_0분, 일정_메모, NORMAL);
         IntegrationSchedule 일정6 = new IntegrationSchedule("6", 공통_일정.getId(), 일정_제목, 날짜_2022년_7월_20일_11시_59분,
-                날짜_2022년_7월_27일_0시_0분, 일정_메모, "NORMAL");
+                날짜_2022년_7월_27일_0시_0분, 일정_메모, NORMAL);
         IntegrationSchedule 일정7 = new IntegrationSchedule("7", 공통_일정.getId(), 일정_제목, 날짜_2022년_7월_27일_11시_59분,
-                날짜_2022년_7월_31일_0시_0분, 일정_메모, "NORMAL");
+                날짜_2022년_7월_31일_0시_0분, 일정_메모, NORMAL);
         IntegrationSchedule 일정8 = new IntegrationSchedule("8", 공통_일정.getId(), 일정_제목, 날짜_2022년_7월_31일_0시_0분,
-                날짜_2022년_8월_15일_14시_0분, 일정_메모, "NORMAL");
+                날짜_2022년_8월_15일_14시_0분, 일정_메모, NORMAL);
 
         List<IntegrationSchedule> 일정_목록 = List.of(일정1, 일정2, 일정3, 일정4, 일정5, 일정6, 일정7, 일정8);
 

--- a/backend/src/test/java/com/allog/dallog/domain/subscription/domain/SubscriptionsTest.java
+++ b/backend/src/test/java/com/allog/dallog/domain/subscription/domain/SubscriptionsTest.java
@@ -5,14 +5,17 @@ import static com.allog.dallog.common.fixtures.CategoryFixtures.setId;
 import static com.allog.dallog.common.fixtures.CategoryFixtures.공통_일정;
 import static com.allog.dallog.common.fixtures.CategoryFixtures.내_일정;
 import static com.allog.dallog.common.fixtures.CategoryFixtures.우아한테크코스_일정;
+import static com.allog.dallog.common.fixtures.IntegrationScheduleFixtures.달록_여행;
 import static com.allog.dallog.common.fixtures.MemberFixtures.파랑;
 import static com.allog.dallog.domain.subscription.domain.Color.COLOR_1;
 import static com.allog.dallog.domain.subscription.domain.Color.COLOR_2;
 import static com.allog.dallog.domain.subscription.domain.Color.COLOR_3;
 import static com.allog.dallog.domain.subscription.domain.Color.COLOR_4;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.allog.dallog.domain.category.domain.Category;
+import com.allog.dallog.domain.category.exception.NoSuchCategoryException;
 import com.allog.dallog.domain.member.domain.Member;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -64,5 +67,43 @@ class SubscriptionsTest {
 
         // when & then
         assertThat(subscriptions.findCheckedCategoryIdsBy(Category::isExternal)).isEqualTo(List.of(4L));
+    }
+
+    @DisplayName("특정 스케줄의 구독 색상을 찾는다.")
+    @Test
+    void 특정_스케줄의_구독_색상을_찾는다() {
+        // given
+        Member 파랑 = 파랑();
+        Category 공통_일정 = setId(공통_일정(파랑), 1L);
+        Category BE_일정 = setId(BE_일정(파랑), 2L);
+        Category 내_일정 = setId(내_일정(파랑), 3L);
+        Category 우아한테크코스_일정 = setId(우아한테크코스_일정(파랑), 4L);
+
+        Subscription 공통_일정_구독 = new Subscription(파랑, 공통_일정, COLOR_1);
+        Subscription BE_일정_구독 = new Subscription(파랑, BE_일정, COLOR_2);
+        Subscription 내_일정_구독 = new Subscription(파랑, 내_일정, COLOR_3);
+        Subscription 우아한테크코스_일정_구독 = new Subscription(파랑, 우아한테크코스_일정, COLOR_4);
+
+        Subscriptions subscriptions =
+                new Subscriptions(List.of(공통_일정_구독, BE_일정_구독, 내_일정_구독, 우아한테크코스_일정_구독));
+
+        // when & then
+        assertThat(subscriptions.findColor(달록_여행)).isEqualTo(COLOR_2);
+    }
+
+    @DisplayName("구독하지 않은 스케줄의 구독 색상을 찾는 경우 예외를 던진다")
+    @Test
+    void 구독하지_않은_스케줄의_구독_색상을_찾는_경우_예외를_던진다() {
+        // given
+        Member 파랑 = 파랑();
+        Category 공통_일정 = setId(공통_일정(파랑), 1L);
+        setId(BE_일정(파랑), 2L);
+
+        Subscription 공통_일정_구독 = new Subscription(파랑, 공통_일정, COLOR_1);
+
+        Subscriptions subscriptions = new Subscriptions(List.of(공통_일정_구독));
+
+        // when & then
+        assertThatThrownBy(() -> subscriptions.findColor(달록_여행)).isInstanceOf(NoSuchCategoryException.class);
     }
 }

--- a/backend/src/test/java/com/allog/dallog/domain/subscription/domain/SubscriptionsTest.java
+++ b/backend/src/test/java/com/allog/dallog/domain/subscription/domain/SubscriptionsTest.java
@@ -1,0 +1,68 @@
+package com.allog.dallog.domain.subscription.domain;
+
+import static com.allog.dallog.common.fixtures.CategoryFixtures.BE_일정;
+import static com.allog.dallog.common.fixtures.CategoryFixtures.setId;
+import static com.allog.dallog.common.fixtures.CategoryFixtures.공통_일정;
+import static com.allog.dallog.common.fixtures.CategoryFixtures.내_일정;
+import static com.allog.dallog.common.fixtures.CategoryFixtures.우아한테크코스_일정;
+import static com.allog.dallog.common.fixtures.MemberFixtures.파랑;
+import static com.allog.dallog.domain.subscription.domain.Color.COLOR_1;
+import static com.allog.dallog.domain.subscription.domain.Color.COLOR_2;
+import static com.allog.dallog.domain.subscription.domain.Color.COLOR_3;
+import static com.allog.dallog.domain.subscription.domain.Color.COLOR_4;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.allog.dallog.domain.category.domain.Category;
+import com.allog.dallog.domain.member.domain.Member;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class SubscriptionsTest {
+
+    @DisplayName("체크된 카테고리 중 내부 카테고리의 아이디를 찾는다.")
+    @Test
+    void 체크된_카테고리_중_내부_카테고리의_아이디를_찾는다() {
+        // given
+        Member 파랑 = 파랑();
+        Category 공통_일정 = setId(공통_일정(파랑), 1L);
+        Category BE_일정 = setId(BE_일정(파랑), 2L);
+        Category 내_일정 = setId(내_일정(파랑), 3L);
+        Category 우아한테크코스_일정 = setId(우아한테크코스_일정(파랑), 4L);
+
+        Subscription 공통_일정_구독 = new Subscription(파랑, 공통_일정, COLOR_1);
+        Subscription BE_일정_구독 = new Subscription(파랑, BE_일정, COLOR_2);
+        Subscription 내_일정_구독 = new Subscription(파랑, 내_일정, COLOR_3);
+        Subscription 우아한테크코스_일정_구독 = new Subscription(파랑, 우아한테크코스_일정, COLOR_4);
+
+        BE_일정_구독.change(COLOR_2, false);
+
+        Subscriptions subscriptions =
+                new Subscriptions(List.of(공통_일정_구독, BE_일정_구독, 내_일정_구독, 우아한테크코스_일정_구독));
+
+        // when & then
+        assertThat(subscriptions.findCheckedCategoryIdsBy(Category::isInternal)).isEqualTo(List.of(1L, 3L));
+    }
+
+    @DisplayName("체크된 카테고리 중 외부 카테고리의 아이디를 찾는다.")
+    @Test
+    void 체크된_카테고리_중_외부_카테고리의_아이디를_찾는다() {
+        // given
+        Member 파랑 = 파랑();
+        Category 공통_일정 = setId(공통_일정(파랑), 1L);
+        Category BE_일정 = setId(BE_일정(파랑), 2L);
+        Category 내_일정 = setId(내_일정(파랑), 3L);
+        Category 우아한테크코스_일정 = setId(우아한테크코스_일정(파랑), 4L);
+
+        Subscription 공통_일정_구독 = new Subscription(파랑, 공통_일정, COLOR_1);
+        Subscription BE_일정_구독 = new Subscription(파랑, BE_일정, COLOR_2);
+        Subscription 내_일정_구독 = new Subscription(파랑, 내_일정, COLOR_3);
+        Subscription 우아한테크코스_일정_구독 = new Subscription(파랑, 우아한테크코스_일정, COLOR_4);
+
+        Subscriptions subscriptions =
+                new Subscriptions(List.of(공통_일정_구독, BE_일정_구독, 내_일정_구독, 우아한테크코스_일정_구독));
+
+        // when & then
+        assertThat(subscriptions.findCheckedCategoryIdsBy(Category::isExternal)).isEqualTo(List.of(4L));
+    }
+}

--- a/backend/src/test/java/com/allog/dallog/infrastructure/oauth/client/StubOAuthClient.java
+++ b/backend/src/test/java/com/allog/dallog/infrastructure/oauth/client/StubOAuthClient.java
@@ -1,9 +1,6 @@
 package com.allog.dallog.infrastructure.oauth.client;
 
 import static com.allog.dallog.common.fixtures.AuthFixtures.STUB_OAUTH_ACCESS_TOKEN;
-import static com.allog.dallog.common.fixtures.AuthFixtures.STUB_OAUTH_EXPIRES_IN;
-import static com.allog.dallog.common.fixtures.AuthFixtures.STUB_OAUTH_SCOPE;
-import static com.allog.dallog.common.fixtures.AuthFixtures.STUB_OAUTH_TOKEN_TYPE;
 
 import com.allog.dallog.common.fixtures.OAuthFixtures;
 import com.allog.dallog.domain.auth.application.OAuthClient;
@@ -19,7 +16,6 @@ public class StubOAuthClient implements OAuthClient {
 
     @Override
     public OAuthAccessTokenResponse getAccessToken(final String refreshToken) {
-        return new OAuthAccessTokenResponse(STUB_OAUTH_ACCESS_TOKEN, STUB_OAUTH_EXPIRES_IN, STUB_OAUTH_SCOPE,
-                STUB_OAUTH_TOKEN_TYPE);
+        return new OAuthAccessTokenResponse(STUB_OAUTH_ACCESS_TOKEN);
     }
 }


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 💻 git rebase를 사용했나요?
- [x] 🌈 알록달록한가요?

## 작업 내용

- `CalendarService`, `MemberScheduleResponse`, `IntegrationSchedule`, `IntegrationScheduleComparator` 등 내부-외부 스케줄 관련 코드들을 리팩토링 하였습니다.
- `Subscriptions` 일급 컬렉션을 만들어 로직을 분리하였습니다.
- `CalendarService`에서 Service에 대한 의존성을 Repository를 의존하도록 변경했습니다.

Closes #564 
