### PR TITLE
[feat] 카테고리 역할 수정 API를 개발한다.

### DIFF
--- a/backend/src/docs/asciidoc/category.adoc
+++ b/backend/src/docs/asciidoc/category.adoc
@@ -131,3 +131,43 @@ include::{snippets}/category/delete/http-response.adoc[]
 ==== HTTP Response
 
 include::{snippets}/category/delete/failByNoCategory/http-response.adoc[]
+
+=== 카테고리 역할 수정
+
+역할이 ADMIN인 회원은 카테고리 구독자(일반 구독자, 관리자, 자기자신 모두 포함)의 역할을 수정할 수 있습니다.
+
+==== HTTP Request
+
+include::{snippets}/category/updateRole/http-request.adoc[]
+
+==== Path Parameters
+
+include::{snippets}/category/updateRole/path-parameters.adoc[]
+
+==== HTTP Response
+
+include::{snippets}/category/updateRole/http-response.adoc[]
+
+=== 카테고리 역할 수정 (권한이 없는 경우)
+
+역할이 ADMIN인 경우만 구독자의 역할을 수정할 수 있습니다.
+
+==== HTTP Response
+
+include::{snippets}/category/updateRole/failByNoPermission/http-response.adoc[]
+
+=== 카테고리 역할 수정 (구독을 하지 않은 경우)
+
+카테고리 역할 수정 대상의 회원이 해당 카테고리를 구독하지 않은 상태인경우 역할 또한 존재하지 않으므로 역할을 찾을 수 없습니다.
+
+==== HTTP Response
+
+include::{snippets}/category/updateRole/failByCategoryRoleNotFound/http-response.adoc[]
+
+=== 카테고리 역할 수정 (자신의 역할 수정시, 자신이 유일한 ADMIN인 경우)
+
+자기자신의 카테고리 역할 수정시 자신이 해당 카테고리의 유일한 ADMIN인 경우 역할을 변경할 수 없습니다.
+
+==== HTTP Response
+
+include::{snippets}/category/updateRole/failBySoleAdmin/http-response.adoc[]

--- a/backend/src/main/java/com/allog/dallog/domain/category/application/CategoryService.java
+++ b/backend/src/main/java/com/allog/dallog/domain/category/application/CategoryService.java
@@ -13,7 +13,9 @@ import com.allog.dallog.domain.category.dto.request.ExternalCategoryCreateReques
 import com.allog.dallog.domain.category.dto.response.CategoriesResponse;
 import com.allog.dallog.domain.category.dto.response.CategoryResponse;
 import com.allog.dallog.domain.category.exception.InvalidCategoryException;
+import com.allog.dallog.domain.categoryrole.domain.CategoryRole;
 import com.allog.dallog.domain.categoryrole.domain.CategoryRoleRepository;
+import com.allog.dallog.domain.categoryrole.domain.CategoryRoleType;
 import com.allog.dallog.domain.member.domain.Member;
 import com.allog.dallog.domain.member.domain.MemberRepository;
 import com.allog.dallog.domain.schedule.domain.ScheduleRepository;
@@ -57,13 +59,20 @@ public class CategoryService {
         Member member = memberRepository.getById(memberId);
         Category category = request.toEntity(member);
         Category savedCategory = categoryRepository.save(category);
+
         subscribeCategory(member, category);
+        createCategoryRoleAsAdminToCreator(member, category);
         return new CategoryResponse(savedCategory);
     }
 
     private void subscribeCategory(final Member member, final Category category) {
         Color color = Color.pick(colorPicker.pickNumber());
         subscriptionRepository.save(new Subscription(member, category, color));
+    }
+
+    private void createCategoryRoleAsAdminToCreator(final Member member, final Category category) {
+        CategoryRole categoryRole = new CategoryRole(category, member, CategoryRoleType.ADMIN);
+        categoryRoleRepository.save(categoryRole);
     }
 
     @Transactional

--- a/backend/src/main/java/com/allog/dallog/domain/categoryrole/application/CategoryRoleService.java
+++ b/backend/src/main/java/com/allog/dallog/domain/categoryrole/application/CategoryRoleService.java
@@ -37,8 +37,8 @@ public class CategoryRoleService {
         loginMemberCategoryRole.validateAuthority(CategoryAuthority.MANAGE_ROLE);
     }
 
-    private void validateSoleAdmin(final Long loginMemberId, final Long categoryId) {
-        boolean isSoleAdmin = categoryRoleRepository.isMemberSoleAdminInCategory(loginMemberId, categoryId);
+    private void validateSoleAdmin(final Long memberId, final Long categoryId) {
+        boolean isSoleAdmin = categoryRoleRepository.isMemberSoleAdminInCategory(memberId, categoryId);
         if (isSoleAdmin) {
             throw new NotAbleToMangeRoleException("변경 대상 회원이 유일한 ADMIN이므로 다른 역할로 변경할 수 없습니다.");
         }

--- a/backend/src/main/java/com/allog/dallog/domain/categoryrole/application/CategoryRoleService.java
+++ b/backend/src/main/java/com/allog/dallog/domain/categoryrole/application/CategoryRoleService.java
@@ -20,9 +20,8 @@ public class CategoryRoleService {
     }
 
     @Transactional
-    public void updateRole(final Long loginMemberId, final CategoryRoleUpdateRequest request) {
-        Long categoryId = request.getCategoryId();
-        Long memberId = request.getMemberId();
+    public void updateRole(final Long loginMemberId, final Long memberId, final Long categoryId,
+                           final CategoryRoleUpdateRequest request) {
         CategoryRoleType roleType = request.getCategoryRoleType();
 
         validateAuthority(loginMemberId, categoryId);

--- a/backend/src/main/java/com/allog/dallog/domain/categoryrole/application/CategoryRoleService.java
+++ b/backend/src/main/java/com/allog/dallog/domain/categoryrole/application/CategoryRoleService.java
@@ -1,0 +1,47 @@
+package com.allog.dallog.domain.categoryrole.application;
+
+import com.allog.dallog.domain.categoryrole.domain.CategoryAuthority;
+import com.allog.dallog.domain.categoryrole.domain.CategoryRole;
+import com.allog.dallog.domain.categoryrole.domain.CategoryRoleRepository;
+import com.allog.dallog.domain.categoryrole.domain.CategoryRoleType;
+import com.allog.dallog.domain.categoryrole.dto.request.CategoryRoleUpdateRequest;
+import com.allog.dallog.domain.categoryrole.exception.NotAbleToMangeRoleException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional(readOnly = true)
+@Service
+public class CategoryRoleService {
+
+    private final CategoryRoleRepository categoryRoleRepository;
+
+    public CategoryRoleService(final CategoryRoleRepository categoryRoleRepository) {
+        this.categoryRoleRepository = categoryRoleRepository;
+    }
+
+    @Transactional
+    public void updateRole(final Long loginMemberId, final CategoryRoleUpdateRequest request) {
+        Long categoryId = request.getCategoryId();
+        Long memberId = request.getMemberId();
+        CategoryRoleType roleType = request.getCategoryRoleType();
+
+        validateAuthority(loginMemberId, categoryId);
+        validateSoleAdmin(memberId, categoryId);
+
+        CategoryRole categoryRole = categoryRoleRepository.getByMemberIdAndCategoryId(memberId, categoryId);
+        categoryRole.changeRole(roleType);
+    }
+
+    private void validateAuthority(final Long loginMemberId, final Long categoryId) {
+        CategoryRole loginMemberCategoryRole = categoryRoleRepository.getByMemberIdAndCategoryId(loginMemberId,
+                categoryId);
+        loginMemberCategoryRole.validateAuthority(CategoryAuthority.MANAGE_ROLE);
+    }
+
+    private void validateSoleAdmin(final Long loginMemberId, final Long categoryId) {
+        boolean isSoleAdmin = categoryRoleRepository.isMemberSoleAdminInCategory(loginMemberId, categoryId);
+        if (isSoleAdmin) {
+            throw new NotAbleToMangeRoleException("변경 대상 회원이 유일한 ADMIN이므로 다른 역할로 변경할 수 없습니다.");
+        }
+    }
+}

--- a/backend/src/main/java/com/allog/dallog/domain/categoryrole/domain/CategoryRole.java
+++ b/backend/src/main/java/com/allog/dallog/domain/categoryrole/domain/CategoryRole.java
@@ -1,6 +1,7 @@
 package com.allog.dallog.domain.categoryrole.domain;
 
 import com.allog.dallog.domain.category.domain.Category;
+import com.allog.dallog.domain.categoryrole.exception.NoPermissionToManageRoleException;
 import com.allog.dallog.domain.common.BaseEntity;
 import com.allog.dallog.domain.member.domain.Member;
 import javax.persistence.Entity;
@@ -42,8 +43,18 @@ public class CategoryRole extends BaseEntity {
         this.categoryRoleType = categoryRoleType;
     }
 
+    public boolean isAdmin() {
+        return categoryRoleType.equals(CategoryRoleType.ADMIN);
+    }
+
     public boolean isNone() {
         return categoryRoleType.equals(CategoryRoleType.NONE);
+    }
+
+    public void validateAuthority(final CategoryAuthority authority) {
+        if (!ableTo(authority)) {
+            throw new NoPermissionToManageRoleException();
+        }
     }
 
     public boolean ableTo(final CategoryAuthority authority) {
@@ -68,5 +79,15 @@ public class CategoryRole extends BaseEntity {
 
     public void changeRole(final CategoryRoleType categoryRoleType) {
         this.categoryRoleType = categoryRoleType;
+    }
+
+    @Override
+    public String toString() {
+        return "CategoryRole{" +
+                "id=" + id +
+                ", category=" + category +
+                ", member=" + member +
+                ", categoryRoleType=" + categoryRoleType +
+                '}';
     }
 }

--- a/backend/src/main/java/com/allog/dallog/domain/categoryrole/domain/CategoryRole.java
+++ b/backend/src/main/java/com/allog/dallog/domain/categoryrole/domain/CategoryRole.java
@@ -61,6 +61,10 @@ public class CategoryRole extends BaseEntity {
         return categoryRoleType.ableTo(authority);
     }
 
+    public void changeRole(final CategoryRoleType categoryRoleType) {
+        this.categoryRoleType = categoryRoleType;
+    }
+
     public Long getId() {
         return id;
     }
@@ -75,19 +79,5 @@ public class CategoryRole extends BaseEntity {
 
     public CategoryRoleType getCategoryRoleType() {
         return categoryRoleType;
-    }
-
-    public void changeRole(final CategoryRoleType categoryRoleType) {
-        this.categoryRoleType = categoryRoleType;
-    }
-
-    @Override
-    public String toString() {
-        return "CategoryRole{" +
-                "id=" + id +
-                ", category=" + category +
-                ", member=" + member +
-                ", categoryRoleType=" + categoryRoleType +
-                '}';
     }
 }

--- a/backend/src/main/java/com/allog/dallog/domain/categoryrole/domain/CategoryRoleRepository.java
+++ b/backend/src/main/java/com/allog/dallog/domain/categoryrole/domain/CategoryRoleRepository.java
@@ -8,6 +8,8 @@ public interface CategoryRoleRepository extends JpaRepository<CategoryRole, Long
 
     Optional<CategoryRole> findByMemberIdAndCategoryId(final Long memberId, final Long categoryId);
 
+    int countByCategoryIdAndCategoryRoleType(final Long categoryId, final CategoryRoleType categoryRoleType);
+
     void deleteByCategoryId(final Long categoryId);
 
     void deleteByMemberId(final Long memberId);
@@ -15,5 +17,12 @@ public interface CategoryRoleRepository extends JpaRepository<CategoryRole, Long
     default CategoryRole getByMemberIdAndCategoryId(final Long memberId, final Long categoryId) {
         return findByMemberIdAndCategoryId(memberId, categoryId)
                 .orElseThrow(NoSuchCategoryRoleException::new);
+    }
+
+    default boolean isMemberSoleAdminInCategory(final Long memberId, final Long categoryId) {
+        CategoryRole categoryRole = getByMemberIdAndCategoryId(memberId, categoryId);
+        int adminCount = countByCategoryIdAndCategoryRoleType(categoryId, CategoryRoleType.ADMIN);
+
+        return categoryRole.isAdmin() && adminCount == 1;
     }
 }

--- a/backend/src/main/java/com/allog/dallog/domain/categoryrole/domain/CategoryRoleType.java
+++ b/backend/src/main/java/com/allog/dallog/domain/categoryrole/domain/CategoryRoleType.java
@@ -7,10 +7,11 @@ import static com.allog.dallog.domain.categoryrole.domain.CategoryAuthority.MANA
 import static com.allog.dallog.domain.categoryrole.domain.CategoryAuthority.MODIFY_SCHEDULE;
 import static com.allog.dallog.domain.categoryrole.domain.CategoryAuthority.RENAME_CATEGORY;
 
+import java.util.EnumSet;
 import java.util.Set;
 
 public enum CategoryRoleType {
-    ADMIN(Set.of(RENAME_CATEGORY, DELETE_CATEGORY, ADD_SCHEDULE, MODIFY_SCHEDULE, DELETE_SCHEDULE, MANAGE_ROLE)),
+    ADMIN(EnumSet.of(RENAME_CATEGORY, DELETE_CATEGORY, ADD_SCHEDULE, MODIFY_SCHEDULE, DELETE_SCHEDULE, MANAGE_ROLE)),
     NONE(Set.of());
 
     private final Set<CategoryAuthority> authorities;

--- a/backend/src/main/java/com/allog/dallog/domain/categoryrole/dto/request/CategoryRoleUpdateRequest.java
+++ b/backend/src/main/java/com/allog/dallog/domain/categoryrole/dto/request/CategoryRoleUpdateRequest.java
@@ -1,0 +1,39 @@
+package com.allog.dallog.domain.categoryrole.dto.request;
+
+import com.allog.dallog.domain.categoryrole.domain.CategoryRoleType;
+import javax.validation.constraints.NotBlank;
+
+public class CategoryRoleUpdateRequest {
+
+    @NotBlank(message = "공백일 수 없습니다.")
+    private Long memberId;
+
+    @NotBlank(message = "공백일 수 없습니다.")
+    private Long categoryId;
+
+
+    @NotBlank(message = "공백일 수 없습니다.")
+    private CategoryRoleType categoryRoleType;
+
+    public CategoryRoleUpdateRequest() {
+    }
+
+    public CategoryRoleUpdateRequest(final Long memberId, final Long categoryId,
+                                     final CategoryRoleType categoryRoleType) {
+        this.memberId = memberId;
+        this.categoryId = categoryId;
+        this.categoryRoleType = categoryRoleType;
+    }
+
+    public Long getCategoryId() {
+        return categoryId;
+    }
+
+    public Long getMemberId() {
+        return memberId;
+    }
+
+    public CategoryRoleType getCategoryRoleType() {
+        return categoryRoleType;
+    }
+}

--- a/backend/src/main/java/com/allog/dallog/domain/categoryrole/dto/request/CategoryRoleUpdateRequest.java
+++ b/backend/src/main/java/com/allog/dallog/domain/categoryrole/dto/request/CategoryRoleUpdateRequest.java
@@ -8,7 +8,7 @@ public class CategoryRoleUpdateRequest {
     @NotBlank(message = "공백일 수 없습니다.")
     private CategoryRoleType categoryRoleType;
 
-    public CategoryRoleUpdateRequest() {
+    private CategoryRoleUpdateRequest() {
     }
 
     public CategoryRoleUpdateRequest(final CategoryRoleType categoryRoleType) {

--- a/backend/src/main/java/com/allog/dallog/domain/categoryrole/dto/request/CategoryRoleUpdateRequest.java
+++ b/backend/src/main/java/com/allog/dallog/domain/categoryrole/dto/request/CategoryRoleUpdateRequest.java
@@ -6,31 +6,13 @@ import javax.validation.constraints.NotBlank;
 public class CategoryRoleUpdateRequest {
 
     @NotBlank(message = "공백일 수 없습니다.")
-    private Long memberId;
-
-    @NotBlank(message = "공백일 수 없습니다.")
-    private Long categoryId;
-
-
-    @NotBlank(message = "공백일 수 없습니다.")
     private CategoryRoleType categoryRoleType;
 
     public CategoryRoleUpdateRequest() {
     }
 
-    public CategoryRoleUpdateRequest(final Long memberId, final Long categoryId,
-                                     final CategoryRoleType categoryRoleType) {
-        this.memberId = memberId;
-        this.categoryId = categoryId;
+    public CategoryRoleUpdateRequest(final CategoryRoleType categoryRoleType) {
         this.categoryRoleType = categoryRoleType;
-    }
-
-    public Long getCategoryId() {
-        return categoryId;
-    }
-
-    public Long getMemberId() {
-        return memberId;
     }
 
     public CategoryRoleType getCategoryRoleType() {

--- a/backend/src/main/java/com/allog/dallog/domain/categoryrole/exception/NoPermissionToManageRoleException.java
+++ b/backend/src/main/java/com/allog/dallog/domain/categoryrole/exception/NoPermissionToManageRoleException.java
@@ -1,0 +1,12 @@
+package com.allog.dallog.domain.categoryrole.exception;
+
+public class NoPermissionToManageRoleException extends RuntimeException {
+
+    public NoPermissionToManageRoleException(final String message) {
+        super(message);
+    }
+
+    public NoPermissionToManageRoleException() {
+        this("역할을 관리할 권한이 없습니다.");
+    }
+}

--- a/backend/src/main/java/com/allog/dallog/domain/categoryrole/exception/NotAbleToMangeRoleException.java
+++ b/backend/src/main/java/com/allog/dallog/domain/categoryrole/exception/NotAbleToMangeRoleException.java
@@ -1,0 +1,12 @@
+package com.allog.dallog.domain.categoryrole.exception;
+
+public class NotAbleToMangeRoleException extends RuntimeException {
+
+    public NotAbleToMangeRoleException(final String message) {
+        super(message);
+    }
+
+    public NotAbleToMangeRoleException() {
+        super("역할을 변경할 수 없습니다.");
+    }
+}

--- a/backend/src/main/java/com/allog/dallog/global/error/ControllerAdvice.java
+++ b/backend/src/main/java/com/allog/dallog/global/error/ControllerAdvice.java
@@ -7,6 +7,9 @@ import com.allog.dallog.domain.auth.exception.NoSuchOAuthTokenException;
 import com.allog.dallog.domain.category.exception.ExistExternalCategoryException;
 import com.allog.dallog.domain.category.exception.InvalidCategoryException;
 import com.allog.dallog.domain.category.exception.NoSuchCategoryException;
+import com.allog.dallog.domain.categoryrole.exception.NoPermissionToManageRoleException;
+import com.allog.dallog.domain.categoryrole.exception.NoSuchCategoryRoleException;
+import com.allog.dallog.domain.categoryrole.exception.NotAbleToMangeRoleException;
 import com.allog.dallog.domain.member.exception.InvalidMemberException;
 import com.allog.dallog.domain.member.exception.NoSuchMemberException;
 import com.allog.dallog.domain.schedule.exception.InvalidScheduleException;
@@ -41,7 +44,8 @@ public class ControllerAdvice {
             InvalidScheduleException.class,
             InvalidSubscriptionException.class,
             ExistSubscriptionException.class,
-            ExistExternalCategoryException.class
+            ExistExternalCategoryException.class,
+            NotAbleToMangeRoleException.class
     })
     public ResponseEntity<ErrorResponse> handleInvalidData(final RuntimeException e) {
         ErrorResponse errorResponse = new ErrorResponse(e.getMessage());
@@ -57,8 +61,11 @@ public class ControllerAdvice {
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(errorResponse);
     }
 
-    @ExceptionHandler(NoPermissionException.class)
-    public ResponseEntity<ErrorResponse> handleNoPermission(final NoPermissionException e) {
+    @ExceptionHandler({
+            NoPermissionException.class,
+            NoPermissionToManageRoleException.class
+    })
+    public ResponseEntity<ErrorResponse> handleNoPermission(final RuntimeException e) {
         ErrorResponse errorResponse = new ErrorResponse(e.getMessage());
         return ResponseEntity.status(HttpStatus.FORBIDDEN).body(errorResponse);
     }
@@ -68,7 +75,8 @@ public class ControllerAdvice {
             NoSuchMemberException.class,
             NoSuchSubscriptionException.class,
             NoSuchScheduleException.class,
-            NoSuchOAuthTokenException.class
+            NoSuchOAuthTokenException.class,
+            NoSuchCategoryRoleException.class
     })
     public ResponseEntity<ErrorResponse> handleNoSuchData(final RuntimeException e) {
         ErrorResponse errorResponse = new ErrorResponse(e.getMessage());

--- a/backend/src/main/java/com/allog/dallog/presentation/CategoryController.java
+++ b/backend/src/main/java/com/allog/dallog/presentation/CategoryController.java
@@ -6,6 +6,8 @@ import com.allog.dallog.domain.category.dto.request.CategoryCreateRequest;
 import com.allog.dallog.domain.category.dto.request.CategoryUpdateRequest;
 import com.allog.dallog.domain.category.dto.response.CategoriesResponse;
 import com.allog.dallog.domain.category.dto.response.CategoryResponse;
+import com.allog.dallog.domain.categoryrole.application.CategoryRoleService;
+import com.allog.dallog.domain.categoryrole.dto.request.CategoryRoleUpdateRequest;
 import com.allog.dallog.presentation.auth.AuthenticationPrincipal;
 import java.net.URI;
 import javax.validation.Valid;
@@ -26,9 +28,11 @@ import org.springframework.web.bind.annotation.RestController;
 public class CategoryController {
 
     private final CategoryService categoryService;
+    private final CategoryRoleService categoryRoleService;
 
-    public CategoryController(final CategoryService categoryService) {
+    public CategoryController(final CategoryService categoryService, final CategoryRoleService categoryRoleService) {
         this.categoryService = categoryService;
+        this.categoryRoleService = categoryRoleService;
     }
 
     @PostMapping
@@ -68,6 +72,15 @@ public class CategoryController {
     public ResponseEntity<Void> delete(@AuthenticationPrincipal final LoginMember loginMember,
                                        @PathVariable final Long categoryId) {
         categoryService.delete(loginMember.getId(), categoryId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PatchMapping("/{categoryId}/subscribers/{memberId}/role")
+    public ResponseEntity<CategoryResponse> updateRole(@AuthenticationPrincipal final LoginMember loginMember,
+                                                       @PathVariable final Long categoryId,
+                                                       @PathVariable final Long memberId,
+                                                       @RequestBody final CategoryRoleUpdateRequest request) {
+        categoryRoleService.updateRole(loginMember.getId(), memberId, categoryId, request);
         return ResponseEntity.noContent().build();
     }
 }

--- a/backend/src/main/java/com/allog/dallog/presentation/CategoryController.java
+++ b/backend/src/main/java/com/allog/dallog/presentation/CategoryController.java
@@ -76,10 +76,10 @@ public class CategoryController {
     }
 
     @PatchMapping("/{categoryId}/subscribers/{memberId}/role")
-    public ResponseEntity<CategoryResponse> updateRole(@AuthenticationPrincipal final LoginMember loginMember,
-                                                       @PathVariable final Long categoryId,
-                                                       @PathVariable final Long memberId,
-                                                       @RequestBody final CategoryRoleUpdateRequest request) {
+    public ResponseEntity<Void> updateRole(@AuthenticationPrincipal final LoginMember loginMember,
+                                           @PathVariable final Long categoryId,
+                                           @PathVariable final Long memberId,
+                                           @RequestBody final CategoryRoleUpdateRequest request) {
         categoryRoleService.updateRole(loginMember.getId(), memberId, categoryId, request);
         return ResponseEntity.noContent().build();
     }

--- a/backend/src/test/java/com/allog/dallog/acceptance/CategoryAcceptanceTest.java
+++ b/backend/src/test/java/com/allog/dallog/acceptance/CategoryAcceptanceTest.java
@@ -8,22 +8,28 @@ import static com.allog.dallog.acceptance.fixtures.CategoryAcceptanceFixtures.�
 import static com.allog.dallog.acceptance.fixtures.CategoryAcceptanceFixtures.새로운_카테고리를_등록한다;
 import static com.allog.dallog.acceptance.fixtures.CategoryAcceptanceFixtures.카테고리를_제목과_페이징을_통해_조회한다;
 import static com.allog.dallog.acceptance.fixtures.CategoryAcceptanceFixtures.카테고리를_페이징을_통해_조회한다;
+import static com.allog.dallog.acceptance.fixtures.CategoryAcceptanceFixtures.회원의_카테고리_역할을_변경한다;
 import static com.allog.dallog.acceptance.fixtures.CommonAcceptanceFixtures.상태코드_200이_반환된다;
 import static com.allog.dallog.acceptance.fixtures.CommonAcceptanceFixtures.상태코드_201이_반환된다;
 import static com.allog.dallog.acceptance.fixtures.CommonAcceptanceFixtures.상태코드_204가_반환된다;
+import static com.allog.dallog.acceptance.fixtures.MemberAcceptanceFixtures.자신의_정보를_조회한다;
+import static com.allog.dallog.acceptance.fixtures.SubscriptionAcceptanceFixtures.카테고리를_구독한다;
 import static com.allog.dallog.common.fixtures.AuthFixtures.GOOGLE_PROVIDER;
 import static com.allog.dallog.common.fixtures.AuthFixtures.STUB_MEMBER_인증_코드;
 import static com.allog.dallog.common.fixtures.CategoryFixtures.BE_일정_생성_요청;
 import static com.allog.dallog.common.fixtures.CategoryFixtures.FE_일정_생성_요청;
 import static com.allog.dallog.common.fixtures.CategoryFixtures.공통_일정_생성_요청;
+import static com.allog.dallog.common.fixtures.CategoryFixtures.내_일정_생성_요청;
 import static com.allog.dallog.common.fixtures.CategoryFixtures.매트_아고라_생성_요청;
 import static com.allog.dallog.common.fixtures.CategoryFixtures.후디_JPA_스터디_생성_요청;
-import static com.allog.dallog.common.fixtures.CategoryFixtures.내_일정_생성_요청;
+import static com.allog.dallog.domain.categoryrole.domain.CategoryRoleType.ADMIN;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+import com.allog.dallog.common.fixtures.OAuthFixtures;
 import com.allog.dallog.domain.category.dto.response.CategoriesResponse;
 import com.allog.dallog.domain.category.dto.response.CategoryResponse;
+import com.allog.dallog.domain.categoryrole.dto.request.CategoryRoleUpdateRequest;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import org.junit.jupiter.api.DisplayName;
@@ -201,6 +207,27 @@ public class CategoryAcceptanceTest extends AcceptanceTest {
 
         // when
         ExtractableResponse<Response> response = 내가_등록한_카테고리를_삭제한다(accessToken, savedCategory.getId());
+
+        // then
+        상태코드_204가_반환된다(response);
+    }
+
+    @DisplayName("특정 구독자의 카테고리 역할을 수정하면 상태코드 204를 반환한다.")
+    @Test
+    void 특정_구독자의_카테고리_역할을_수정하면_상태코드_204를_반환한다() {
+        // given
+        String 관리자_토큰 = 자체_토큰을_생성하고_토큰을_반환한다(GOOGLE_PROVIDER, OAuthFixtures.후디.getCode());
+        CategoryResponse 카테고리 = 새로운_카테고리를_등록한다(관리자_토큰, 공통_일정_생성_요청).as(CategoryResponse.class);
+
+        String 구독자_토큰 = 자체_토큰을_생성하고_토큰을_반환한다(GOOGLE_PROVIDER, OAuthFixtures.매트.getCode());
+        ExtractableResponse<Response> 회원정보 = 자신의_정보를_조회한다(구독자_토큰);
+        long 구독자_id = 회원정보.body().jsonPath().getLong("id");
+
+        카테고리를_구독한다(구독자_토큰, 카테고리.getId());
+
+        // when
+        ExtractableResponse<Response> response = 회원의_카테고리_역할을_변경한다(관리자_토큰, 카테고리.getId(), 구독자_id,
+                new CategoryRoleUpdateRequest(ADMIN));
 
         // then
         상태코드_204가_반환된다(response);

--- a/backend/src/test/java/com/allog/dallog/acceptance/SubscriptionAcceptanceTest.java
+++ b/backend/src/test/java/com/allog/dallog/acceptance/SubscriptionAcceptanceTest.java
@@ -4,6 +4,7 @@ import static com.allog.dallog.acceptance.fixtures.AuthAcceptanceFixtures.자체
 import static com.allog.dallog.acceptance.fixtures.CommonAcceptanceFixtures.상태코드_201이_반환된다;
 import static com.allog.dallog.acceptance.fixtures.CommonAcceptanceFixtures.상태코드_204가_반환된다;
 import static com.allog.dallog.acceptance.fixtures.SubscriptionAcceptanceFixtures.구독_목록을_조회한다;
+import static com.allog.dallog.acceptance.fixtures.SubscriptionAcceptanceFixtures.카테고리를_구독한다;
 import static com.allog.dallog.common.fixtures.AuthFixtures.GOOGLE_PROVIDER;
 import static com.allog.dallog.common.fixtures.AuthFixtures.STUB_CREATOR_인증_코드;
 import static com.allog.dallog.common.fixtures.AuthFixtures.STUB_MEMBER_인증_코드;
@@ -153,16 +154,5 @@ public class SubscriptionAcceptanceTest extends AcceptanceTest {
                 .then().log().all()
                 .extract()
                 .as(CategoryResponse.class);
-    }
-
-    private SubscriptionResponse 카테고리를_구독한다(final String accessToken, final Long categoryId) {
-        return RestAssured.given().log().all()
-                .auth().oauth2(accessToken)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when().post("/api/members/me/categories/{categoryId}/subscriptions", categoryId)
-                .then().log().all()
-                .statusCode(HttpStatus.CREATED.value())
-                .extract()
-                .as(SubscriptionResponse.class);
     }
 }

--- a/backend/src/test/java/com/allog/dallog/acceptance/fixtures/CategoryAcceptanceFixtures.java
+++ b/backend/src/test/java/com/allog/dallog/acceptance/fixtures/CategoryAcceptanceFixtures.java
@@ -2,6 +2,7 @@ package com.allog.dallog.acceptance.fixtures;
 
 import com.allog.dallog.domain.category.dto.request.CategoryCreateRequest;
 import com.allog.dallog.domain.category.dto.request.CategoryUpdateRequest;
+import com.allog.dallog.domain.categoryrole.dto.request.CategoryRoleUpdateRequest;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
@@ -67,6 +68,18 @@ public class CategoryAcceptanceFixtures {
         return RestAssured.given().log().all()
                 .auth().oauth2(accessToken)
                 .when().delete("/api/categories/{categoryId}", id)
+                .then().log().all()
+                .extract();
+    }
+
+    public static ExtractableResponse<Response> 회원의_카테고리_역할을_변경한다(final String accessToken, final Long categoryId,
+                                                                  final Long memberId,
+                                                                  final CategoryRoleUpdateRequest request) {
+        return RestAssured.given().log().all()
+                .auth().oauth2(accessToken)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(request)
+                .when().patch("/api/categories/{categoryId}/subscribers/{memberId}/role", categoryId, memberId)
                 .then().log().all()
                 .extract();
     }

--- a/backend/src/test/java/com/allog/dallog/acceptance/fixtures/SubscriptionAcceptanceFixtures.java
+++ b/backend/src/test/java/com/allog/dallog/acceptance/fixtures/SubscriptionAcceptanceFixtures.java
@@ -1,5 +1,6 @@
 package com.allog.dallog.acceptance.fixtures;
 
+import com.allog.dallog.domain.subscription.dto.response.SubscriptionResponse;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
@@ -16,5 +17,16 @@ public class SubscriptionAcceptanceFixtures {
                 .then().log().all()
                 .statusCode(HttpStatus.OK.value())
                 .extract();
+    }
+
+    public static SubscriptionResponse 카테고리를_구독한다(final String accessToken, final Long categoryId) {
+        return RestAssured.given().log().all()
+                .auth().oauth2(accessToken)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when().post("/api/members/me/categories/{categoryId}/subscriptions", categoryId)
+                .then().log().all()
+                .statusCode(HttpStatus.CREATED.value())
+                .extract()
+                .as(SubscriptionResponse.class);
     }
 }

--- a/backend/src/test/java/com/allog/dallog/domain/category/application/CategoryServiceTest.java
+++ b/backend/src/test/java/com/allog/dallog/domain/category/application/CategoryServiceTest.java
@@ -42,6 +42,7 @@ import com.allog.dallog.domain.category.exception.InvalidCategoryException;
 import com.allog.dallog.domain.category.exception.NoSuchCategoryException;
 import com.allog.dallog.domain.categoryrole.domain.CategoryRole;
 import com.allog.dallog.domain.categoryrole.domain.CategoryRoleRepository;
+import com.allog.dallog.domain.categoryrole.domain.CategoryRoleType;
 import com.allog.dallog.domain.member.application.MemberService;
 import com.allog.dallog.domain.member.domain.Member;
 import com.allog.dallog.domain.member.domain.MemberRepository;
@@ -129,6 +130,21 @@ class CategoryServiceTest extends ServiceTest {
         List<SubscriptionResponse> actual = subscriptions.getSubscriptions();
         // then
         assertThat(actual).hasSize(2);
+    }
+
+    @DisplayName("카테고리 생성 시 생성자에 대한 카테고리 역할을 ADMIN으로 생성한다.")
+    @Test
+    void 카테고리_생성_시_생성자에_대한_카테고리_역할을_ADMIN으로_생성한다() {
+        // given
+        Long 후디_id = parseMemberId(AuthFixtures.후디_인증_코드_토큰_요청());
+
+        CategoryResponse JPA_스터디 = categoryService.save(후디_id, 후디_JPA_스터디_생성_요청);
+
+        // when
+        CategoryRole actual = categoryRoleRepository.findByMemberIdAndCategoryId(후디_id, JPA_스터디.getId()).get();
+
+        // then
+        assertThat(actual.getCategoryRoleType()).isEqualTo(CategoryRoleType.ADMIN);
     }
 
     @DisplayName("새로운 카테고리를 생성 할 떄 이름이 공백이거나 길이가 20을 초과하는 경우 예외를 던진다.")

--- a/backend/src/test/java/com/allog/dallog/domain/categoryrole/application/CategoryRoleServiceTest.java
+++ b/backend/src/test/java/com/allog/dallog/domain/categoryrole/application/CategoryRoleServiceTest.java
@@ -1,0 +1,143 @@
+package com.allog.dallog.domain.categoryrole.application;
+
+import static com.allog.dallog.common.fixtures.CategoryFixtures.BE_일정_생성_요청;
+import static com.allog.dallog.common.fixtures.MemberFixtures.관리자;
+import static com.allog.dallog.common.fixtures.MemberFixtures.매트;
+import static com.allog.dallog.common.fixtures.MemberFixtures.후디;
+import static com.allog.dallog.domain.categoryrole.domain.CategoryRoleType.ADMIN;
+import static com.allog.dallog.domain.categoryrole.domain.CategoryRoleType.NONE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.allog.dallog.common.annotation.ServiceTest;
+import com.allog.dallog.domain.category.application.CategoryService;
+import com.allog.dallog.domain.category.dto.response.CategoryResponse;
+import com.allog.dallog.domain.categoryrole.domain.CategoryRole;
+import com.allog.dallog.domain.categoryrole.domain.CategoryRoleRepository;
+import com.allog.dallog.domain.categoryrole.dto.request.CategoryRoleUpdateRequest;
+import com.allog.dallog.domain.categoryrole.exception.NoPermissionToManageRoleException;
+import com.allog.dallog.domain.categoryrole.exception.NotAbleToMangeRoleException;
+import com.allog.dallog.domain.member.domain.Member;
+import com.allog.dallog.domain.member.domain.MemberRepository;
+import com.allog.dallog.domain.subscription.application.SubscriptionService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class CategoryRoleServiceTest extends ServiceTest {
+
+    @Autowired
+    private CategoryRoleService categoryRoleService;
+
+    @Autowired
+    private CategoryRoleRepository categoryRoleRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private CategoryService categoryService;
+
+    @Autowired
+    private SubscriptionService subscriptionService;
+
+    @DisplayName("ADMIN 회원이 구독자의 역할을 변경할 수 있다")
+    @Test
+    void ADMIN_회원이_구독자의_역할을_변경할_수_있다() {
+        // given
+        Member 관리자 = memberRepository.save(관리자());
+        Member 후디 = memberRepository.save(후디());
+
+        CategoryResponse BE_일정 = categoryService.save(관리자.getId(), BE_일정_생성_요청);
+
+        subscriptionService.save(후디.getId(), BE_일정.getId());
+
+        // when
+        CategoryRoleUpdateRequest request = new CategoryRoleUpdateRequest(후디.getId(), BE_일정.getId(), ADMIN);
+        categoryRoleService.updateRole(관리자.getId(), request);
+
+        CategoryRole actual = categoryRoleRepository.findByMemberIdAndCategoryId(후디.getId(), BE_일정.getId()).get();
+
+        // then
+        assertThat(actual.getCategoryRoleType()).isEqualTo(ADMIN);
+    }
+
+    @DisplayName("ADMIN 유저가 아닌 경우 구독자의 역할을 변경할 수 없다")
+    @Test
+    void ADMIN_유저가_아닌_경우_구독자의_역할을_변경할_수_없다() {
+        // given
+        Member 관리자 = memberRepository.save(관리자());
+        Member 관리자가_아닌_유저 = memberRepository.save(매트());
+        Member 구독자 = memberRepository.save(후디());
+
+        CategoryResponse BE_일정 = categoryService.save(관리자.getId(), BE_일정_생성_요청);
+
+        subscriptionService.save(관리자가_아닌_유저.getId(), BE_일정.getId());
+        subscriptionService.save(구독자.getId(), BE_일정.getId());
+
+        CategoryRoleUpdateRequest request = new CategoryRoleUpdateRequest(구독자.getId(), BE_일정.getId(), ADMIN);
+
+        // when & then
+        assertThatThrownBy(() -> categoryRoleService.updateRole(관리자가_아닌_유저.getId(), request))
+                .isInstanceOf(NoPermissionToManageRoleException.class);
+    }
+
+    @DisplayName("ADMIN 회원이 다른 관리자 유저의 역할을 변경할 수 있다")
+    @Test
+    void ADMIN_회원이_다른_관리자_유저의_역할을_변경할_수_있다() {
+        // given
+        Member 관리자 = memberRepository.save(관리자());
+        CategoryResponse BE_일정 = categoryService.save(관리자.getId(), BE_일정_생성_요청);
+
+        Member 후디 = memberRepository.save(후디());
+        Member 매트 = memberRepository.save(매트());
+
+        subscriptionService.save(후디.getId(), BE_일정.getId());
+        subscriptionService.save(매트.getId(), BE_일정.getId());
+
+        categoryRoleService.updateRole(관리자.getId(), new CategoryRoleUpdateRequest(후디.getId(), BE_일정.getId(), ADMIN));
+        categoryRoleService.updateRole(관리자.getId(), new CategoryRoleUpdateRequest(매트.getId(), BE_일정.getId(), ADMIN));
+
+        // when
+        categoryRoleService.updateRole(후디.getId(), new CategoryRoleUpdateRequest(매트.getId(), BE_일정.getId(), NONE));
+        CategoryRole actual = categoryRoleRepository.findByMemberIdAndCategoryId(매트.getId(), BE_일정.getId()).get();
+
+        // then
+        assertThat(actual.getCategoryRoleType()).isEqualTo(NONE);
+    }
+
+    @DisplayName("ADMIN 회원이 자기자신의 역할을 변경할 수 있다.")
+    @Test
+    void ADMIN_회원이_자기자신의_역할을_변경할_수_있다() {
+        // given
+        Member 관리자 = memberRepository.save(관리자());
+        CategoryResponse BE_일정 = categoryService.save(관리자.getId(), BE_일정_생성_요청);
+
+        Member 후디 = memberRepository.save(후디());
+        subscriptionService.save(후디.getId(), BE_일정.getId());
+        categoryRoleService.updateRole(관리자.getId(), new CategoryRoleUpdateRequest(후디.getId(), BE_일정.getId(), ADMIN));
+        // '관리자' 회원이 유일한 ADMIN이 아니도록 다른 ADMIN 추가
+
+        // when
+        CategoryRoleUpdateRequest request = new CategoryRoleUpdateRequest(관리자.getId(), BE_일정.getId(), NONE);
+        categoryRoleService.updateRole(관리자.getId(), request);
+
+        CategoryRole actual = categoryRoleRepository.findByMemberIdAndCategoryId(관리자.getId(), BE_일정.getId()).get();
+
+        // then
+        assertThat(actual.getCategoryRoleType()).isEqualTo(NONE);
+    }
+
+    @DisplayName("ADMIN 회원이 자기자신의 역할을 변경할때, 자신이 유일한 ADMIN인 경우 예외가 발생한다.")
+    @Test
+    void ADMIN_회원이_자기자신의_역할을_변경할때_자신이_유일한_ADMIN인_경우_예외가_발생한다() {
+        // given
+        Member 관리자 = memberRepository.save(관리자());
+        CategoryResponse BE_일정 = categoryService.save(관리자.getId(), BE_일정_생성_요청);
+
+        // when & then
+        CategoryRoleUpdateRequest request = new CategoryRoleUpdateRequest(관리자.getId(), BE_일정.getId(), NONE);
+        assertThatThrownBy(() -> categoryRoleService.updateRole(관리자.getId(), request))
+                .isInstanceOf(NotAbleToMangeRoleException.class);
+    }
+}

--- a/backend/src/test/java/com/allog/dallog/domain/categoryrole/application/CategoryRoleServiceTest.java
+++ b/backend/src/test/java/com/allog/dallog/domain/categoryrole/application/CategoryRoleServiceTest.java
@@ -53,8 +53,8 @@ class CategoryRoleServiceTest extends ServiceTest {
         subscriptionService.save(후디.getId(), BE_일정.getId());
 
         // when
-        CategoryRoleUpdateRequest request = new CategoryRoleUpdateRequest(후디.getId(), BE_일정.getId(), ADMIN);
-        categoryRoleService.updateRole(관리자.getId(), request);
+        CategoryRoleUpdateRequest request = new CategoryRoleUpdateRequest(ADMIN);
+        categoryRoleService.updateRole(관리자.getId(), 후디.getId(), BE_일정.getId(), request);
 
         CategoryRole actual = categoryRoleRepository.findByMemberIdAndCategoryId(후디.getId(), BE_일정.getId()).get();
 
@@ -75,10 +75,11 @@ class CategoryRoleServiceTest extends ServiceTest {
         subscriptionService.save(관리자가_아닌_유저.getId(), BE_일정.getId());
         subscriptionService.save(구독자.getId(), BE_일정.getId());
 
-        CategoryRoleUpdateRequest request = new CategoryRoleUpdateRequest(구독자.getId(), BE_일정.getId(), ADMIN);
+        CategoryRoleUpdateRequest request = new CategoryRoleUpdateRequest(ADMIN);
 
         // when & then
-        assertThatThrownBy(() -> categoryRoleService.updateRole(관리자가_아닌_유저.getId(), request))
+        assertThatThrownBy(
+                () -> categoryRoleService.updateRole(관리자가_아닌_유저.getId(), 구독자.getId(), BE_일정.getId(), request))
                 .isInstanceOf(NoPermissionToManageRoleException.class);
     }
 
@@ -95,11 +96,11 @@ class CategoryRoleServiceTest extends ServiceTest {
         subscriptionService.save(후디.getId(), BE_일정.getId());
         subscriptionService.save(매트.getId(), BE_일정.getId());
 
-        categoryRoleService.updateRole(관리자.getId(), new CategoryRoleUpdateRequest(후디.getId(), BE_일정.getId(), ADMIN));
-        categoryRoleService.updateRole(관리자.getId(), new CategoryRoleUpdateRequest(매트.getId(), BE_일정.getId(), ADMIN));
+        categoryRoleService.updateRole(관리자.getId(), 후디.getId(), BE_일정.getId(), new CategoryRoleUpdateRequest(ADMIN));
+        categoryRoleService.updateRole(관리자.getId(), 매트.getId(), BE_일정.getId(), new CategoryRoleUpdateRequest(ADMIN));
 
         // when
-        categoryRoleService.updateRole(후디.getId(), new CategoryRoleUpdateRequest(매트.getId(), BE_일정.getId(), NONE));
+        categoryRoleService.updateRole(후디.getId(), 매트.getId(), BE_일정.getId(), new CategoryRoleUpdateRequest(NONE));
         CategoryRole actual = categoryRoleRepository.findByMemberIdAndCategoryId(매트.getId(), BE_일정.getId()).get();
 
         // then
@@ -115,12 +116,12 @@ class CategoryRoleServiceTest extends ServiceTest {
 
         Member 후디 = memberRepository.save(후디());
         subscriptionService.save(후디.getId(), BE_일정.getId());
-        categoryRoleService.updateRole(관리자.getId(), new CategoryRoleUpdateRequest(후디.getId(), BE_일정.getId(), ADMIN));
+        categoryRoleService.updateRole(관리자.getId(), 후디.getId(), BE_일정.getId(), new CategoryRoleUpdateRequest(ADMIN));
         // '관리자' 회원이 유일한 ADMIN이 아니도록 다른 ADMIN 추가
 
         // when
-        CategoryRoleUpdateRequest request = new CategoryRoleUpdateRequest(관리자.getId(), BE_일정.getId(), NONE);
-        categoryRoleService.updateRole(관리자.getId(), request);
+        CategoryRoleUpdateRequest request = new CategoryRoleUpdateRequest(NONE);
+        categoryRoleService.updateRole(관리자.getId(), 관리자.getId(), BE_일정.getId(), request);
 
         CategoryRole actual = categoryRoleRepository.findByMemberIdAndCategoryId(관리자.getId(), BE_일정.getId()).get();
 
@@ -136,8 +137,8 @@ class CategoryRoleServiceTest extends ServiceTest {
         CategoryResponse BE_일정 = categoryService.save(관리자.getId(), BE_일정_생성_요청);
 
         // when & then
-        CategoryRoleUpdateRequest request = new CategoryRoleUpdateRequest(관리자.getId(), BE_일정.getId(), NONE);
-        assertThatThrownBy(() -> categoryRoleService.updateRole(관리자.getId(), request))
+        CategoryRoleUpdateRequest request = new CategoryRoleUpdateRequest(NONE);
+        assertThatThrownBy(() -> categoryRoleService.updateRole(관리자.getId(), 관리자.getId(), BE_일정.getId(), request))
                 .isInstanceOf(NotAbleToMangeRoleException.class);
     }
 }

--- a/backend/src/test/java/com/allog/dallog/domain/categoryrole/domain/CategoryRoleTest.java
+++ b/backend/src/test/java/com/allog/dallog/domain/categoryrole/domain/CategoryRoleTest.java
@@ -1,4 +1,4 @@
-package com.allog.dallog.domain.categoryrole;
+package com.allog.dallog.domain.categoryrole.domain;
 
 import static com.allog.dallog.common.fixtures.CategoryFixtures.BE_일정;
 import static com.allog.dallog.common.fixtures.MemberFixtures.관리자;
@@ -6,9 +6,6 @@ import static com.allog.dallog.common.fixtures.MemberFixtures.후디;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.allog.dallog.domain.category.domain.Category;
-import com.allog.dallog.domain.categoryrole.domain.CategoryAuthority;
-import com.allog.dallog.domain.categoryrole.domain.CategoryRole;
-import com.allog.dallog.domain.categoryrole.domain.CategoryRoleType;
 import com.allog.dallog.domain.member.domain.Member;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;

--- a/backend/src/test/java/com/allog/dallog/domain/categoryrole/domain/CategoryRoleTypeTest.java
+++ b/backend/src/test/java/com/allog/dallog/domain/categoryrole/domain/CategoryRoleTypeTest.java
@@ -1,9 +1,7 @@
-package com.allog.dallog.domain.categoryrole;
+package com.allog.dallog.domain.categoryrole.domain;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.allog.dallog.domain.categoryrole.domain.CategoryAuthority;
-import com.allog.dallog.domain.categoryrole.domain.CategoryRoleType;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;

--- a/backend/src/test/java/com/allog/dallog/presentation/MemberControllerTest.java
+++ b/backend/src/test/java/com/allog/dallog/presentation/MemberControllerTest.java
@@ -16,7 +16,6 @@ import static org.springframework.restdocs.operation.preprocess.Preprocessors.pr
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -136,7 +135,7 @@ class MemberControllerTest extends ControllerTest {
                 .deleteById(any());
 
         // when & then
-        mockMvc.perform(delete("/api/members/me")
+        mockMvc.perform(patch("/api/{categoryId}/subscribers/{memberId}/role")
                         .accept(MediaType.APPLICATION_JSON)
                         .header(AUTHORIZATION_HEADER_NAME, AUTHORIZATION_HEADER_VALUE)
                 )

--- a/backend/src/test/java/com/allog/dallog/presentation/MemberControllerTest.java
+++ b/backend/src/test/java/com/allog/dallog/presentation/MemberControllerTest.java
@@ -126,26 +126,4 @@ class MemberControllerTest extends ControllerTest {
                 .andExpect(status().isNoContent());
     }
 
-    @DisplayName("등록된 회원이 회원탈퇴 한다.")
-    @Test
-    void 등록된_회원이_회원탈퇴_한다() throws Exception {
-        // given
-        willDoNothing()
-                .given(memberService)
-                .deleteById(any());
-
-        // when & then
-        mockMvc.perform(patch("/api/{categoryId}/subscribers/{memberId}/role")
-                        .accept(MediaType.APPLICATION_JSON)
-                        .header(AUTHORIZATION_HEADER_NAME, AUTHORIZATION_HEADER_VALUE)
-                )
-                .andDo(print())
-                .andDo(document("member/delete",
-                        preprocessRequest(prettyPrint()),
-                        preprocessResponse(prettyPrint()),
-                        requestHeaders(
-                                headerWithName("Authorization").description("JWT 토큰")
-                        )))
-                .andExpect(status().isNoContent());
-    }
 }


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 💻 git rebase를 사용했나요?
- [x] 🌈 알록달록한가요?

## 작업 내용

- 카테고리를 생성한 시점에 해당 유저와 카테고리에 대해 ADMIN 역할을 자동으로 생성합니다.
- 구독자의 역할을 변경하는 API를 구현합니다. 이 API는 ADMIN 유저만 실행할 수 있습니다.
- 관리자 유저의 역할을 변경하는 API를 구현합니다. 이 API는 ADMIN 유저만 실행할 수 있습니다.
- 자신이 관리자 유저인 경우, 자신의 역할을 NONE으로 변경하는 API를 구현합니다.
- ADMIN 이 자기자신을 ADMIN이 아닌 역할로 변경할 때, 자기자신이 유일한 ADMIN 인 경우 권한을 변경할 수 없습니다.

## 스크린샷

## 주의사항

#678 
