### PR TITLE
[style] 달력의 전체 높이를 사용자 화면의 높이에 맞춘다.

### DIFF
--- a/frontend/src/pages/CalendarPage/CalendarPage.styles.ts
+++ b/frontend/src/pages/CalendarPage/CalendarPage.styles.ts
@@ -3,7 +3,7 @@ import { css, Theme } from '@emotion/react';
 import { DAYS } from '@/constants/date';
 
 const calendarPage = css`
-  padding: 0 5rem;
+  padding: 0 5rem 5rem;
 `;
 
 const calendarHeader = ({ colors, flex }: Theme) => css`
@@ -82,12 +82,14 @@ const navButtonTitle = ({ colors }: Theme) => css`
 const navBarGrid = css`
   display: grid;
   grid-template-columns: repeat(7, calc(100% / 7));
+
+  height: 7rem;
 `;
 
 const calendarGrid = (rowNum: number) => css`
   display: grid;
   grid-template-columns: repeat(7, calc(100% / 7));
-  grid-auto-rows: calc(75vh / ${rowNum});
+  grid-auto-rows: calc(calc(100vh - 42rem) / ${rowNum});
 `;
 
 const dayBar = ({ colors }: Theme, day: string) => css`


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 💻 git rebase를 사용했나요?
- [x] 🌈 알록달록한가요?

## 스크린샷

### 변경 전

<img width="1624" alt="변경 전 작은 화면" src="https://user-images.githubusercontent.com/52729559/191252274-9c4749f5-f2de-4eb0-a668-d89f1c34f6d9.png">

![변경 전 큰 화면](https://user-images.githubusercontent.com/52729559/191252446-90758b5f-1e06-4a3a-9ce1-3b9232eed263.png)

### 변경 후

<img width="1624" alt="변경 후 작은 화면" src="https://user-images.githubusercontent.com/52729559/191252203-b96048a2-87f5-46f4-b678-7cf35315200a.png">

![변경 후 큰 화면](https://user-images.githubusercontent.com/52729559/191252172-48307e47-2143-4867-9d51-7d2b0ae3c5ab.png)

## 주의사항

(이번 PR에 대한 주의사항은 아니지만 이번에 발견하게 돼서 알아두면 좋을 것 같아 남깁니다)

일정과 `일정 더보기`가 화면 크기가 바뀔 때마다 다르게 보이는데요!
지금은 사용자의 화면 크기가 바뀌어도 리렌더링이 일어나지 않아서 화면의 크기가 작아지면 일정이 넘치게 보일 때가 있네요 🥲

이건 추후 반응형 대응할 때 고려하면 좋을 것 같습니다~!

Closes #628 
