### PR TITLE
[refactor] 자신의 일정을 조회하는 기능을 개선한다. 

### DIFF
--- a/backend/src/main/java/com/allog/dallog/domain/schedule/application/CheckedSchedulesFinder.java
+++ b/backend/src/main/java/com/allog/dallog/domain/schedule/application/CheckedSchedulesFinder.java
@@ -7,7 +7,7 @@ import com.allog.dallog.domain.category.domain.ExternalCategoryDetail;
 import com.allog.dallog.domain.externalcalendar.application.ExternalCalendarClient;
 import com.allog.dallog.domain.schedule.domain.IntegrationSchedule;
 import com.allog.dallog.domain.schedule.domain.TypedSchedules;
-import com.allog.dallog.domain.schedule.dto.FindSchedulesMaterial;
+import com.allog.dallog.domain.schedule.dto.MaterialToFindSchedules;
 import com.allog.dallog.domain.schedule.dto.request.DateRangeRequest;
 import com.allog.dallog.domain.schedule.dto.response.MemberScheduleResponses;
 import java.time.format.DateTimeFormatter;
@@ -18,7 +18,7 @@ import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 
 @Service
-public class SubscribingSchedulesFinder {
+public class CheckedSchedulesFinder {
 
     private static final String DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss";
 
@@ -26,15 +26,15 @@ public class SubscribingSchedulesFinder {
     private final OAuthClient oAuthClient;
     private final ExternalCalendarClient externalCalendarClient;
 
-    public SubscribingSchedulesFinder(final ScheduleService scheduleService, final OAuthClient oAuthClient,
-                                      final ExternalCalendarClient externalCalendarClient) {
+    public CheckedSchedulesFinder(final ScheduleService scheduleService, final OAuthClient oAuthClient,
+                                  final ExternalCalendarClient externalCalendarClient) {
         this.scheduleService = scheduleService;
         this.oAuthClient = oAuthClient;
         this.externalCalendarClient = externalCalendarClient;
     }
 
-    public MemberScheduleResponses findMySubscribingSchedules(final Long memberId, final DateRangeRequest request) {
-        FindSchedulesMaterial material = scheduleService.findInternalByMemberIdAndDateRange(memberId, request);
+    public MemberScheduleResponses findMyCheckedSchedules(final Long memberId, final DateRangeRequest request) {
+        MaterialToFindSchedules material = scheduleService.findInternalByMemberIdAndDateRange(memberId, request);
 
         List<IntegrationSchedule> schedules = material.getSchedules();
 
@@ -53,7 +53,7 @@ public class SubscribingSchedulesFinder {
     }
 
     private List<IntegrationSchedule> toExternalSchedules(final DateRangeRequest request,
-                                                          final FindSchedulesMaterial material,
+                                                          final MaterialToFindSchedules material,
                                                           final String accessToken) {
         List<ExternalCategoryDetail> externalCategoryDetails = material.getExternalCategoryDetails();
         if (externalCategoryDetails.isEmpty()) {

--- a/backend/src/main/java/com/allog/dallog/domain/schedule/application/ScheduleService.java
+++ b/backend/src/main/java/com/allog/dallog/domain/schedule/application/ScheduleService.java
@@ -11,7 +11,7 @@ import com.allog.dallog.domain.member.domain.MemberRepository;
 import com.allog.dallog.domain.schedule.domain.IntegrationSchedule;
 import com.allog.dallog.domain.schedule.domain.Schedule;
 import com.allog.dallog.domain.schedule.domain.ScheduleRepository;
-import com.allog.dallog.domain.schedule.dto.FindSchedulesMaterial;
+import com.allog.dallog.domain.schedule.dto.MaterialToFindSchedules;
 import com.allog.dallog.domain.schedule.dto.request.DateRangeRequest;
 import com.allog.dallog.domain.schedule.dto.request.ScheduleCreateRequest;
 import com.allog.dallog.domain.schedule.dto.request.ScheduleUpdateRequest;
@@ -60,15 +60,15 @@ public class ScheduleService {
         return new ScheduleResponse(schedule);
     }
 
-    public FindSchedulesMaterial findInternalByMemberIdAndDateRange(final Long memberId,
-                                                                    final DateRangeRequest request) {
+    public MaterialToFindSchedules findInternalByMemberIdAndDateRange(final Long memberId,
+                                                                      final DateRangeRequest request) {
         Subscriptions subscriptions = new Subscriptions(subscriptionRepository.findByMemberId(memberId));
         List<IntegrationSchedule> schedules = toIntegrationSchedules(subscriptions, request);
 
         String refreshToken = toRefreshToken(memberId);
         List<ExternalCategoryDetail> externalCategoryDetails = toCategoryDetails(subscriptions);
 
-        return new FindSchedulesMaterial(subscriptions, schedules, refreshToken, externalCategoryDetails);
+        return new MaterialToFindSchedules(subscriptions, schedules, refreshToken, externalCategoryDetails);
     }
 
     private String toRefreshToken(final Long memberId) {

--- a/backend/src/main/java/com/allog/dallog/domain/schedule/dto/FindSchedulesMaterial.java
+++ b/backend/src/main/java/com/allog/dallog/domain/schedule/dto/FindSchedulesMaterial.java
@@ -1,0 +1,40 @@
+package com.allog.dallog.domain.schedule.dto;
+
+import com.allog.dallog.domain.category.domain.ExternalCategoryDetail;
+import com.allog.dallog.domain.schedule.domain.IntegrationSchedule;
+import com.allog.dallog.domain.subscription.domain.Subscriptions;
+import java.util.ArrayList;
+import java.util.List;
+
+public class FindSchedulesMaterial {
+
+    private final Subscriptions subscriptions;
+    private final List<IntegrationSchedule> schedules;
+    private final String refreshToken;
+    private final List<ExternalCategoryDetail> externalCategoryDetails;
+
+    public FindSchedulesMaterial(final Subscriptions subscriptions, final List<IntegrationSchedule> schedules,
+                                 final String refreshToken,
+                                 final List<ExternalCategoryDetail> externalCategoryDetails) {
+        this.subscriptions = subscriptions;
+        this.schedules = new ArrayList<>(schedules);
+        this.refreshToken = refreshToken;
+        this.externalCategoryDetails = new ArrayList<>(externalCategoryDetails);
+    }
+
+    public Subscriptions getSubscriptions() {
+        return subscriptions;
+    }
+
+    public List<IntegrationSchedule> getSchedules() {
+        return schedules;
+    }
+
+    public String getRefreshToken() {
+        return refreshToken;
+    }
+
+    public List<ExternalCategoryDetail> getExternalCategoryDetails() {
+        return externalCategoryDetails;
+    }
+}

--- a/backend/src/main/java/com/allog/dallog/domain/schedule/dto/MaterialToFindSchedules.java
+++ b/backend/src/main/java/com/allog/dallog/domain/schedule/dto/MaterialToFindSchedules.java
@@ -6,16 +6,16 @@ import com.allog.dallog.domain.subscription.domain.Subscriptions;
 import java.util.ArrayList;
 import java.util.List;
 
-public class FindSchedulesMaterial {
+public class MaterialToFindSchedules {
 
     private final Subscriptions subscriptions;
     private final List<IntegrationSchedule> schedules;
     private final String refreshToken;
     private final List<ExternalCategoryDetail> externalCategoryDetails;
 
-    public FindSchedulesMaterial(final Subscriptions subscriptions, final List<IntegrationSchedule> schedules,
-                                 final String refreshToken,
-                                 final List<ExternalCategoryDetail> externalCategoryDetails) {
+    public MaterialToFindSchedules(final Subscriptions subscriptions, final List<IntegrationSchedule> schedules,
+                                   final String refreshToken,
+                                   final List<ExternalCategoryDetail> externalCategoryDetails) {
         this.subscriptions = subscriptions;
         this.schedules = new ArrayList<>(schedules);
         this.refreshToken = refreshToken;

--- a/backend/src/main/java/com/allog/dallog/presentation/ScheduleController.java
+++ b/backend/src/main/java/com/allog/dallog/presentation/ScheduleController.java
@@ -1,8 +1,8 @@
 package com.allog.dallog.presentation;
 
 import com.allog.dallog.domain.auth.dto.LoginMember;
+import com.allog.dallog.domain.schedule.application.CheckedSchedulesFinder;
 import com.allog.dallog.domain.schedule.application.ScheduleService;
-import com.allog.dallog.domain.schedule.application.SubscribingSchedulesFinder;
 import com.allog.dallog.domain.schedule.dto.request.DateRangeRequest;
 import com.allog.dallog.domain.schedule.dto.request.ScheduleCreateRequest;
 import com.allog.dallog.domain.schedule.dto.request.ScheduleUpdateRequest;
@@ -27,12 +27,12 @@ import org.springframework.web.bind.annotation.RestController;
 public class ScheduleController {
 
     private final ScheduleService scheduleService;
-    private final SubscribingSchedulesFinder subscribingSchedulesFinder;
+    private final CheckedSchedulesFinder checkedSchedulesFinder;
 
     public ScheduleController(final ScheduleService scheduleService,
-                              final SubscribingSchedulesFinder subscribingSchedulesFinder) {
+                              final CheckedSchedulesFinder checkedSchedulesFinder) {
         this.scheduleService = scheduleService;
-        this.subscribingSchedulesFinder = subscribingSchedulesFinder;
+        this.checkedSchedulesFinder = checkedSchedulesFinder;
     }
 
     @PostMapping("/categories/{categoryId}/schedules")
@@ -44,10 +44,9 @@ public class ScheduleController {
     }
 
     @GetMapping("/members/me/schedules")
-    public ResponseEntity<MemberScheduleResponses> findMySubscribingSchedules(
+    public ResponseEntity<MemberScheduleResponses> findMyCheckedSchedules(
             @AuthenticationPrincipal final LoginMember loginMember, @ModelAttribute DateRangeRequest request) {
-        MemberScheduleResponses response = subscribingSchedulesFinder
-                .findMySubscribingSchedules(loginMember.getId(), request);
+        MemberScheduleResponses response = checkedSchedulesFinder.findMyCheckedSchedules(loginMember.getId(), request);
         return ResponseEntity.ok(response);
     }
 

--- a/backend/src/test/java/com/allog/dallog/domain/schedule/application/CheckedSchedulesFinderTest.java
+++ b/backend/src/test/java/com/allog/dallog/domain/schedule/application/CheckedSchedulesFinderTest.java
@@ -37,10 +37,10 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-class SubscribingSchedulesFinderTest extends ServiceTest {
+class CheckedSchedulesFinderTest extends ServiceTest {
 
     @Autowired
-    private SubscribingSchedulesFinder subscribingSchedulesFinder;
+    private CheckedSchedulesFinder checkedSchedulesFinder;
 
     @Autowired
     private CategoryService categoryService;
@@ -98,7 +98,7 @@ class SubscribingSchedulesFinderTest extends ServiceTest {
         externalCategoryDetailRepository.save(new ExternalCategoryDetail(우아한테크코스, "dfggsdfasdasadsgs"));
 
         // when
-        MemberScheduleResponses memberScheduleResponses = subscribingSchedulesFinder.findMySubscribingSchedules(
+        MemberScheduleResponses memberScheduleResponses = checkedSchedulesFinder.findMyCheckedSchedules(
                 memberId, new DateRangeRequest("2022-07-01T00:00", "2022-08-15T23:59"));
 
         // then

--- a/backend/src/test/java/com/allog/dallog/domain/schedule/application/ScheduleServiceTest.java
+++ b/backend/src/test/java/com/allog/dallog/domain/schedule/application/ScheduleServiceTest.java
@@ -206,7 +206,7 @@ class ScheduleServiceTest extends ServiceTest {
 
         // when
         List<IntegrationSchedule> schedules = scheduleService.findInternalByMemberIdAndDateRange(리버_id,
-                new DateRangeRequest("2022-07-01T00:00", "2022-08-15T23:59"));
+                new DateRangeRequest("2022-07-01T00:00", "2022-08-15T23:59")).getSchedules();
 
         // then
         assertThat(schedules).hasSize(2);

--- a/backend/src/test/java/com/allog/dallog/presentation/ScheduleControllerTest.java
+++ b/backend/src/test/java/com/allog/dallog/presentation/ScheduleControllerTest.java
@@ -30,8 +30,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.allog.dallog.domain.auth.application.AuthService;
 import com.allog.dallog.domain.auth.exception.NoPermissionException;
 import com.allog.dallog.domain.category.exception.NoSuchCategoryException;
+import com.allog.dallog.domain.schedule.application.CheckedSchedulesFinder;
 import com.allog.dallog.domain.schedule.application.ScheduleService;
-import com.allog.dallog.domain.schedule.application.SubscribingSchedulesFinder;
 import com.allog.dallog.domain.schedule.dto.request.ScheduleCreateRequest;
 import com.allog.dallog.domain.schedule.dto.request.ScheduleUpdateRequest;
 import com.allog.dallog.domain.schedule.dto.response.MemberScheduleResponse;
@@ -60,7 +60,7 @@ class ScheduleControllerTest extends ControllerTest {
     private ScheduleService scheduleService;
 
     @MockBean
-    private SubscribingSchedulesFinder subscribingSchedulesFinder;
+    private CheckedSchedulesFinder checkedSchedulesFinder;
 
     @DisplayName("일정 정보를 등록하면 상태코드 201을 반환한다.")
     @Test
@@ -341,7 +341,7 @@ class ScheduleControllerTest extends ControllerTest {
         MemberScheduleResponses memberScheduleResponses = new MemberScheduleResponses(List.of(장기간_일정_1, 장기간_일정_2),
                 List.of(종일_일정_1, 종일_일정_2), List.of(짧은_일정_1, 짧은_일정_2));
 
-        given(subscribingSchedulesFinder.findMySubscribingSchedules(any(), any()))
+        given(checkedSchedulesFinder.findMyCheckedSchedules(any(), any()))
                 .willReturn(memberScheduleResponses);
 
         // when & then


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 💻 git rebase를 사용했나요?
- [x] 🌈 알록달록한가요?

## 작업 내용

불필요하게 잡고 있던 트랜잭션 시간을 최소화하기 위해 개선하였습니다.

```java
@Service
public class SubscribingSchedulesFinder {
    ...
    public MemberScheduleResponses findMySubscribingSchedules(final Long memberId, final DateRangeRequest request) {
        // Transaction 시작
        FindSchedulesMaterial material = scheduleService.findInternalByMemberIdAndDateRange(memberId, request);
        // Transaction 끝

        List<IntegrationSchedule> schedules = material.getSchedules();

        String refreshToken = material.getRefreshToken();
        String accessToken = toAccessToken(refreshToken);

        List<IntegrationSchedule> externalSchedules = toExternalSchedules(request, material, accessToken);
        schedules.addAll(externalSchedules);

        return new MemberScheduleResponses(material.getSubscriptions(), new TypedSchedules(schedules));
    }
    ...
}
```

## 스크린샷

## 주의사항

Closes #652 
