### PR TITLE
[refactor] 토큰 발급시 AccessToken과 RefreshToken을 모두 발급한다.

### DIFF
--- a/backend/src/main/java/com/allog/dallog/domain/auth/application/AuthService.java
+++ b/backend/src/main/java/com/allog/dallog/domain/auth/application/AuthService.java
@@ -68,8 +68,8 @@ public class AuthService {
         return createTokenResponse(foundMember);
     }
 
-    private TokenResponse createTokenResponse(final Member foundMember) {
-        Long memberId = foundMember.getId();
+    private TokenResponse createTokenResponse(final Member member) {
+        Long memberId = member.getId();
         String accessToken = tokenProvider.createToken(String.valueOf(memberId));
 
         if (InMemoryTokenRepository.exist(memberId)) {

--- a/backend/src/main/java/com/allog/dallog/domain/auth/application/AuthService.java
+++ b/backend/src/main/java/com/allog/dallog/domain/auth/application/AuthService.java
@@ -2,9 +2,9 @@ package com.allog.dallog.domain.auth.application;
 
 import static com.allog.dallog.domain.category.domain.CategoryType.PERSONAL;
 
-import com.allog.dallog.domain.auth.domain.InMemoryTokenRepository;
 import com.allog.dallog.domain.auth.domain.OAuthToken;
 import com.allog.dallog.domain.auth.domain.OAuthTokenRepository;
+import com.allog.dallog.domain.auth.domain.TokenRepository;
 import com.allog.dallog.domain.auth.dto.OAuthMember;
 import com.allog.dallog.domain.auth.dto.request.TokenRequest;
 import com.allog.dallog.domain.auth.dto.response.TokenResponse;
@@ -34,12 +34,13 @@ public class AuthService {
     private final OAuthClient oAuthClient;
     private final TokenProvider tokenProvider;
     private final ColorPicker colorPicker;
+    private final TokenRepository tokenRepository;
 
     public AuthService(final MemberRepository memberRepository, final CategoryRepository categoryRepository,
                        final OAuthTokenRepository oAuthTokenRepository,
                        final SubscriptionRepository subscriptionRepository, final OAuthUri oAuthUri,
                        final OAuthClient oAuthClient, final TokenProvider tokenProvider,
-                       final ColorPicker colorPicker) {
+                       final ColorPicker colorPicker, final TokenRepository tokenRepository) {
         this.memberRepository = memberRepository;
         this.categoryRepository = categoryRepository;
         this.oAuthTokenRepository = oAuthTokenRepository;
@@ -48,6 +49,7 @@ public class AuthService {
         this.oAuthClient = oAuthClient;
         this.tokenProvider = tokenProvider;
         this.colorPicker = colorPicker;
+        this.tokenRepository = tokenRepository;
     }
 
     public String generateGoogleLink(final String redirectUri) {
@@ -72,13 +74,13 @@ public class AuthService {
         Long memberId = member.getId();
         String accessToken = tokenProvider.createToken(String.valueOf(memberId));
 
-        if (InMemoryTokenRepository.exist(memberId)) {
-            String refreshToken = InMemoryTokenRepository.getToken(memberId);
+        if (tokenRepository.exist(memberId)) {
+            String refreshToken = tokenRepository.getToken(memberId);
             return new TokenResponse(accessToken, refreshToken);
         }
 
         String refreshToken = tokenProvider.createToken(String.valueOf(memberId));
-        InMemoryTokenRepository.save(memberId, refreshToken);
+        tokenRepository.save(memberId, refreshToken);
         return new TokenResponse(accessToken, refreshToken);
     }
 

--- a/backend/src/main/java/com/allog/dallog/domain/auth/domain/InMemoryTokenRepository.java
+++ b/backend/src/main/java/com/allog/dallog/domain/auth/domain/InMemoryTokenRepository.java
@@ -1,0 +1,25 @@
+package com.allog.dallog.domain.auth.domain;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class InMemoryTokenRepository {
+
+    private final static Map<Long, String> TokenRepository = new HashMap<>();
+
+    public static void save(final Long memberId, final String refreshToken) {
+        TokenRepository.put(memberId, refreshToken);
+    }
+
+    public static boolean exist(final Long memberId) {
+        return TokenRepository.containsKey(memberId);
+    }
+
+    public static String getToken(final Long memberId) {
+        return TokenRepository.get(memberId);
+    }
+
+    public static void deleteAll() {
+        TokenRepository.clear();
+    }
+}

--- a/backend/src/main/java/com/allog/dallog/domain/auth/domain/InMemoryTokenRepository.java
+++ b/backend/src/main/java/com/allog/dallog/domain/auth/domain/InMemoryTokenRepository.java
@@ -2,24 +2,30 @@ package com.allog.dallog.domain.auth.domain;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import org.springframework.stereotype.Component;
 
-public class InMemoryTokenRepository {
+@Component
+public class InMemoryTokenRepository implements TokenRepository {
 
     private static final Map<Long, String> TOKEN_REPOSITORY = new ConcurrentHashMap<>();
 
-    public static void save(final Long memberId, final String refreshToken) {
+    @Override
+    public void save(final Long memberId, final String refreshToken) {
         TOKEN_REPOSITORY.put(memberId, refreshToken);
     }
 
-    public static boolean exist(final Long memberId) {
+    @Override
+    public void deleteAll() {
+        TOKEN_REPOSITORY.clear();
+    }
+
+    @Override
+    public boolean exist(final Long memberId) {
         return TOKEN_REPOSITORY.containsKey(memberId);
     }
 
-    public static String getToken(final Long memberId) {
+    @Override
+    public String getToken(final Long memberId) {
         return TOKEN_REPOSITORY.get(memberId);
-    }
-
-    public static void deleteAll() {
-        TOKEN_REPOSITORY.clear();
     }
 }

--- a/backend/src/main/java/com/allog/dallog/domain/auth/domain/InMemoryTokenRepository.java
+++ b/backend/src/main/java/com/allog/dallog/domain/auth/domain/InMemoryTokenRepository.java
@@ -1,25 +1,25 @@
 package com.allog.dallog.domain.auth.domain;
 
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class InMemoryTokenRepository {
 
-    private final static Map<Long, String> TokenRepository = new HashMap<>();
+    private static final Map<Long, String> TOKEN_REPOSITORY = new ConcurrentHashMap<>();
 
     public static void save(final Long memberId, final String refreshToken) {
-        TokenRepository.put(memberId, refreshToken);
+        TOKEN_REPOSITORY.put(memberId, refreshToken);
     }
 
     public static boolean exist(final Long memberId) {
-        return TokenRepository.containsKey(memberId);
+        return TOKEN_REPOSITORY.containsKey(memberId);
     }
 
     public static String getToken(final Long memberId) {
-        return TokenRepository.get(memberId);
+        return TOKEN_REPOSITORY.get(memberId);
     }
 
     public static void deleteAll() {
-        TokenRepository.clear();
+        TOKEN_REPOSITORY.clear();
     }
 }

--- a/backend/src/main/java/com/allog/dallog/domain/auth/domain/TokenRepository.java
+++ b/backend/src/main/java/com/allog/dallog/domain/auth/domain/TokenRepository.java
@@ -1,0 +1,12 @@
+package com.allog.dallog.domain.auth.domain;
+
+public interface TokenRepository {
+
+    void save(final Long memberId, final String refreshToken);
+
+    void deleteAll();
+
+    boolean exist(final Long memberId);
+
+    String getToken(final Long memberId);
+}

--- a/backend/src/main/java/com/allog/dallog/domain/auth/dto/response/TokenResponse.java
+++ b/backend/src/main/java/com/allog/dallog/domain/auth/dto/response/TokenResponse.java
@@ -3,15 +3,21 @@ package com.allog.dallog.domain.auth.dto.response;
 public class TokenResponse {
 
     private String accessToken;
+    private String refreshToken;
 
     private TokenResponse() {
     }
 
-    public TokenResponse(final String accessToken) {
+    public TokenResponse(final String accessToken, final String refreshToken) {
         this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
     }
 
     public String getAccessToken() {
         return accessToken;
+    }
+
+    public String getRefreshToken() {
+        return refreshToken;
     }
 }

--- a/backend/src/test/java/com/allog/dallog/acceptance/AuthAcceptanceTest.java
+++ b/backend/src/test/java/com/allog/dallog/acceptance/AuthAcceptanceTest.java
@@ -49,6 +49,7 @@ public class AuthAcceptanceTest extends AcceptanceTest {
         assertAll(() -> {
             상태코드_200이_반환된다(response);
             assertThat(tokenResponse.getAccessToken()).isNotEmpty();
+            assertThat(tokenResponse.getRefreshToken()).isNotEmpty();
         });
     }
 

--- a/backend/src/test/java/com/allog/dallog/common/config/TokenConfig.java
+++ b/backend/src/test/java/com/allog/dallog/common/config/TokenConfig.java
@@ -4,6 +4,8 @@ import static com.allog.dallog.common.fixtures.AuthFixtures.더미_시크릿_키
 
 import com.allog.dallog.domain.auth.application.StubTokenProvider;
 import com.allog.dallog.domain.auth.application.TokenProvider;
+import com.allog.dallog.domain.auth.domain.InMemoryTokenRepository;
+import com.allog.dallog.domain.auth.domain.TokenRepository;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 
@@ -13,5 +15,10 @@ public class TokenConfig {
     @Bean
     public TokenProvider tokenProvider() {
         return new StubTokenProvider(더미_시크릿_키);
+    }
+
+    @Bean
+    public TokenRepository tokenRepository() {
+        return new InMemoryTokenRepository();
     }
 }

--- a/backend/src/test/java/com/allog/dallog/common/config/TokenConfig.java
+++ b/backend/src/test/java/com/allog/dallog/common/config/TokenConfig.java
@@ -16,9 +16,4 @@ public class TokenConfig {
     public TokenProvider tokenProvider() {
         return new StubTokenProvider(더미_시크릿_키);
     }
-
-    @Bean
-    public TokenRepository tokenRepository() {
-        return new InMemoryTokenRepository();
-    }
 }

--- a/backend/src/test/java/com/allog/dallog/common/fixtures/AuthFixtures.java
+++ b/backend/src/test/java/com/allog/dallog/common/fixtures/AuthFixtures.java
@@ -15,6 +15,7 @@ public class AuthFixtures {
     public static final String OAUTH_PROVIDER = "oauthProvider";
 
     public static final String STUB_MEMBER_인증_코드 = "member authorization code";
+    public static final String STUB_MEMBER_REFRESH_인증_코드 = "member refresh authorization code";
     public static final String STUB_CREATOR_인증_코드 = "creator authorization code";
 
     public static final String 더미_엑세스_토큰 = "aaaaa.bbbbb.ccccc";
@@ -60,7 +61,7 @@ public class AuthFixtures {
     }
 
     public static TokenResponse MEMBER_인증_코드_토큰_응답() {
-        return new TokenResponse(STUB_MEMBER_인증_코드);
+        return new TokenResponse(STUB_MEMBER_인증_코드, STUB_MEMBER_REFRESH_인증_코드);
     }
 
 

--- a/backend/src/test/java/com/allog/dallog/domain/auth/application/AuthServiceTest.java
+++ b/backend/src/test/java/com/allog/dallog/domain/auth/application/AuthServiceTest.java
@@ -35,13 +35,14 @@ class AuthServiceTest extends ServiceTest {
 
     @DisplayName("토큰 생성을 하면 OAuth 서버에서 인증 후 토큰을 반환한다")
     @Test
-    void 토큰_생성을_하면_OAuth_서버에서_인증_후_토큰을_반환한다() {
+    void 토큰_생성을_하면_OAuth_서버에서_인증_후_토큰들을_반환한다() {
         // given & when
         TokenRequest tokenRequest = new TokenRequest(STUB_MEMBER_인증_코드, "https://dallog.me/oauth");
         TokenResponse actual = authService.generateToken(tokenRequest);
 
         // then
         assertThat(actual.getAccessToken()).isNotEmpty();
+        assertThat(actual.getRefreshToken()).isNotEmpty();
     }
 
     @DisplayName("Authorization Code를 받으면 회원이 데이터베이스에 저장된다.")
@@ -65,11 +66,27 @@ class AuthServiceTest extends ServiceTest {
         TokenRequest tokenRequest = new TokenRequest(STUB_MEMBER_인증_코드, "https://dallog.me/oauth");
         authService.generateToken(tokenRequest);
 
-        // when & then
+        // when
         authService.generateToken(tokenRequest);
         List<Member> actual = memberRepository.findAll();
 
         // then
         assertThat(actual).hasSize(1);
+    }
+
+    @DisplayName("이미 가입된 회원이고 저장된 RefreshToken이 있으면, 저장된 RefreshToken을 반환한다.")
+    @Test
+    void 이미_가입된_회원이고_저장된_RefreshToken이_있으면_저장된_RefreshToken을_반환한다() {
+        // 이미 가입된 유저가 소셜 로그인 버튼을 클릭했을 경우엔 회원가입 과정이 생략되고, 곧바로 access token과 refreshtoken이 발급되어야 한다.
+
+        // given
+        TokenRequest tokenRequest = new TokenRequest(STUB_MEMBER_인증_코드, "https://dallog.me/oauth");
+        TokenResponse tokenResponse = authService.generateToken(tokenRequest);
+
+        // when
+        TokenResponse actual = authService.generateToken(tokenRequest);
+
+        // then
+        assertThat(actual.getRefreshToken()).isEqualTo(tokenResponse.getRefreshToken());
     }
 }

--- a/backend/src/test/java/com/allog/dallog/domain/auth/application/AuthServiceTest.java
+++ b/backend/src/test/java/com/allog/dallog/domain/auth/application/AuthServiceTest.java
@@ -3,6 +3,7 @@ package com.allog.dallog.domain.auth.application;
 import static com.allog.dallog.common.fixtures.AuthFixtures.MEMBER_이메일;
 import static com.allog.dallog.common.fixtures.AuthFixtures.STUB_MEMBER_인증_코드;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.allog.dallog.common.annotation.ServiceTest;
 import com.allog.dallog.domain.auth.dto.request.TokenRequest;
@@ -41,8 +42,10 @@ class AuthServiceTest extends ServiceTest {
         TokenResponse actual = authService.generateToken(tokenRequest);
 
         // then
-        assertThat(actual.getAccessToken()).isNotEmpty();
-        assertThat(actual.getRefreshToken()).isNotEmpty();
+        assertAll(() -> {
+            assertThat(actual.getAccessToken()).isNotEmpty();
+            assertThat(actual.getRefreshToken()).isNotEmpty();
+        });
     }
 
     @DisplayName("Authorization Code를 받으면 회원이 데이터베이스에 저장된다.")

--- a/backend/src/test/java/com/allog/dallog/domain/auth/domain/InMemoryTokenRepositoryTest.java
+++ b/backend/src/test/java/com/allog/dallog/domain/auth/domain/InMemoryTokenRepositoryTest.java
@@ -2,15 +2,24 @@ package com.allog.dallog.domain.auth.domain;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.allog.dallog.common.config.ExternalApiConfig;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
+@SpringBootTest(classes = ExternalApiConfig.class)
+@ActiveProfiles("test")
 class InMemoryTokenRepositoryTest {
+
+    @Autowired
+    private TokenRepository tokenRepository;
 
     @AfterEach
     void setUp() {
-        InMemoryTokenRepository.deleteAll();
+        tokenRepository.deleteAll();
     }
 
     @DisplayName("토큰을 저장한다.")
@@ -21,10 +30,10 @@ class InMemoryTokenRepositoryTest {
         String dummyRefreshToken = "dummy token";
 
         // when
-        InMemoryTokenRepository.save(dummyMemberId, dummyRefreshToken);
+        tokenRepository.save(dummyMemberId, dummyRefreshToken);
 
         // then
-        assertThat(InMemoryTokenRepository.getToken(dummyMemberId)).isEqualTo(dummyRefreshToken);
+        assertThat(tokenRepository.getToken(dummyMemberId)).isEqualTo(dummyRefreshToken);
     }
 
     @DisplayName("MemberId에 해당하는 토큰이 있으면 true를 반환한다.")
@@ -33,10 +42,10 @@ class InMemoryTokenRepositoryTest {
         // given
         Long dummyMemberId = 1L;
         String dummyRefreshToken = "dummy token";
-        InMemoryTokenRepository.save(dummyMemberId, dummyRefreshToken);
+        tokenRepository.save(dummyMemberId, dummyRefreshToken);
 
         // when
-        boolean actual = InMemoryTokenRepository.exist(dummyMemberId);
+        boolean actual = tokenRepository.exist(dummyMemberId);
 
         // then
         assertThat(actual).isTrue();
@@ -50,7 +59,7 @@ class InMemoryTokenRepositoryTest {
         String dummyRefreshToken = "dummy token";
 
         // when
-        boolean actual = InMemoryTokenRepository.exist(dummyMemberId);
+        boolean actual = tokenRepository.exist(dummyMemberId);
 
         // then
         assertThat(actual).isFalse();
@@ -62,10 +71,10 @@ class InMemoryTokenRepositoryTest {
         // given
         Long dummyMemberId = 1L;
         String dummyRefreshToken = "dummy token";
-        InMemoryTokenRepository.save(dummyMemberId, dummyRefreshToken);
+        tokenRepository.save(dummyMemberId, dummyRefreshToken);
 
         // when
-        String actual = InMemoryTokenRepository.getToken(dummyMemberId);
+        String actual = tokenRepository.getToken(dummyMemberId);
 
         // then
         assertThat(actual).isEqualTo(dummyRefreshToken);

--- a/backend/src/test/java/com/allog/dallog/domain/auth/domain/InMemoryTokenRepositoryTest.java
+++ b/backend/src/test/java/com/allog/dallog/domain/auth/domain/InMemoryTokenRepositoryTest.java
@@ -1,0 +1,73 @@
+package com.allog.dallog.domain.auth.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class InMemoryTokenRepositoryTest {
+
+    @AfterEach
+    void setUp() {
+        InMemoryTokenRepository.deleteAll();
+    }
+
+    @DisplayName("토큰을 저장한다.")
+    @Test
+    void 토큰을_저장한다() {
+        // given
+        Long dummyMemberId = 1L;
+        String dummyRefreshToken = "dummy token";
+
+        // when
+        InMemoryTokenRepository.save(dummyMemberId, dummyRefreshToken);
+
+        // then
+        assertThat(InMemoryTokenRepository.getToken(dummyMemberId)).isEqualTo(dummyRefreshToken);
+    }
+
+    @DisplayName("MemberId에 해당하는 토큰이 있으면 true를 반환한다.")
+    @Test
+    void MemberId에_해당하는_토큰이_있으면_true를_반환한다() {
+        // given
+        Long dummyMemberId = 1L;
+        String dummyRefreshToken = "dummy token";
+        InMemoryTokenRepository.save(dummyMemberId, dummyRefreshToken);
+
+        // when
+        boolean actual = InMemoryTokenRepository.exist(dummyMemberId);
+
+        // then
+        assertThat(actual).isTrue();
+    }
+
+    @DisplayName("MemberId에 해당하는 토큰이 없으면 false를 반환한다.")
+    @Test
+    void MemberId에_해당하는_토큰이_없으면_false를_반환한다() {
+        // given
+        Long dummyMemberId = 1L;
+        String dummyRefreshToken = "dummy token";
+
+        // when
+        boolean actual = InMemoryTokenRepository.exist(dummyMemberId);
+
+        // then
+        assertThat(actual).isFalse();
+    }
+
+    @DisplayName("MemberId에 해당하는 토큰을 가져온다.")
+    @Test
+    void MemberId에_해당하는_토큰을_가져온다() {
+        // given
+        Long dummyMemberId = 1L;
+        String dummyRefreshToken = "dummy token";
+        InMemoryTokenRepository.save(dummyMemberId, dummyRefreshToken);
+
+        // when
+        String actual = InMemoryTokenRepository.getToken(dummyMemberId);
+
+        // then
+        assertThat(actual).isEqualTo(dummyRefreshToken);
+    }
+}

--- a/backend/src/test/java/com/allog/dallog/presentation/AuthControllerTest.java
+++ b/backend/src/test/java/com/allog/dallog/presentation/AuthControllerTest.java
@@ -88,7 +88,8 @@ class AuthControllerTest extends ControllerTest {
                                         .description("OAuth Redirect URI")
                         ),
                         responseFields(
-                                fieldWithPath("accessToken").type(JsonFieldType.STRING).description("달록 Access Token")
+                                fieldWithPath("accessToken").type(JsonFieldType.STRING).description("달록 Access Token"),
+                                fieldWithPath("refreshToken").type(JsonFieldType.STRING).description("달록 Refresh Token")
                         )
                 ))
                 .andExpect(status().isOk());


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 💻 git rebase를 사용했나요?
- [x] 🌈 알록달록한가요?

## 작업 내용

- 토큰 발급 요청시, 엑세스 토큰과 리프레시 토큰을 모두 발급 
- InMemoryTokenRepository를 통해 리프레시 토큰 발급

## 주의사항
- 우선은 적은 FileChanged를 유지하기 위해서 JwtTokenProvider를 통해 RefreshToken도 발급하도록 하였습니다.
- 토큰 발급시 RefreshToken을 InMemoryDb로 저장하도록 하였습니다.

Closes #677 
