### PR TITLE
[refactor] CalenderService에서 월별 일정 조회 로직을 제거한다.

### DIFF
--- a/backend/src/main/java/com/allog/dallog/domain/category/application/ExternalCategoryDetailService.java
+++ b/backend/src/main/java/com/allog/dallog/domain/category/application/ExternalCategoryDetailService.java
@@ -1,0 +1,30 @@
+package com.allog.dallog.domain.category.application;
+
+import com.allog.dallog.domain.category.domain.Category;
+import com.allog.dallog.domain.category.domain.ExternalCategoryDetail;
+import com.allog.dallog.domain.category.domain.ExternalCategoryDetailRepository;
+import com.allog.dallog.domain.subscription.domain.SubscriptionRepository;
+import com.allog.dallog.domain.subscription.domain.Subscriptions;
+import java.util.List;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional(readOnly = true)
+@Service
+public class ExternalCategoryDetailService {
+
+    private final ExternalCategoryDetailRepository externalCategoryDetailRepository;
+    private final SubscriptionRepository subscriptionRepository;
+
+    public ExternalCategoryDetailService(final ExternalCategoryDetailRepository externalCategoryDetailRepository,
+                                         final SubscriptionRepository subscriptionRepository) {
+        this.externalCategoryDetailRepository = externalCategoryDetailRepository;
+        this.subscriptionRepository = subscriptionRepository;
+    }
+
+    public List<ExternalCategoryDetail> findByMemberId(final Long memberId) {
+        Subscriptions subscriptions = new Subscriptions(subscriptionRepository.findByMemberId(memberId));
+        List<Category> categories = subscriptions.findExternalCategory();
+        return externalCategoryDetailRepository.findByCategoryIn(categories);
+    }
+}

--- a/backend/src/main/java/com/allog/dallog/domain/category/domain/ExternalCategoryDetailRepository.java
+++ b/backend/src/main/java/com/allog/dallog/domain/category/domain/ExternalCategoryDetailRepository.java
@@ -1,25 +1,28 @@
 package com.allog.dallog.domain.category.domain;
 
-import com.allog.dallog.domain.category.exception.NoSuchExternalCategoryDetailException;
 import com.allog.dallog.domain.category.exception.ExistExternalCategoryException;
+import com.allog.dallog.domain.category.exception.NoSuchExternalCategoryDetailException;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ExternalCategoryDetailRepository extends JpaRepository<ExternalCategoryDetail, Long> {
 
-    Optional<ExternalCategoryDetail> findByCategoryId(final Long categoryId);
+    Optional<ExternalCategoryDetail> findByCategory(final Category category);
+
+    List<ExternalCategoryDetail> findByCategoryIn(final List<Category> categories);
 
     boolean existsByExternalIdAndCategoryIn(final String externalId, final List<Category> categories);
 
     void deleteByCategoryId(final Long categoryId);
 
-    default ExternalCategoryDetail getByCategoryId(final Long categoryId) {
-        return this.findByCategoryId(categoryId)
+    default ExternalCategoryDetail getByCategory(final Category category) {
+        return this.findByCategory(category)
                 .orElseThrow(NoSuchExternalCategoryDetailException::new);
     }
 
-    default void validateExistByExternalIdAndCategoryIn(final String externalId, final List<Category> externalCategories) {
+    default void validateExistByExternalIdAndCategoryIn(final String externalId,
+                                                        final List<Category> externalCategories) {
         if (existsByExternalIdAndCategoryIn(externalId, externalCategories)) {
             throw new ExistExternalCategoryException();
         }

--- a/backend/src/main/java/com/allog/dallog/domain/composition/application/CalendarService.java
+++ b/backend/src/main/java/com/allog/dallog/domain/composition/application/CalendarService.java
@@ -5,9 +5,8 @@ import com.allog.dallog.domain.auth.domain.OAuthTokenRepository;
 import com.allog.dallog.domain.category.domain.ExternalCategoryDetail;
 import com.allog.dallog.domain.category.domain.ExternalCategoryDetailRepository;
 import com.allog.dallog.domain.externalcalendar.application.ExternalCalendarClient;
-import com.allog.dallog.domain.integrationschedule.dao.IntegrationScheduleDao;
-import com.allog.dallog.domain.integrationschedule.domain.IntegrationSchedule;
 import com.allog.dallog.domain.schedule.application.ScheduleService;
+import com.allog.dallog.domain.integrationschedule.domain.IntegrationSchedule;
 import com.allog.dallog.domain.schedule.dto.request.DateRangeRequest;
 import com.allog.dallog.domain.subscription.domain.SubscriptionRepository;
 import com.allog.dallog.domain.subscription.domain.Subscriptions;
@@ -25,7 +24,6 @@ public class CalendarService {
 
     private static final String DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss";
 
-    private final IntegrationScheduleDao integrationScheduleDao;
     private final ScheduleService scheduleService;
     private final SubscriptionRepository subscriptionRepository;
     private final ExternalCategoryDetailRepository externalCategoryDetailRepository;
@@ -33,12 +31,11 @@ public class CalendarService {
     private final OAuthClient oAuthClient;
     private final ExternalCalendarClient externalCalendarClient;
 
-    public CalendarService(final IntegrationScheduleDao integrationScheduleDao, final ScheduleService scheduleService,
+    public CalendarService(final ScheduleService scheduleService,
                            final SubscriptionRepository subscriptionRepository,
                            final ExternalCategoryDetailRepository externalCategoryDetailRepository,
                            final OAuthTokenRepository oAuthTokenRepository, final OAuthClient oAuthClient,
                            final ExternalCalendarClient externalCalendarClient) {
-        this.integrationScheduleDao = integrationScheduleDao;
         this.scheduleService = scheduleService;
         this.subscriptionRepository = subscriptionRepository;
         this.externalCategoryDetailRepository = externalCategoryDetailRepository;

--- a/backend/src/main/java/com/allog/dallog/domain/integrationschedule/domain/IntegrationSchedule.java
+++ b/backend/src/main/java/com/allog/dallog/domain/integrationschedule/domain/IntegrationSchedule.java
@@ -2,6 +2,7 @@ package com.allog.dallog.domain.integrationschedule.domain;
 
 import com.allog.dallog.domain.category.domain.Category;
 import com.allog.dallog.domain.category.domain.CategoryType;
+import com.allog.dallog.domain.schedule.domain.Schedule;
 import com.allog.dallog.domain.subscription.domain.Subscription;
 import java.time.LocalDateTime;
 import java.util.Objects;
@@ -18,6 +19,15 @@ public class IntegrationSchedule {
     private final Period period;
     private final String memo;
     private final CategoryType categoryType;
+
+    public IntegrationSchedule(final Schedule schedule, final CategoryType categoryType) {
+        this.id = String.valueOf(schedule.getId());
+        this.categoryId = schedule.getCategory().getId();
+        this.title = schedule.getTitle();
+        this.period = new Period(schedule.getStartDateTime(), schedule.getEndDateTime());
+        this.memo = schedule.getMemo();
+        this.categoryType = categoryType;
+    }
 
     public IntegrationSchedule(final String id, final Long categoryId, final String title,
                                final LocalDateTime startDateTime, final LocalDateTime endDateTime, final String memo,

--- a/backend/src/main/java/com/allog/dallog/domain/schedule/application/ScheduleService.java
+++ b/backend/src/main/java/com/allog/dallog/domain/schedule/application/ScheduleService.java
@@ -50,7 +50,7 @@ public class ScheduleService {
         return new ScheduleResponse(schedule);
     }
 
-    public List<IntegrationSchedule> findByMemberIdAndDateRange(final Long memberId, final DateRangeRequest dateRange) {
+    public List<IntegrationSchedule> findInternalByMemberIdAndDateRange(final Long memberId, final DateRangeRequest dateRange) {
         Subscriptions subscriptions = new Subscriptions(subscriptionRepository.findByMemberId(memberId));
         return integrationSchedules(dateRange, subscriptions);
     }

--- a/backend/src/main/java/com/allog/dallog/domain/schedule/application/ScheduleService.java
+++ b/backend/src/main/java/com/allog/dallog/domain/schedule/application/ScheduleService.java
@@ -2,13 +2,19 @@ package com.allog.dallog.domain.schedule.application;
 
 import com.allog.dallog.domain.category.domain.Category;
 import com.allog.dallog.domain.category.domain.CategoryRepository;
+import com.allog.dallog.domain.integrationschedule.domain.IntegrationSchedule;
 import com.allog.dallog.domain.member.domain.Member;
 import com.allog.dallog.domain.member.domain.MemberRepository;
 import com.allog.dallog.domain.schedule.domain.Schedule;
 import com.allog.dallog.domain.schedule.domain.ScheduleRepository;
+import com.allog.dallog.domain.schedule.dto.request.DateRangeRequest;
 import com.allog.dallog.domain.schedule.dto.request.ScheduleCreateRequest;
 import com.allog.dallog.domain.schedule.dto.request.ScheduleUpdateRequest;
 import com.allog.dallog.domain.schedule.dto.response.ScheduleResponse;
+import com.allog.dallog.domain.subscription.domain.SubscriptionRepository;
+import com.allog.dallog.domain.subscription.domain.Subscriptions;
+import java.util.ArrayList;
+import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,12 +25,15 @@ public class ScheduleService {
     private final ScheduleRepository scheduleRepository;
     private final CategoryRepository categoryRepository;
     private final MemberRepository memberRepository;
+    private final SubscriptionRepository subscriptionRepository;
 
     public ScheduleService(final ScheduleRepository scheduleRepository, final CategoryRepository categoryRepository,
-                           final MemberRepository memberRepository) {
+                           final MemberRepository memberRepository,
+                           final SubscriptionRepository subscriptionRepository) {
         this.scheduleRepository = scheduleRepository;
         this.categoryRepository = categoryRepository;
         this.memberRepository = memberRepository;
+        this.subscriptionRepository = subscriptionRepository;
     }
 
     @Transactional
@@ -39,6 +48,24 @@ public class ScheduleService {
     public ScheduleResponse findById(final Long id) {
         Schedule schedule = scheduleRepository.getById(id);
         return new ScheduleResponse(schedule);
+    }
+
+    public List<IntegrationSchedule> findByMemberIdAndDateRange(final Long memberId, final DateRangeRequest dateRange) {
+        Subscriptions subscriptions = new Subscriptions(subscriptionRepository.findByMemberId(memberId));
+        return integrationSchedules(dateRange, subscriptions);
+    }
+
+    private List<IntegrationSchedule> integrationSchedules(final DateRangeRequest dateRange,
+                                                           final Subscriptions subscriptions) {
+        List<IntegrationSchedule> integrationSchedules = new ArrayList<>();
+
+        List<Category> categories = subscriptions.findInternalCategory();
+        for (Category category : categories) {
+            List<IntegrationSchedule> schedules = scheduleRepository.createByCategoryAndBetween(
+                    category, dateRange.getStartDateTime(), dateRange.getEndDateTime());
+            integrationSchedules.addAll(schedules);
+        }
+        return integrationSchedules;
     }
 
     @Transactional

--- a/backend/src/main/java/com/allog/dallog/domain/schedule/application/SubscribingSchedulesFinder.java
+++ b/backend/src/main/java/com/allog/dallog/domain/schedule/application/SubscribingSchedulesFinder.java
@@ -48,7 +48,8 @@ public class SubscribingSchedulesFinder {
         List<IntegrationSchedule> schedules = new ArrayList<>();
 
         List<IntegrationSchedule> externalSchedules = findExternalSchedules(memberId, dateRange);
-        List<IntegrationSchedule> internalSchedules = scheduleService.findByMemberIdAndDateRange(memberId, dateRange);
+        List<IntegrationSchedule> internalSchedules = scheduleService.findInternalByMemberIdAndDateRange(memberId,
+                dateRange);
 
         schedules.addAll(externalSchedules);
         schedules.addAll(internalSchedules);

--- a/backend/src/main/java/com/allog/dallog/domain/schedule/application/SubscribingSchedulesFinder.java
+++ b/backend/src/main/java/com/allog/dallog/domain/schedule/application/SubscribingSchedulesFinder.java
@@ -1,0 +1,95 @@
+package com.allog.dallog.domain.schedule.application;
+
+import com.allog.dallog.domain.auth.application.OAuthClient;
+import com.allog.dallog.domain.auth.domain.OAuthToken;
+import com.allog.dallog.domain.auth.domain.OAuthTokenRepository;
+import com.allog.dallog.domain.auth.dto.response.OAuthAccessTokenResponse;
+import com.allog.dallog.domain.category.application.ExternalCategoryDetailService;
+import com.allog.dallog.domain.category.domain.ExternalCategoryDetail;
+import com.allog.dallog.domain.externalcalendar.application.ExternalCalendarClient;
+import com.allog.dallog.domain.integrationschedule.domain.IntegrationSchedule;
+import com.allog.dallog.domain.integrationschedule.domain.TypedSchedules;
+import com.allog.dallog.domain.schedule.dto.request.DateRangeRequest;
+import com.allog.dallog.domain.schedule.dto.response.MemberScheduleResponses;
+import com.allog.dallog.domain.subscription.domain.SubscriptionRepository;
+import com.allog.dallog.domain.subscription.domain.Subscriptions;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.stereotype.Service;
+
+@Service
+public class SubscribingSchedulesFinder {
+
+    private static final String DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss";
+
+    private final ScheduleService scheduleService;
+    private final SubscriptionRepository subscriptionRepository;
+    private final ExternalCategoryDetailService externalCategoryDetailService;
+    private final ExternalCalendarClient externalCalendarClient;
+    private final OAuthTokenRepository oAuthTokenRepository;
+    private final OAuthClient oAuthClient;
+
+    public SubscribingSchedulesFinder(final ScheduleService scheduleService,
+                                      final SubscriptionRepository subscriptionRepository,
+                                      final ExternalCategoryDetailService externalCategoryDetailService,
+                                      final ExternalCalendarClient externalCalendarClient,
+                                      final OAuthTokenRepository oAuthTokenRepository, final OAuthClient oAuthClient) {
+        this.scheduleService = scheduleService;
+        this.subscriptionRepository = subscriptionRepository;
+        this.externalCategoryDetailService = externalCategoryDetailService;
+        this.externalCalendarClient = externalCalendarClient;
+        this.oAuthTokenRepository = oAuthTokenRepository;
+        this.oAuthClient = oAuthClient;
+    }
+
+    public MemberScheduleResponses findMySubscribingSchedules(final Long memberId, final DateRangeRequest dateRange) {
+        List<IntegrationSchedule> schedules = new ArrayList<>();
+
+        List<IntegrationSchedule> externalSchedules = findExternalSchedules(memberId, dateRange);
+        List<IntegrationSchedule> internalSchedules = scheduleService.findByMemberIdAndDateRange(memberId, dateRange);
+
+        schedules.addAll(externalSchedules);
+        schedules.addAll(internalSchedules);
+
+        Subscriptions subscriptions = new Subscriptions(subscriptionRepository.findByMemberId(memberId));
+        return new MemberScheduleResponses(subscriptions, new TypedSchedules(schedules));
+    }
+
+    private List<IntegrationSchedule> findExternalSchedules(final Long memberId, final DateRangeRequest dateRange) {
+        List<IntegrationSchedule> schedules = new ArrayList<>();
+
+        List<ExternalCategoryDetail> details = externalCategoryDetailService.findByMemberId(memberId);
+        if (details.isEmpty()) {
+            return schedules;
+        }
+
+        String accessToken = getGoogleAccessToken(memberId);
+        for (ExternalCategoryDetail detail : details) {
+            List<IntegrationSchedule> googleSchedules = findGoogleSchedules(dateRange, accessToken, detail);
+            schedules.addAll(googleSchedules);
+        }
+        return schedules;
+    }
+
+    private String getGoogleAccessToken(final Long memberId) {
+        OAuthToken oAuthToken = oAuthTokenRepository.getByMemberId(memberId);
+        String refreshToken = oAuthToken.getRefreshToken();
+
+        OAuthAccessTokenResponse accessTokenResponse = oAuthClient.getAccessToken(refreshToken);
+        return accessTokenResponse.getValue();
+    }
+
+    private List<IntegrationSchedule> findGoogleSchedules(final DateRangeRequest dateRange, final String accessToken,
+                                                          final ExternalCategoryDetail detail) {
+        LocalDateTime startDateTime = dateRange.getStartDateTime();
+        LocalDateTime endDateTime = dateRange.getEndDateTime();
+
+        String startTime = startDateTime.format(DateTimeFormatter.ofPattern(DATE_FORMAT));
+        String endTime = endDateTime.format(DateTimeFormatter.ofPattern(DATE_FORMAT));
+
+        return externalCalendarClient.getExternalCalendarSchedules(
+                accessToken, detail.getCategory().getId(), detail.getExternalId(), startTime, endTime);
+    }
+}

--- a/backend/src/main/java/com/allog/dallog/domain/schedule/application/SubscribingSchedulesFinder.java
+++ b/backend/src/main/java/com/allog/dallog/domain/schedule/application/SubscribingSchedulesFinder.java
@@ -66,15 +66,15 @@ public class SubscribingSchedulesFinder {
             return schedules;
         }
 
-        String accessToken = getGoogleAccessToken(memberId);
+        String accessToken = getExternalAccessToken(memberId);
         for (ExternalCategoryDetail detail : details) {
-            List<IntegrationSchedule> googleSchedules = findGoogleSchedules(dateRange, accessToken, detail);
-            schedules.addAll(googleSchedules);
+            List<IntegrationSchedule> externalSchedules = findExternalSchedules(dateRange, accessToken, detail);
+            schedules.addAll(externalSchedules);
         }
         return schedules;
     }
 
-    private String getGoogleAccessToken(final Long memberId) {
+    private String getExternalAccessToken(final Long memberId) {
         OAuthToken oAuthToken = oAuthTokenRepository.getByMemberId(memberId);
         String refreshToken = oAuthToken.getRefreshToken();
 
@@ -82,8 +82,8 @@ public class SubscribingSchedulesFinder {
         return accessTokenResponse.getValue();
     }
 
-    private List<IntegrationSchedule> findGoogleSchedules(final DateRangeRequest dateRange, final String accessToken,
-                                                          final ExternalCategoryDetail detail) {
+    private List<IntegrationSchedule> findExternalSchedules(final DateRangeRequest dateRange, final String accessToken,
+                                                            final ExternalCategoryDetail detail) {
         LocalDateTime startDateTime = dateRange.getStartDateTime();
         LocalDateTime endDateTime = dateRange.getEndDateTime();
 

--- a/backend/src/main/java/com/allog/dallog/domain/schedule/domain/ScheduleRepository.java
+++ b/backend/src/main/java/com/allog/dallog/domain/schedule/domain/ScheduleRepository.java
@@ -27,8 +27,9 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
                 .orElseThrow(NoSuchScheduleException::new);
     }
 
-    default List<IntegrationSchedule> createByCategoryAndBetween(
-            final Category category, final LocalDateTime startDateTime, final LocalDateTime endDateTime) {
+    default List<IntegrationSchedule> createByCategoryAndBetween(final Category category,
+                                                                 final LocalDateTime startDateTime,
+                                                                 final LocalDateTime endDateTime) {
         List<Schedule> schedules = findByCategoryAndBetween(category, startDateTime, endDateTime);
 
         return schedules.stream()

--- a/backend/src/main/java/com/allog/dallog/domain/schedule/domain/ScheduleRepository.java
+++ b/backend/src/main/java/com/allog/dallog/domain/schedule/domain/ScheduleRepository.java
@@ -1,15 +1,38 @@
 package com.allog.dallog.domain.schedule.domain;
 
+import com.allog.dallog.domain.category.domain.Category;
+import com.allog.dallog.domain.integrationschedule.domain.IntegrationSchedule;
 import com.allog.dallog.domain.schedule.exception.NoSuchScheduleException;
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.stream.Collectors;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
 
     void deleteByCategoryIdIn(final List<Long> categoryIds);
 
+    @Query("SELECT s "
+            + "FROM Schedule s "
+            + "JOIN s.category c "
+            + "WHERE c = :category "
+            + "AND s.startDateTime <= :endDate "
+            + "AND s.endDateTime >= :startDate")
+    List<Schedule> findByCategoryAndBetween(final Category category, final LocalDateTime startDate,
+                                            final LocalDateTime endDate);
+
     default Schedule getById(final Long id) {
         return this.findById(id)
                 .orElseThrow(NoSuchScheduleException::new);
+    }
+
+    default List<IntegrationSchedule> createByCategoryAndBetween(
+            final Category category, final LocalDateTime startDateTime, final LocalDateTime endDateTime) {
+        List<Schedule> schedules = findByCategoryAndBetween(category, startDateTime, endDateTime);
+
+        return schedules.stream()
+                .map(schedule -> new IntegrationSchedule(schedule, category.getCategoryType()))
+                .collect(Collectors.toList());
     }
 }

--- a/backend/src/main/java/com/allog/dallog/domain/subscription/domain/Subscription.java
+++ b/backend/src/main/java/com/allog/dallog/domain/subscription/domain/Subscription.java
@@ -19,7 +19,7 @@ import javax.persistence.Table;
 @Table(name = "subscriptions")
 @Entity
 public class Subscription extends BaseEntity {
-    
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id")
@@ -59,6 +59,14 @@ public class Subscription extends BaseEntity {
         if (category.isCreatorId(memberId)) {
             throw new NoPermissionException("내가 만든 카테고리는 구독 취소 할 수 없습니다.");
         }
+    }
+
+    public boolean hasInternalCategory() {
+        return category.isInternal();
+    }
+
+    public boolean hasExternalCategory() {
+        return category.isExternal();
     }
 
     public Long getId() {

--- a/backend/src/main/java/com/allog/dallog/domain/subscription/domain/Subscriptions.java
+++ b/backend/src/main/java/com/allog/dallog/domain/subscription/domain/Subscriptions.java
@@ -4,7 +4,6 @@ import com.allog.dallog.domain.category.domain.Category;
 import com.allog.dallog.domain.category.exception.NoSuchCategoryException;
 import com.allog.dallog.domain.integrationschedule.domain.IntegrationSchedule;
 import java.util.List;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 public class Subscriptions {
@@ -15,12 +14,19 @@ public class Subscriptions {
         this.subscriptions = subscriptions;
     }
 
-    public List<Long> findCheckedCategoryIdsBy(final Predicate<Category> predicate) {
+    public List<Category> findInternalCategory() {
         return subscriptions.stream()
                 .filter(Subscription::isChecked)
+                .filter(Subscription::hasInternalCategory)
                 .map(Subscription::getCategory)
-                .filter(predicate)
-                .map(Category::getId)
+                .collect(Collectors.toList());
+    }
+
+    public List<Category> findExternalCategory() {
+        return subscriptions.stream()
+                .filter(Subscription::isChecked)
+                .filter(Subscription::hasExternalCategory)
+                .map(Subscription::getCategory)
                 .collect(Collectors.toList());
     }
 

--- a/backend/src/main/java/com/allog/dallog/presentation/ScheduleController.java
+++ b/backend/src/main/java/com/allog/dallog/presentation/ScheduleController.java
@@ -1,8 +1,8 @@
 package com.allog.dallog.presentation;
 
 import com.allog.dallog.domain.auth.dto.LoginMember;
-import com.allog.dallog.domain.composition.application.CalendarService;
 import com.allog.dallog.domain.schedule.application.ScheduleService;
+import com.allog.dallog.domain.schedule.application.SubscribingSchedulesFinder;
 import com.allog.dallog.domain.schedule.dto.request.DateRangeRequest;
 import com.allog.dallog.domain.schedule.dto.request.ScheduleCreateRequest;
 import com.allog.dallog.domain.schedule.dto.request.ScheduleUpdateRequest;
@@ -27,11 +27,12 @@ import org.springframework.web.bind.annotation.RestController;
 public class ScheduleController {
 
     private final ScheduleService scheduleService;
-    private final CalendarService calendarService;
+    private final SubscribingSchedulesFinder subscribingSchedulesFinder;
 
-    public ScheduleController(final ScheduleService scheduleService, final CalendarService calendarService) {
+    public ScheduleController(final ScheduleService scheduleService,
+                              final SubscribingSchedulesFinder subscribingSchedulesFinder) {
         this.scheduleService = scheduleService;
-        this.calendarService = calendarService;
+        this.subscribingSchedulesFinder = subscribingSchedulesFinder;
     }
 
     @PostMapping("/categories/{categoryId}/schedules")
@@ -43,9 +44,10 @@ public class ScheduleController {
     }
 
     @GetMapping("/members/me/schedules")
-    public ResponseEntity<MemberScheduleResponses> findByMemberId(
+    public ResponseEntity<MemberScheduleResponses> findMySubscribingSchedules(
             @AuthenticationPrincipal final LoginMember loginMember, @ModelAttribute DateRangeRequest request) {
-        MemberScheduleResponses response = calendarService.findSchedulesByMemberId(loginMember.getId(), request);
+        MemberScheduleResponses response = subscribingSchedulesFinder
+                .findMySubscribingSchedules(loginMember.getId(), request);
         return ResponseEntity.ok(response);
     }
 

--- a/backend/src/test/java/com/allog/dallog/common/fixtures/CategoryFixtures.java
+++ b/backend/src/test/java/com/allog/dallog/common/fixtures/CategoryFixtures.java
@@ -21,10 +21,12 @@ public class CategoryFixtures {
     /* BE 일정 카테고리 */
     public static final String BE_일정_이름 = "BE 일정";
     public static final CategoryCreateRequest BE_일정_생성_요청 = new CategoryCreateRequest(BE_일정_이름, NORMAL);
+    public static final CategoryCreateRequest 외부_BE_일정_생성_요청 = new CategoryCreateRequest(BE_일정_이름, GOOGLE);
 
     /* FE 일정 카테고리 */
     public static final String FE_일정_이름 = "FE 일정";
     public static final CategoryCreateRequest FE_일정_생성_요청 = new CategoryCreateRequest(FE_일정_이름, NORMAL);
+    public static final CategoryCreateRequest 외부_FE_일정_생성_요청 = new CategoryCreateRequest(FE_일정_이름, GOOGLE);
 
     /* 매트 아고라 카테고리 */
     public static final String 매트_아고라_이름 = "매트 아고라";

--- a/backend/src/test/java/com/allog/dallog/domain/category/application/ExternalCategoryDetailServiceTest.java
+++ b/backend/src/test/java/com/allog/dallog/domain/category/application/ExternalCategoryDetailServiceTest.java
@@ -1,0 +1,56 @@
+package com.allog.dallog.domain.category.application;
+
+import static com.allog.dallog.common.fixtures.AuthFixtures.리버_인증_코드_토큰_요청;
+import static com.allog.dallog.common.fixtures.CategoryFixtures.BE_일정_생성_요청;
+import static com.allog.dallog.common.fixtures.CategoryFixtures.FE_일정_생성_요청;
+import static com.allog.dallog.common.fixtures.CategoryFixtures.외부_BE_일정_생성_요청;
+import static com.allog.dallog.common.fixtures.CategoryFixtures.외부_FE_일정_생성_요청;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.allog.dallog.common.annotation.ServiceTest;
+import com.allog.dallog.domain.category.domain.Category;
+import com.allog.dallog.domain.category.domain.CategoryRepository;
+import com.allog.dallog.domain.category.domain.ExternalCategoryDetail;
+import com.allog.dallog.domain.category.domain.ExternalCategoryDetailRepository;
+import com.allog.dallog.domain.category.dto.response.CategoryResponse;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class ExternalCategoryDetailServiceTest extends ServiceTest {
+
+    @Autowired
+    private ExternalCategoryDetailService externalCategoryDetailService;
+
+    @Autowired
+    private CategoryService categoryService;
+
+    @Autowired
+    private ExternalCategoryDetailRepository externalCategoryDetailRepository;
+
+    @Autowired
+    private CategoryRepository categoryRepository;
+
+    @DisplayName("월별 일정 조회 시, 유저 ID로 해당하는 외부 연동 카테고리 전체를 조회한다.")
+    @Test
+    void 월별_일정_조회_시_유저_ID로_해당하는_외부_연동_카테고리의_전체를_조회한다() {
+        // given
+        Long 리버_id = parseMemberId(리버_인증_코드_토큰_요청());
+
+        CategoryResponse 외부_BE_일정_응답 = categoryService.save(리버_id, 외부_BE_일정_생성_요청);
+        Category 외부_BE_일정 = categoryRepository.getById(외부_BE_일정_응답.getId());
+
+        CategoryResponse 외부_FE_일정_응답 = categoryService.save(리버_id, 외부_FE_일정_생성_요청);
+        Category 외부_FE_일정 = categoryRepository.getById(외부_FE_일정_응답.getId());
+
+        externalCategoryDetailRepository.save(new ExternalCategoryDetail(외부_BE_일정, "1111111"));
+        externalCategoryDetailRepository.save(new ExternalCategoryDetail(외부_FE_일정, "2222222"));
+
+        // when
+        List<ExternalCategoryDetail> details = externalCategoryDetailService.findByMemberId(리버_id);
+
+        // then
+        assertThat(details).hasSize(2);
+    }
+}

--- a/backend/src/test/java/com/allog/dallog/domain/category/domain/ExternalCategoryDetailRepositoryTest.java
+++ b/backend/src/test/java/com/allog/dallog/domain/category/domain/ExternalCategoryDetailRepositoryTest.java
@@ -1,5 +1,6 @@
 package com.allog.dallog.domain.category.domain;
 
+import static com.allog.dallog.common.fixtures.CategoryFixtures.공통_일정;
 import static com.allog.dallog.common.fixtures.CategoryFixtures.우아한테크코스_일정;
 import static com.allog.dallog.common.fixtures.MemberFixtures.관리자;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -37,8 +38,10 @@ public class ExternalCategoryDetailRepositoryTest extends RepositoryTest {
 
         externalCategoryDetailRepository.save(new ExternalCategoryDetail(우아한테크코스_일정, "externalId"));
 
+        Category 공통_일정 = categoryRepository.save(공통_일정(관리자));
+
         // when & then
-        assertThatThrownBy(() -> externalCategoryDetailRepository.getByCategoryId(0L))
+        assertThatThrownBy(() -> externalCategoryDetailRepository.getByCategory(공통_일정))
                 .isInstanceOf(NoSuchExternalCategoryDetailException.class);
     }
 

--- a/backend/src/test/java/com/allog/dallog/domain/composition/application/CalendarServiceTest.java
+++ b/backend/src/test/java/com/allog/dallog/domain/composition/application/CalendarServiceTest.java
@@ -1,6 +1,5 @@
 package com.allog.dallog.domain.composition.application;
 
-import static com.allog.dallog.common.fixtures.AuthFixtures.MEMBER_인증_코드_토큰_요청;
 import static com.allog.dallog.common.fixtures.AuthFixtures.관리자_인증_코드_토큰_요청;
 import static com.allog.dallog.common.fixtures.AuthFixtures.리버_인증_코드_토큰_요청;
 import static com.allog.dallog.common.fixtures.AuthFixtures.매트_인증_코드_토큰_요청;
@@ -9,7 +8,6 @@ import static com.allog.dallog.common.fixtures.AuthFixtures.후디_인증_코드
 import static com.allog.dallog.common.fixtures.CategoryFixtures.BE_일정_생성_요청;
 import static com.allog.dallog.common.fixtures.CategoryFixtures.FE_일정_생성_요청;
 import static com.allog.dallog.common.fixtures.CategoryFixtures.공통_일정_생성_요청;
-import static com.allog.dallog.common.fixtures.CategoryFixtures.우아한테크코스_외부_일정_생성_요청;
 import static com.allog.dallog.common.fixtures.ScheduleFixtures.날짜_2022년_7월_10일_0시_0분;
 import static com.allog.dallog.common.fixtures.ScheduleFixtures.날짜_2022년_7월_10일_11시_59분;
 import static com.allog.dallog.common.fixtures.ScheduleFixtures.날짜_2022년_7월_15일_16시_0분;
@@ -17,7 +15,6 @@ import static com.allog.dallog.common.fixtures.ScheduleFixtures.날짜_2022년_7
 import static com.allog.dallog.common.fixtures.ScheduleFixtures.날짜_2022년_7월_16일_16시_1분;
 import static com.allog.dallog.common.fixtures.ScheduleFixtures.날짜_2022년_7월_16일_18시_0분;
 import static com.allog.dallog.common.fixtures.ScheduleFixtures.날짜_2022년_7월_16일_20시_0분;
-import static com.allog.dallog.common.fixtures.ScheduleFixtures.날짜_2022년_7월_1일_0시_0분;
 import static com.allog.dallog.common.fixtures.ScheduleFixtures.날짜_2022년_7월_20일_0시_0분;
 import static com.allog.dallog.common.fixtures.ScheduleFixtures.날짜_2022년_7월_20일_11시_59분;
 import static com.allog.dallog.common.fixtures.ScheduleFixtures.날짜_2022년_7월_27일_0시_0분;
@@ -25,23 +22,17 @@ import static com.allog.dallog.common.fixtures.ScheduleFixtures.날짜_2022년_7
 import static com.allog.dallog.common.fixtures.ScheduleFixtures.날짜_2022년_7월_31일_0시_0분;
 import static com.allog.dallog.common.fixtures.ScheduleFixtures.날짜_2022년_7월_7일_16시_0분;
 import static com.allog.dallog.common.fixtures.ScheduleFixtures.날짜_2022년_8월_15일_14시_0분;
-import static com.allog.dallog.common.fixtures.ScheduleFixtures.날짜_2022년_8월_15일_17시_0분;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.allog.dallog.common.annotation.ServiceTest;
 import com.allog.dallog.domain.category.application.CategoryService;
-import com.allog.dallog.domain.category.domain.Category;
 import com.allog.dallog.domain.category.domain.CategoryRepository;
-import com.allog.dallog.domain.category.domain.ExternalCategoryDetail;
 import com.allog.dallog.domain.category.domain.ExternalCategoryDetailRepository;
 import com.allog.dallog.domain.category.dto.response.CategoryResponse;
 import com.allog.dallog.domain.integrationschedule.domain.IntegrationSchedule;
 import com.allog.dallog.domain.schedule.application.ScheduleService;
 import com.allog.dallog.domain.schedule.dto.request.DateRangeRequest;
 import com.allog.dallog.domain.schedule.dto.request.ScheduleCreateRequest;
-import com.allog.dallog.domain.schedule.dto.response.MemberScheduleResponse;
-import com.allog.dallog.domain.schedule.dto.response.MemberScheduleResponses;
 import com.allog.dallog.domain.subscription.application.SubscriptionService;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -67,64 +58,6 @@ class CalendarServiceTest extends ServiceTest {
 
     @Autowired
     private CategoryRepository categoryRepository;
-
-    @DisplayName("시작일시와 종료일시로 유저의 캘린더를 일정 유형에 따라 분류하고 정렬하여 반환한다.")
-    @Test
-    void 시작일시와_종료일시로_유저의_캘린더를_일정_유형에_따라_분류하고_정렬하여_반환한다() {
-        // given
-        Long memberId = parseMemberId(MEMBER_인증_코드_토큰_요청());
-
-        CategoryResponse BE_일정_응답 = categoryService.save(memberId, BE_일정_생성_요청);
-        Category BE_일정 = categoryRepository.getById(BE_일정_응답.getId());
-
-        /* 장기간 일정 */
-        scheduleService.save(memberId, BE_일정.getId(),
-                new ScheduleCreateRequest("장기간 첫번째", 날짜_2022년_7월_1일_0시_0분, 날짜_2022년_8월_15일_14시_0분, ""));
-        scheduleService.save(memberId, BE_일정.getId(),
-                new ScheduleCreateRequest("장기간 두번째", 날짜_2022년_7월_1일_0시_0분, 날짜_2022년_7월_31일_0시_0분, ""));
-        scheduleService.save(memberId, BE_일정.getId(),
-                new ScheduleCreateRequest("장기간 세번째", 날짜_2022년_7월_1일_0시_0분, 날짜_2022년_7월_16일_16시_1분, ""));
-        scheduleService.save(memberId, BE_일정.getId(),
-                new ScheduleCreateRequest("장기간 네번째", 날짜_2022년_7월_7일_16시_0분, 날짜_2022년_7월_15일_16시_0분, ""));
-        scheduleService.save(memberId, BE_일정.getId(),
-                new ScheduleCreateRequest("장기간 다섯번째", 날짜_2022년_7월_31일_0시_0분, 날짜_2022년_8월_15일_17시_0분, ""));
-
-        /* 종일 일정 */
-        scheduleService.save(memberId, BE_일정.getId(),
-                new ScheduleCreateRequest("종일 첫번째", 날짜_2022년_7월_10일_0시_0분, 날짜_2022년_7월_10일_11시_59분, ""));
-        scheduleService.save(memberId, BE_일정.getId(),
-                new ScheduleCreateRequest("종일 두번째", 날짜_2022년_7월_20일_0시_0분, 날짜_2022년_7월_20일_11시_59분, ""));
-        scheduleService.save(memberId, BE_일정.getId(),
-                new ScheduleCreateRequest("종일 세번째", 날짜_2022년_7월_27일_0시_0분, 날짜_2022년_7월_27일_11시_59분, ""));
-
-        /* 몇시간 일정 */
-        scheduleService.save(memberId, BE_일정.getId(),
-                new ScheduleCreateRequest("몇시간 첫번째", 날짜_2022년_7월_16일_16시_0분, 날짜_2022년_7월_16일_20시_0분, ""));
-        scheduleService.save(memberId, BE_일정.getId(),
-                new ScheduleCreateRequest("몇시간 두번째", 날짜_2022년_7월_16일_16시_0분, 날짜_2022년_7월_16일_18시_0분, ""));
-        scheduleService.save(memberId, BE_일정.getId(),
-                new ScheduleCreateRequest("몇시간 세번째", 날짜_2022년_7월_16일_16시_0분, 날짜_2022년_7월_16일_16시_1분, ""));
-        scheduleService.save(memberId, BE_일정.getId(),
-                new ScheduleCreateRequest("몇시간 네번째", 날짜_2022년_7월_16일_18시_0분, 날짜_2022년_7월_16일_18시_0분, ""));
-
-        CategoryResponse 우아한테크코스_외부_일정_응답 = categoryService.save(memberId, 우아한테크코스_외부_일정_생성_요청);
-        Category 우아한테크코스 = categoryRepository.getById(우아한테크코스_외부_일정_응답.getId());
-        externalCategoryDetailRepository.save(new ExternalCategoryDetail(우아한테크코스, "dfggsdfasdasadsgs"));
-
-        // when
-        MemberScheduleResponses memberScheduleResponses = calendarService.findSchedulesByMemberId(memberId,
-                new DateRangeRequest("2022-07-01T00:00", "2022-08-15T23:59"));
-
-        // then
-        assertAll(() -> {
-            assertThat(memberScheduleResponses.getLongTerms()).extracting(MemberScheduleResponse::getTitle)
-                    .contains("장기간 첫번째", "장기간 두번째", "장기간 세번째", "장기간 네번째", "장기간 다섯번째");
-            assertThat(memberScheduleResponses.getAllDays()).extracting(MemberScheduleResponse::getTitle)
-                    .contains("종일 첫번째", "종일 두번째", "종일 세번째");
-            assertThat(memberScheduleResponses.getFewHours()).extracting(MemberScheduleResponse::getTitle)
-                    .contains("몇시간 첫번째", "몇시간 두번째", "몇시간 세번째", "몇시간 네번째");
-        });
-    }
 
     // TODO: 외부 일정을 잘 가져오는지를 테스트 해야함
     @DisplayName("카테고리를 구독하는 유저들의 모든 내부 일정을 가져온다.")

--- a/backend/src/test/java/com/allog/dallog/domain/composition/application/CalendarServiceTest.java
+++ b/backend/src/test/java/com/allog/dallog/domain/composition/application/CalendarServiceTest.java
@@ -8,6 +8,7 @@ import static com.allog.dallog.common.fixtures.AuthFixtures.후디_인증_코드
 import static com.allog.dallog.common.fixtures.CategoryFixtures.BE_일정_생성_요청;
 import static com.allog.dallog.common.fixtures.CategoryFixtures.FE_일정_생성_요청;
 import static com.allog.dallog.common.fixtures.CategoryFixtures.공통_일정_생성_요청;
+import static com.allog.dallog.common.fixtures.CategoryFixtures.외부_BE_일정_생성_요청;
 import static com.allog.dallog.common.fixtures.ScheduleFixtures.날짜_2022년_7월_10일_0시_0분;
 import static com.allog.dallog.common.fixtures.ScheduleFixtures.날짜_2022년_7월_10일_11시_59분;
 import static com.allog.dallog.common.fixtures.ScheduleFixtures.날짜_2022년_7월_15일_16시_0분;
@@ -26,7 +27,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.allog.dallog.common.annotation.ServiceTest;
 import com.allog.dallog.domain.category.application.CategoryService;
+import com.allog.dallog.domain.category.domain.Category;
 import com.allog.dallog.domain.category.domain.CategoryRepository;
+import com.allog.dallog.domain.category.domain.ExternalCategoryDetail;
 import com.allog.dallog.domain.category.domain.ExternalCategoryDetailRepository;
 import com.allog.dallog.domain.category.dto.response.CategoryResponse;
 import com.allog.dallog.domain.integrationschedule.domain.IntegrationSchedule;
@@ -70,6 +73,11 @@ class CalendarServiceTest extends ServiceTest {
         CategoryResponse BE_일정 = categoryService.save(관리자_id, BE_일정_생성_요청);
         CategoryResponse FE_일정 = categoryService.save(관리자_id, FE_일정_생성_요청);
 
+        CategoryResponse 외부_BE_일정_응답 = categoryService.save(관리자_id, 외부_BE_일정_생성_요청);
+        Category 외부_BE_일정 = categoryRepository.getById(외부_BE_일정_응답.getId());
+
+        externalCategoryDetailRepository.save(new ExternalCategoryDetail(외부_BE_일정, "11111111"));
+
         /* 카테고리에 일정 추가 */
         scheduleService.save(관리자_id, 공통_일정.getId(),
                 new ScheduleCreateRequest("공통 일정 1", 날짜_2022년_7월_7일_16시_0분, 날짜_2022년_7월_10일_0시_0분, ""));
@@ -103,13 +111,18 @@ class CalendarServiceTest extends ServiceTest {
         subscriptionService.save(매트_id, FE_일정.getId());
         subscriptionService.save(리버_id, FE_일정.getId());
 
+        subscriptionService.save(후디_id, 외부_BE_일정.getId());
+        subscriptionService.save(파랑_id, 외부_BE_일정.getId());
+        subscriptionService.save(매트_id, 외부_BE_일정.getId());
+        subscriptionService.save(리버_id, 외부_BE_일정.getId());
+
         // when
         List<IntegrationSchedule> actual = calendarService.getSchedulesBySubscriberIds(
                 List.of(후디_id, 파랑_id, 매트_id, 리버_id), new DateRangeRequest("2022-07-07T16:00", "2022-08-15T14:00"));
 
         // then
         assertThat(actual.stream().map(IntegrationSchedule::getTitle))
-                .containsExactly("공통 일정 1", "공통 일정 2", "공통 일정 3", "백엔드 일정 1", "백엔드 일정 2", "백엔드 일정 3", "프론트엔드 일정 1",
-                        "프론트엔드 일정 2");
+                .contains("공통 일정 1", "공통 일정 2", "공통 일정 3", "백엔드 일정 1", "백엔드 일정 2", "백엔드 일정 3", "프론트엔드 일정 1",
+                        "포수타", "레벨3 방학", "프론트엔드 일정 2");
     }
 }

--- a/backend/src/test/java/com/allog/dallog/domain/schedule/application/ScheduleServiceTest.java
+++ b/backend/src/test/java/com/allog/dallog/domain/schedule/application/ScheduleServiceTest.java
@@ -11,11 +11,13 @@ import static com.allog.dallog.common.fixtures.ScheduleFixtures.레벨_인터뷰
 import static com.allog.dallog.common.fixtures.ScheduleFixtures.레벨_인터뷰_시작일시;
 import static com.allog.dallog.common.fixtures.ScheduleFixtures.레벨_인터뷰_제목;
 import static com.allog.dallog.common.fixtures.ScheduleFixtures.레벨_인터뷰_종료일시;
+import static com.allog.dallog.common.fixtures.ScheduleFixtures.알록달록_회식_생성_요청;
 import static com.allog.dallog.common.fixtures.ScheduleFixtures.알록달록_회의_메모;
 import static com.allog.dallog.common.fixtures.ScheduleFixtures.알록달록_회의_생성_요청;
 import static com.allog.dallog.common.fixtures.ScheduleFixtures.알록달록_회의_시작일시;
 import static com.allog.dallog.common.fixtures.ScheduleFixtures.알록달록_회의_제목;
 import static com.allog.dallog.common.fixtures.ScheduleFixtures.알록달록_회의_종료일시;
+import static com.allog.dallog.domain.category.domain.CategoryType.NORMAL;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -23,14 +25,18 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import com.allog.dallog.common.annotation.ServiceTest;
 import com.allog.dallog.domain.auth.exception.NoPermissionException;
 import com.allog.dallog.domain.category.application.CategoryService;
+import com.allog.dallog.domain.category.domain.CategoryType;
 import com.allog.dallog.domain.category.dto.response.CategoryResponse;
 import com.allog.dallog.domain.category.exception.NoSuchCategoryException;
+import com.allog.dallog.domain.integrationschedule.domain.IntegrationSchedule;
+import com.allog.dallog.domain.schedule.dto.request.DateRangeRequest;
 import com.allog.dallog.domain.schedule.dto.request.ScheduleCreateRequest;
 import com.allog.dallog.domain.schedule.dto.request.ScheduleUpdateRequest;
 import com.allog.dallog.domain.schedule.dto.response.ScheduleResponse;
 import com.allog.dallog.domain.schedule.exception.InvalidScheduleException;
 import com.allog.dallog.domain.schedule.exception.NoSuchScheduleException;
 import java.time.LocalDateTime;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -183,6 +189,31 @@ class ScheduleServiceTest extends ServiceTest {
 
         // when & then
         assertThatThrownBy(() -> scheduleService.findById(잘못된_아이디));
+    }
+
+    @DisplayName("월별 일정 조회 시, 통합일정 정보를 반환한다.")
+    @Test
+    void 월별_일정_조회_시_통합일정_정보를_반환한다() {
+        // given
+        Long 리버_id = parseMemberId(리버_인증_코드_토큰_요청());
+        CategoryResponse BE_일정 = categoryService.save(리버_id, BE_일정_생성_요청);
+        ScheduleResponse 알록달록_회의 = scheduleService.save(리버_id, BE_일정.getId(), 알록달록_회의_생성_요청);
+        ScheduleResponse 알록달록_회식 = scheduleService.save(리버_id, BE_일정.getId(), 알록달록_회식_생성_요청);
+
+        // when
+        List<IntegrationSchedule> schedules = scheduleService.findByMemberIdAndDateRange(리버_id,
+                new DateRangeRequest("2022-07-01T00:00", "2022-08-15T23:59"));
+
+        // then
+        assertThat(schedules).hasSize(2);
+        assertAll(
+                () -> {
+                    assertThat(schedules.get(0).getId()).isEqualTo(String.valueOf(알록달록_회의.getId()));
+                    assertThat(schedules.get(0).getCategoryType()).isEqualTo(NORMAL);
+                    assertThat(schedules.get(1).getId()).isEqualTo(String.valueOf(알록달록_회식.getId()));
+                    assertThat(schedules.get(1).getCategoryType()).isEqualTo(NORMAL);
+                }
+        );
     }
 
     @DisplayName("일정을 수정한다.")

--- a/backend/src/test/java/com/allog/dallog/domain/schedule/application/ScheduleServiceTest.java
+++ b/backend/src/test/java/com/allog/dallog/domain/schedule/application/ScheduleServiceTest.java
@@ -25,7 +25,6 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import com.allog.dallog.common.annotation.ServiceTest;
 import com.allog.dallog.domain.auth.exception.NoPermissionException;
 import com.allog.dallog.domain.category.application.CategoryService;
-import com.allog.dallog.domain.category.domain.CategoryType;
 import com.allog.dallog.domain.category.dto.response.CategoryResponse;
 import com.allog.dallog.domain.category.exception.NoSuchCategoryException;
 import com.allog.dallog.domain.integrationschedule.domain.IntegrationSchedule;
@@ -201,7 +200,7 @@ class ScheduleServiceTest extends ServiceTest {
         ScheduleResponse 알록달록_회식 = scheduleService.save(리버_id, BE_일정.getId(), 알록달록_회식_생성_요청);
 
         // when
-        List<IntegrationSchedule> schedules = scheduleService.findByMemberIdAndDateRange(리버_id,
+        List<IntegrationSchedule> schedules = scheduleService.findInternalByMemberIdAndDateRange(리버_id,
                 new DateRangeRequest("2022-07-01T00:00", "2022-08-15T23:59"));
 
         // then

--- a/backend/src/test/java/com/allog/dallog/domain/schedule/application/SubscribingSchedulesFinderTest.java
+++ b/backend/src/test/java/com/allog/dallog/domain/schedule/application/SubscribingSchedulesFinderTest.java
@@ -1,0 +1,118 @@
+package com.allog.dallog.domain.schedule.application;
+
+import static com.allog.dallog.common.fixtures.AuthFixtures.MEMBER_인증_코드_토큰_요청;
+import static com.allog.dallog.common.fixtures.CategoryFixtures.BE_일정_생성_요청;
+import static com.allog.dallog.common.fixtures.CategoryFixtures.우아한테크코스_외부_일정_생성_요청;
+import static com.allog.dallog.common.fixtures.ScheduleFixtures.날짜_2022년_7월_10일_0시_0분;
+import static com.allog.dallog.common.fixtures.ScheduleFixtures.날짜_2022년_7월_10일_11시_59분;
+import static com.allog.dallog.common.fixtures.ScheduleFixtures.날짜_2022년_7월_15일_16시_0분;
+import static com.allog.dallog.common.fixtures.ScheduleFixtures.날짜_2022년_7월_16일_16시_0분;
+import static com.allog.dallog.common.fixtures.ScheduleFixtures.날짜_2022년_7월_16일_16시_1분;
+import static com.allog.dallog.common.fixtures.ScheduleFixtures.날짜_2022년_7월_16일_18시_0분;
+import static com.allog.dallog.common.fixtures.ScheduleFixtures.날짜_2022년_7월_16일_20시_0분;
+import static com.allog.dallog.common.fixtures.ScheduleFixtures.날짜_2022년_7월_1일_0시_0분;
+import static com.allog.dallog.common.fixtures.ScheduleFixtures.날짜_2022년_7월_20일_0시_0분;
+import static com.allog.dallog.common.fixtures.ScheduleFixtures.날짜_2022년_7월_20일_11시_59분;
+import static com.allog.dallog.common.fixtures.ScheduleFixtures.날짜_2022년_7월_27일_0시_0분;
+import static com.allog.dallog.common.fixtures.ScheduleFixtures.날짜_2022년_7월_27일_11시_59분;
+import static com.allog.dallog.common.fixtures.ScheduleFixtures.날짜_2022년_7월_31일_0시_0분;
+import static com.allog.dallog.common.fixtures.ScheduleFixtures.날짜_2022년_7월_7일_16시_0분;
+import static com.allog.dallog.common.fixtures.ScheduleFixtures.날짜_2022년_8월_15일_14시_0분;
+import static com.allog.dallog.common.fixtures.ScheduleFixtures.날짜_2022년_8월_15일_17시_0분;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.allog.dallog.common.annotation.ServiceTest;
+import com.allog.dallog.domain.category.application.CategoryService;
+import com.allog.dallog.domain.category.domain.Category;
+import com.allog.dallog.domain.category.domain.CategoryRepository;
+import com.allog.dallog.domain.category.domain.ExternalCategoryDetail;
+import com.allog.dallog.domain.category.domain.ExternalCategoryDetailRepository;
+import com.allog.dallog.domain.category.dto.response.CategoryResponse;
+import com.allog.dallog.domain.schedule.dto.request.DateRangeRequest;
+import com.allog.dallog.domain.schedule.dto.request.ScheduleCreateRequest;
+import com.allog.dallog.domain.schedule.dto.response.MemberScheduleResponse;
+import com.allog.dallog.domain.schedule.dto.response.MemberScheduleResponses;
+import com.allog.dallog.domain.subscription.application.SubscriptionService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class SubscribingSchedulesFinderTest extends ServiceTest {
+
+    @Autowired
+    private SubscribingSchedulesFinder subscribingSchedulesFinder;
+
+    @Autowired
+    private CategoryService categoryService;
+
+    @Autowired
+    private ExternalCategoryDetailRepository externalCategoryDetailRepository;
+
+    @Autowired
+    private SubscriptionService subscriptionService;
+
+    @Autowired
+    private ScheduleService scheduleService;
+
+    @Autowired
+    private CategoryRepository categoryRepository;
+
+    @DisplayName("시작일시와 종료일시로 유저의 달력을 일정 유형에 따라 분류하고 정렬하여 반환한다.")
+    @Test
+    void 시작일시와_종료일시로_유저의_달력을_일정_유형에_따라_분류하고_정렬하여_반환한다() {
+        // given
+        Long memberId = parseMemberId(MEMBER_인증_코드_토큰_요청());
+
+        CategoryResponse BE_일정_응답 = categoryService.save(memberId, BE_일정_생성_요청);
+        Category BE_일정 = categoryRepository.getById(BE_일정_응답.getId());
+
+        /* 장기간 일정 */
+        scheduleService.save(memberId, BE_일정.getId(),
+                new ScheduleCreateRequest("장기간 첫번째", 날짜_2022년_7월_1일_0시_0분, 날짜_2022년_8월_15일_14시_0분, ""));
+        scheduleService.save(memberId, BE_일정.getId(),
+                new ScheduleCreateRequest("장기간 두번째", 날짜_2022년_7월_1일_0시_0분, 날짜_2022년_7월_31일_0시_0분, ""));
+        scheduleService.save(memberId, BE_일정.getId(),
+                new ScheduleCreateRequest("장기간 세번째", 날짜_2022년_7월_1일_0시_0분, 날짜_2022년_7월_16일_16시_1분, ""));
+        scheduleService.save(memberId, BE_일정.getId(),
+                new ScheduleCreateRequest("장기간 네번째", 날짜_2022년_7월_7일_16시_0분, 날짜_2022년_7월_15일_16시_0분, ""));
+        scheduleService.save(memberId, BE_일정.getId(),
+                new ScheduleCreateRequest("장기간 다섯번째", 날짜_2022년_7월_31일_0시_0분, 날짜_2022년_8월_15일_17시_0분, ""));
+
+        /* 종일 일정 */
+        scheduleService.save(memberId, BE_일정.getId(),
+                new ScheduleCreateRequest("종일 첫번째", 날짜_2022년_7월_10일_0시_0분, 날짜_2022년_7월_10일_11시_59분, ""));
+        scheduleService.save(memberId, BE_일정.getId(),
+                new ScheduleCreateRequest("종일 두번째", 날짜_2022년_7월_20일_0시_0분, 날짜_2022년_7월_20일_11시_59분, ""));
+        scheduleService.save(memberId, BE_일정.getId(),
+                new ScheduleCreateRequest("종일 세번째", 날짜_2022년_7월_27일_0시_0분, 날짜_2022년_7월_27일_11시_59분, ""));
+
+        /* 몇시간 일정 */
+        scheduleService.save(memberId, BE_일정.getId(),
+                new ScheduleCreateRequest("몇시간 첫번째", 날짜_2022년_7월_16일_16시_0분, 날짜_2022년_7월_16일_20시_0분, ""));
+        scheduleService.save(memberId, BE_일정.getId(),
+                new ScheduleCreateRequest("몇시간 두번째", 날짜_2022년_7월_16일_16시_0분, 날짜_2022년_7월_16일_18시_0분, ""));
+        scheduleService.save(memberId, BE_일정.getId(),
+                new ScheduleCreateRequest("몇시간 세번째", 날짜_2022년_7월_16일_16시_0분, 날짜_2022년_7월_16일_16시_1분, ""));
+        scheduleService.save(memberId, BE_일정.getId(),
+                new ScheduleCreateRequest("몇시간 네번째", 날짜_2022년_7월_16일_18시_0분, 날짜_2022년_7월_16일_18시_0분, ""));
+
+        CategoryResponse 우아한테크코스_외부_일정_응답 = categoryService.save(memberId, 우아한테크코스_외부_일정_생성_요청);
+        Category 우아한테크코스 = categoryRepository.getById(우아한테크코스_외부_일정_응답.getId());
+        externalCategoryDetailRepository.save(new ExternalCategoryDetail(우아한테크코스, "dfggsdfasdasadsgs"));
+
+        // when
+        MemberScheduleResponses memberScheduleResponses = subscribingSchedulesFinder.findMySubscribingSchedules(
+                memberId, new DateRangeRequest("2022-07-01T00:00", "2022-08-15T23:59"));
+
+        // then
+        assertAll(() -> {
+            assertThat(memberScheduleResponses.getLongTerms()).extracting(MemberScheduleResponse::getTitle)
+                    .contains("장기간 첫번째", "장기간 두번째", "장기간 세번째", "장기간 네번째", "장기간 다섯번째");
+            assertThat(memberScheduleResponses.getAllDays()).extracting(MemberScheduleResponse::getTitle)
+                    .contains("종일 첫번째", "종일 두번째", "종일 세번째");
+            assertThat(memberScheduleResponses.getFewHours()).extracting(MemberScheduleResponse::getTitle)
+                    .contains("몇시간 첫번째", "몇시간 두번째", "몇시간 세번째", "몇시간 네번째");
+        });
+    }
+}

--- a/backend/src/test/java/com/allog/dallog/domain/subscription/domain/SubscriptionsTest.java
+++ b/backend/src/test/java/com/allog/dallog/domain/subscription/domain/SubscriptionsTest.java
@@ -106,4 +106,42 @@ class SubscriptionsTest {
         // when & then
         assertThatThrownBy(() -> subscriptions.findColor(달록_여행)).isInstanceOf(NoSuchCategoryException.class);
     }
+
+    @DisplayName("구독한 카테고리중 내부 카테고리를 찾아 반환한다.")
+    @Test
+    void 구독한_카테고리중_내부_카테고리를_찾아_반환한다() {
+        // given
+        Member 파랑 = 파랑();
+        Category 공통_일정 = setId(공통_일정(파랑), 1L);
+        setId(BE_일정(파랑), 2L);
+
+        Subscription 공통_일정_구독 = new Subscription(파랑, 공통_일정, COLOR_1);
+
+        Subscriptions subscriptions = new Subscriptions(List.of(공통_일정_구독));
+
+        // when
+        List<Category> categories = subscriptions.findInternalCategory();
+
+        // then
+        assertThat(categories).hasSize(1);
+    }
+
+    @DisplayName("구독한 카테고리중 외부 카테고리를 찾아 반환한다.")
+    @Test
+    void 구독한_카테고리중_외부_카테고리를_찾아_반환한다() {
+        // given
+        Member 파랑 = 파랑();
+        Category 공통_일정 = setId(공통_일정(파랑), 1L);
+        setId(BE_일정(파랑), 2L);
+
+        Subscription 공통_일정_구독 = new Subscription(파랑, 공통_일정, COLOR_1);
+
+        Subscriptions subscriptions = new Subscriptions(List.of(공통_일정_구독));
+
+        // when
+        List<Category> categories = subscriptions.findExternalCategory();
+
+        // then
+        assertThat(categories).hasSize(0);
+    }
 }

--- a/backend/src/test/java/com/allog/dallog/domain/subscription/domain/SubscriptionsTest.java
+++ b/backend/src/test/java/com/allog/dallog/domain/subscription/domain/SubscriptionsTest.java
@@ -44,7 +44,7 @@ class SubscriptionsTest {
                 new Subscriptions(List.of(공통_일정_구독, BE_일정_구독, 내_일정_구독, 우아한테크코스_일정_구독));
 
         // when & then
-        assertThat(subscriptions.findCheckedCategoryIdsBy(Category::isInternal)).isEqualTo(List.of(1L, 3L));
+        assertThat(subscriptions.findInternalCategory()).isEqualTo(List.of(공통_일정, 내_일정));
     }
 
     @DisplayName("체크된 카테고리 중 외부 카테고리의 아이디를 찾는다.")
@@ -66,7 +66,7 @@ class SubscriptionsTest {
                 new Subscriptions(List.of(공통_일정_구독, BE_일정_구독, 내_일정_구독, 우아한테크코스_일정_구독));
 
         // when & then
-        assertThat(subscriptions.findCheckedCategoryIdsBy(Category::isExternal)).isEqualTo(List.of(4L));
+        assertThat(subscriptions.findExternalCategory()).isEqualTo(List.of(우아한테크코스_일정));
     }
 
     @DisplayName("특정 스케줄의 구독 색상을 찾는다.")

--- a/backend/src/test/java/com/allog/dallog/presentation/ScheduleControllerTest.java
+++ b/backend/src/test/java/com/allog/dallog/presentation/ScheduleControllerTest.java
@@ -35,6 +35,7 @@ import com.allog.dallog.domain.composition.application.SchedulerService;
 import com.allog.dallog.domain.externalcalendar.application.ExternalCalendarClient;
 import com.allog.dallog.domain.integrationschedule.dao.IntegrationScheduleDao;
 import com.allog.dallog.domain.schedule.application.ScheduleService;
+import com.allog.dallog.domain.schedule.application.SubscribingSchedulesFinder;
 import com.allog.dallog.domain.schedule.dto.request.ScheduleCreateRequest;
 import com.allog.dallog.domain.schedule.dto.request.ScheduleUpdateRequest;
 import com.allog.dallog.domain.schedule.dto.response.MemberScheduleResponse;
@@ -67,6 +68,9 @@ class ScheduleControllerTest extends ControllerTest {
 
     @MockBean
     private CalendarService calendarService;
+
+    @MockBean
+    private SubscribingSchedulesFinder subscribingSchedulesFinder;
 
     @MockBean
     private IntegrationScheduleDao integrationScheduleDao;
@@ -347,7 +351,7 @@ class ScheduleControllerTest extends ControllerTest {
         MemberScheduleResponses memberScheduleResponses = new MemberScheduleResponses(List.of(장기간_일정_1, 장기간_일정_2),
                 List.of(종일_일정_1, 종일_일정_2), List.of(짧은_일정_1, 짧은_일정_2));
 
-        given(calendarService.findSchedulesByMemberId(any(), any()))
+        given(subscribingSchedulesFinder.findMySubscribingSchedules(any(), any()))
                 .willReturn(memberScheduleResponses);
 
         // when & then


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 💻 git rebase를 사용했나요?
- [x] 🌈 알록달록한가요?

## 작업 내용

- CalenderService에서 월별 일정 조회 로직을 제거

--- 
몇가지 객체가 생겨서 주요한 변경점에 대해서 작성해보았습니다🙂

## 상세 작업 내용
###  1. `SubscribingSchedulesFinder` 객체 생성
네이밍은 좋은 네이밍은 아닌것 같군요..
**주요한 로직은 memberId를 기반으로 구독한 일정 한달치와 구글 캘린더에 있는일정 한달치를 가져오는 로직을 가지고 있습니다.**
구글 캘린더에 대한 트랜잭션 처리를 제거하는 작업을 처리하기 위해 상위 Service와 유사하게 생성하고 
`Schedule` 패키지 하위에 함께 두었습니다.

### 2. 월별 일정 조회 시 `IntegrationDao`가 아닌 `ScheduleRepository`에서 `integrationSchedule`을 생성하여 반환하도록 로직을 변경해보았습니다.
객체 id 가 아닌 객체를 기반으로 Repository에서 데이터를 가져오도록 구성해보기 위해 위와 같이 변경해보았습니다🙂

### 3. Entity간의 단방향 매핑만 고려하여 로직 생성
리팩터링을 하면서 양방향 매핑이 되어있으면 `domain`에게 더많은 책임을 줄 수 있는 부분들이 있었는데,
우선은 단방향 매핑만 고려하여 로직을 구성해보았습니다.
추후에, 양방향 매핑을 고려하여 리팩터링을 진행 해도 좋을것 같아요🙂

아직 고쳐야 할 부분이 많네요..!

Closes #600 
