### PR TITLE
특정 상황에서 발생하는 500 에러를 핸들링 한다.

### DIFF
--- a/backend/src/main/java/com/allog/dallog/domain/schedule/domain/Schedule.java
+++ b/backend/src/main/java/com/allog/dallog/domain/schedule/domain/Schedule.java
@@ -88,7 +88,7 @@ public class Schedule extends BaseEntity {
     }
 
     private boolean isValidDateTimeRange(final LocalDateTime dateTime) {
-        return dateTime.isBefore(MAX_DATE_TIME) || dateTime.isAfter(MIN_DATE_TIME);
+        return dateTime.isBefore(MIN_DATE_TIME) || dateTime.isAfter(MAX_DATE_TIME);
     }
 
     private void validateMemoLength(final String memo) {

--- a/backend/src/main/java/com/allog/dallog/domain/schedule/domain/Schedule.java
+++ b/backend/src/main/java/com/allog/dallog/domain/schedule/domain/Schedule.java
@@ -21,6 +21,9 @@ public class Schedule extends BaseEntity {
     private static final int MAX_TITLE_LENGTH = 50;
     private static final int MAX_MEMO_LENGTH = 255;
 
+    private static final LocalDateTime MAX_DATE_TIME = LocalDateTime.of(1000, 1, 1, 0, 0);
+    private static final LocalDateTime MIN_DATE_TIME = LocalDateTime.of(9999, 12, 31, 11, 59, 59, 999999);
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id")
@@ -79,6 +82,13 @@ public class Schedule extends BaseEntity {
         if (startDateTime.isAfter(endDateTime)) {
             throw new InvalidScheduleException("종료일시가 시작일시보다 이전일 수 없습니다.");
         }
+        if (isValidDateTimeRange(startDateTime) && isValidDateTimeRange(endDateTime)) {
+            throw new InvalidScheduleException("가능한 날짜 범위(1000년 - 9999년)를 벗어났습니다.");
+        }
+    }
+
+    private boolean isValidDateTimeRange(final LocalDateTime dateTime) {
+        return dateTime.isBefore(MIN_DATE_TIME) || dateTime.isAfter(MAX_DATE_TIME);
     }
 
     private void validateMemoLength(final String memo) {

--- a/backend/src/main/java/com/allog/dallog/domain/schedule/domain/Schedule.java
+++ b/backend/src/main/java/com/allog/dallog/domain/schedule/domain/Schedule.java
@@ -21,8 +21,8 @@ public class Schedule extends BaseEntity {
     private static final int MAX_TITLE_LENGTH = 50;
     private static final int MAX_MEMO_LENGTH = 255;
 
-    private static final LocalDateTime MAX_DATE_TIME = LocalDateTime.of(1000, 1, 1, 0, 0);
-    private static final LocalDateTime MIN_DATE_TIME = LocalDateTime.of(9999, 12, 31, 11, 59, 59, 999999);
+    private static final LocalDateTime MIN_DATE_TIME = LocalDateTime.of(1000, 1, 1, 0, 0);
+    private static final LocalDateTime MAX_DATE_TIME = LocalDateTime.of(9999, 12, 31, 11, 59, 59, 999999);
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -88,7 +88,7 @@ public class Schedule extends BaseEntity {
     }
 
     private boolean isValidDateTimeRange(final LocalDateTime dateTime) {
-        return dateTime.isBefore(MIN_DATE_TIME) || dateTime.isAfter(MAX_DATE_TIME);
+        return dateTime.isBefore(MAX_DATE_TIME) || dateTime.isAfter(MIN_DATE_TIME);
     }
 
     private void validateMemoLength(final String memo) {

--- a/backend/src/main/java/com/allog/dallog/domain/schedule/domain/Schedule.java
+++ b/backend/src/main/java/com/allog/dallog/domain/schedule/domain/Schedule.java
@@ -22,7 +22,7 @@ public class Schedule extends BaseEntity {
     private static final int MAX_MEMO_LENGTH = 255;
 
     private static final LocalDateTime MIN_DATE_TIME = LocalDateTime.of(1000, 1, 1, 0, 0);
-    private static final LocalDateTime MAX_DATE_TIME = LocalDateTime.of(9999, 12, 31, 11, 59, 59, 999999);
+    private static final LocalDateTime MAX_DATE_TIME = LocalDateTime.of(9999, 12, 31, 11, 59, 59, 999999000);
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/backend/src/main/java/com/allog/dallog/domain/schedule/domain/Schedule.java
+++ b/backend/src/main/java/com/allog/dallog/domain/schedule/domain/Schedule.java
@@ -82,12 +82,15 @@ public class Schedule extends BaseEntity {
         if (startDateTime.isAfter(endDateTime)) {
             throw new InvalidScheduleException("종료일시가 시작일시보다 이전일 수 없습니다.");
         }
-        if (isValidDateTimeRange(startDateTime) && isValidDateTimeRange(endDateTime)) {
-            throw new InvalidScheduleException("가능한 날짜 범위(1000년 - 9999년)를 벗어났습니다.");
+        if (isNotValidDateTimeRange(startDateTime) || isNotValidDateTimeRange(endDateTime)) {
+            throw new InvalidScheduleException(
+                    String.format("일정은 %s부터 %s까지 등록할 수 있습니다.",
+                            MIN_DATE_TIME.toLocalDate(), MAX_DATE_TIME.toLocalDate())
+            );
         }
     }
 
-    private boolean isValidDateTimeRange(final LocalDateTime dateTime) {
+    private boolean isNotValidDateTimeRange(final LocalDateTime dateTime) {
         return dateTime.isBefore(MIN_DATE_TIME) || dateTime.isAfter(MAX_DATE_TIME);
     }
 

--- a/backend/src/main/java/com/allog/dallog/global/error/ControllerAdvice.java
+++ b/backend/src/main/java/com/allog/dallog/global/error/ControllerAdvice.java
@@ -69,6 +69,7 @@ public class ControllerAdvice {
         ErrorResponse errorResponse = new ErrorResponse(errorMessage);
         return ResponseEntity.badRequest().body(errorResponse);
     }
+
     @ExceptionHandler(MethodArgumentTypeMismatchException.class)
     public ResponseEntity<ErrorResponse> handleTypeMismatch() {
         ErrorResponse errorResponse = new ErrorResponse("잘못된 데이터 타입입니다.");

--- a/backend/src/main/java/com/allog/dallog/global/error/ControllerAdvice.java
+++ b/backend/src/main/java/com/allog/dallog/global/error/ControllerAdvice.java
@@ -110,7 +110,7 @@ public class ControllerAdvice {
 
     @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
     public ResponseEntity<ErrorResponse> handleNotSupportedMethod() {
-        ErrorResponse errorResponse = new ErrorResponse("잘못된 HTTP 메소드 요청입니다.");
+        ErrorResponse errorResponse = new ErrorResponse("지원하지 않는 HTTP 메소드 요청입니다.");
         return ResponseEntity.status(HttpStatus.METHOD_NOT_ALLOWED).body(errorResponse);
     }
 

--- a/backend/src/main/java/com/allog/dallog/global/error/ControllerAdvice.java
+++ b/backend/src/main/java/com/allog/dallog/global/error/ControllerAdvice.java
@@ -28,6 +28,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.FieldError;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -50,6 +51,27 @@ public class ControllerAdvice {
     })
     public ResponseEntity<ErrorResponse> handleInvalidData(final RuntimeException e) {
         ErrorResponse errorResponse = new ErrorResponse(e.getMessage());
+        return ResponseEntity.badRequest().body(errorResponse);
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ErrorResponse> handleInvalidRequestBody() {
+        ErrorResponse errorResponse = new ErrorResponse("잘못된 형식의 Request Body 입니다.");
+        return ResponseEntity.badRequest().body(errorResponse);
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleInvalidDtoField(final MethodArgumentNotValidException e) {
+        FieldError firstFieldError = e.getFieldErrors().get(0);
+        String errorMessage = String.format(INVALID_DTO_FIELD_ERROR_MESSAGE_FORMAT, firstFieldError.getField(),
+                firstFieldError.getDefaultMessage(), firstFieldError.getRejectedValue());
+
+        ErrorResponse errorResponse = new ErrorResponse(errorMessage);
+        return ResponseEntity.badRequest().body(errorResponse);
+    }
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<ErrorResponse> handleTypeMismatch() {
+        ErrorResponse errorResponse = new ErrorResponse("잘못된 데이터 타입입니다.");
         return ResponseEntity.badRequest().body(errorResponse);
     }
 
@@ -85,33 +107,17 @@ public class ControllerAdvice {
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(errorResponse);
     }
 
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    public ResponseEntity<ErrorResponse> handleNotSupportedMethod() {
+        ErrorResponse errorResponse = new ErrorResponse("잘못된 HTTP 메소드 요청입니다.");
+        return ResponseEntity.status(HttpStatus.METHOD_NOT_ALLOWED).body(errorResponse);
+    }
+
     @ExceptionHandler(OAuthException.class)
     public ResponseEntity<ErrorResponse> handleOAuthException(final RuntimeException e) {
         log.error("OAuth 통신 과정에서 에러가 발생했습니다.", e);
         ErrorResponse errorResponse = new ErrorResponse("OAuth 통신 과정에서 에러가 발생했습니다.");
         return ResponseEntity.internalServerError().body(errorResponse);
-    }
-
-    @ExceptionHandler(HttpMessageNotReadableException.class)
-    public ResponseEntity<ErrorResponse> handleInvalidRequestBody() {
-        ErrorResponse errorResponse = new ErrorResponse("잘못된 형식의 Request Body 입니다.");
-        return ResponseEntity.badRequest().body(errorResponse);
-    }
-
-    @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<ErrorResponse> handleInvalidDtoField(final MethodArgumentNotValidException e) {
-        FieldError firstFieldError = e.getFieldErrors().get(0);
-        String errorMessage = String.format(INVALID_DTO_FIELD_ERROR_MESSAGE_FORMAT, firstFieldError.getField(),
-                firstFieldError.getDefaultMessage(), firstFieldError.getRejectedValue());
-
-        ErrorResponse errorResponse = new ErrorResponse(errorMessage);
-        return ResponseEntity.badRequest().body(errorResponse);
-    }
-
-    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
-    public ResponseEntity<ErrorResponse> handleTypeMismatch() {
-        ErrorResponse errorResponse = new ErrorResponse("잘못된 데이터 타입입니다.");
-        return ResponseEntity.badRequest().body(errorResponse);
     }
 
     @ExceptionHandler(Exception.class)

--- a/backend/src/test/java/com/allog/dallog/domain/schedule/domain/ScheduleTest.java
+++ b/backend/src/test/java/com/allog/dallog/domain/schedule/domain/ScheduleTest.java
@@ -7,10 +7,12 @@ import static com.allog.dallog.common.fixtures.ScheduleFixtures.알록달록_회
 import static com.allog.dallog.common.fixtures.ScheduleFixtures.알록달록_회의_제목;
 import static com.allog.dallog.common.fixtures.ScheduleFixtures.알록달록_회의_종료일시;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import com.allog.dallog.domain.category.domain.Category;
 import com.allog.dallog.domain.schedule.exception.InvalidScheduleException;
+import java.time.LocalDateTime;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -26,6 +28,28 @@ public class ScheduleTest {
 
         // when & then
         assertDoesNotThrow(() -> new Schedule(BE_일정_카테고리, 알록달록_회의_제목, 알록달록_회의_시작일시, 알록달록_회의_종료일시, 알록달록_회의_메모));
+    }
+
+    @DisplayName("일정 일시가 가능한 범위를 벗어나는 경우 예외를 던진다.")
+    @Test
+    void 일정_일시가_가능한_범위를_벗어나는_경우_예외를_던진다() {
+        //given
+        Category BE_일정_카테고리 = BE_일정(관리자());
+        LocalDateTime 잘못된_시작_일시 = LocalDateTime.MIN;
+        LocalDateTime 잘못된_종료_일시 = LocalDateTime.MAX;
+
+        // when & then
+        assertAll(() -> {
+                    assertThatThrownBy(
+                            () -> new Schedule(BE_일정_카테고리, 알록달록_회의_제목, 잘못된_시작_일시,
+                                    알록달록_회의_종료일시, 알록달록_회의_메모)
+                    ).isInstanceOf(InvalidScheduleException.class);
+                    assertThatThrownBy(
+                            () -> new Schedule(BE_일정_카테고리, 알록달록_회의_제목, 알록달록_회의_시작일시,
+                                    잘못된_종료_일시, 알록달록_회의_메모)
+                    ).isInstanceOf(InvalidScheduleException.class);
+                }
+        );
     }
 
     @DisplayName("일정 제목의 길이가 50을 초과하는 경우 예외를 던진다.")

--- a/backend/src/test/java/com/allog/dallog/domain/schedule/domain/ScheduleTest.java
+++ b/backend/src/test/java/com/allog/dallog/domain/schedule/domain/ScheduleTest.java
@@ -29,20 +29,34 @@ public class ScheduleTest {
         assertDoesNotThrow(() -> new Schedule(BE_일정_카테고리, 알록달록_회의_제목, 알록달록_회의_시작일시, 알록달록_회의_종료일시, 알록달록_회의_메모));
     }
 
-    @DisplayName("일정 일시가 가능한 범위를 벗어나는 경우 예외를 던진다.")
+    @DisplayName("일정 시작 일시가 가능한 범위를 벗어나는 경우 예외를 던진다.")
     @Test
-    void 일정_일시가_가능한_범위를_벗어나는_경우_예외를_던진다() {
+    void 일정_시작_일시가_가능한_범위를_벗어나는_경우_예외를_던진다() {
         //given
         Category BE_일정_카테고리 = BE_일정(관리자());
         LocalDateTime 잘못된_시작_일시 = LocalDateTime.MIN;
+
+        // when & then
+        assertThatThrownBy(
+                () -> new Schedule(BE_일정_카테고리, 알록달록_회의_제목,
+                        잘못된_시작_일시, 알록달록_회의_종료일시, 알록달록_회의_메모)
+        ).isInstanceOf(InvalidScheduleException.class);
+    }
+
+    @DisplayName("일정 종료 일시가 가능한 범위를 벗어나는 경우 예외를 던진다.")
+    @Test
+    void 일정_종료_일시가_가능한_범위를_벗어나는_경우_예외를_던진다() {
+        //given
+        Category BE_일정_카테고리 = BE_일정(관리자());
         LocalDateTime 잘못된_종료_일시 = LocalDateTime.MAX;
 
         // when & then
         assertThatThrownBy(
                 () -> new Schedule(BE_일정_카테고리, 알록달록_회의_제목,
-                        잘못된_시작_일시, 잘못된_종료_일시, 알록달록_회의_메모)
+                        알록달록_회의_시작일시, 잘못된_종료_일시, 알록달록_회의_메모)
         ).isInstanceOf(InvalidScheduleException.class);
     }
+
 
     @DisplayName("일정 제목의 길이가 50을 초과하는 경우 예외를 던진다.")
     @ParameterizedTest

--- a/backend/src/test/java/com/allog/dallog/domain/schedule/domain/ScheduleTest.java
+++ b/backend/src/test/java/com/allog/dallog/domain/schedule/domain/ScheduleTest.java
@@ -7,7 +7,6 @@ import static com.allog.dallog.common.fixtures.ScheduleFixtures.알록달록_회
 import static com.allog.dallog.common.fixtures.ScheduleFixtures.알록달록_회의_제목;
 import static com.allog.dallog.common.fixtures.ScheduleFixtures.알록달록_회의_종료일시;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import com.allog.dallog.domain.category.domain.Category;
@@ -39,17 +38,10 @@ public class ScheduleTest {
         LocalDateTime 잘못된_종료_일시 = LocalDateTime.MAX;
 
         // when & then
-        assertAll(() -> {
-                    assertThatThrownBy(
-                            () -> new Schedule(BE_일정_카테고리, 알록달록_회의_제목, 잘못된_시작_일시,
-                                    알록달록_회의_종료일시, 알록달록_회의_메모)
-                    ).isInstanceOf(InvalidScheduleException.class);
-                    assertThatThrownBy(
-                            () -> new Schedule(BE_일정_카테고리, 알록달록_회의_제목, 알록달록_회의_시작일시,
-                                    잘못된_종료_일시, 알록달록_회의_메모)
-                    ).isInstanceOf(InvalidScheduleException.class);
-                }
-        );
+        assertThatThrownBy(
+                () -> new Schedule(BE_일정_카테고리, 알록달록_회의_제목,
+                        잘못된_시작_일시, 잘못된_종료_일시, 알록달록_회의_메모)
+        ).isInstanceOf(InvalidScheduleException.class);
     }
 
     @DisplayName("일정 제목의 길이가 50을 초과하는 경우 예외를 던진다.")


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 💻 git rebase를 사용했나요?
- [x] 🌈 알록달록한가요?

## 작업 내용

- 지원하지 않는 메서드로 요청시 500 에러가 발생
`HttpRequestMethodNotSupportedException` -> 405로 던진다.
- 특정 년도를 벗어나 일정을 생성/수정하면 500 에러가 발생
스케줄 생성 시 범위 검증 -> 400으로 던진다.

## 주의사항

- #697 머지한 이후 머지

Closes #673 
