### PR TITLE
[feat] 패키지간의 순환 참조를 제거한다.

### DIFF
--- a/backend/src/main/java/com/allog/dallog/domain/categoryrole/domain/CategoryRole.java
+++ b/backend/src/main/java/com/allog/dallog/domain/categoryrole/domain/CategoryRole.java
@@ -53,7 +53,7 @@ public class CategoryRole extends BaseEntity {
 
     public void validateAuthority(final CategoryAuthority authority) {
         if (!ableTo(authority)) {
-            throw new NoCategoryAuthorityException(authority);
+            throw new NoCategoryAuthorityException(authority.getName());
         }
     }
 

--- a/backend/src/main/java/com/allog/dallog/domain/categoryrole/exception/NoCategoryAuthorityException.java
+++ b/backend/src/main/java/com/allog/dallog/domain/categoryrole/exception/NoCategoryAuthorityException.java
@@ -1,14 +1,8 @@
 package com.allog.dallog.domain.categoryrole.exception;
 
-import com.allog.dallog.domain.categoryrole.domain.CategoryAuthority;
-
 public class NoCategoryAuthorityException extends RuntimeException {
 
-    public NoCategoryAuthorityException(final String message) {
-        super(message);
-    }
-
-    public NoCategoryAuthorityException(final CategoryAuthority authority) {
-        this(authority.getName() + " 권한이 없습니다.");
+    public NoCategoryAuthorityException(final String authorityName) {
+        super(authorityName + " 권한이 없습니다.");
     }
 }

--- a/backend/src/test/java/com/allog/dallog/presentation/CategoryControllerTest.java
+++ b/backend/src/test/java/com/allog/dallog/presentation/CategoryControllerTest.java
@@ -560,7 +560,7 @@ class CategoryControllerTest extends ControllerTest {
         Long categoryId = 1L;
         Long memberId = 2L;
 
-        willThrow(new NoCategoryAuthorityException(CategoryAuthority.CHANGE_ROLE_OF_SUBSCRIBER))
+        willThrow(new NoCategoryAuthorityException(CategoryAuthority.CHANGE_ROLE_OF_SUBSCRIBER.getName()))
                 .willDoNothing()
                 .given(categoryRoleService)
                 .updateRole(any(), any(), any(), any());


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 💻 git rebase를 사용했나요?
- [x] 🌈 알록달록한가요?

## 작업 내용

- categoryrole.exception 과 categoryrole.domain 패키지 간의 순환참조 제거

(참고) categoryrole 패키지와 category 패키지간의 순환참조는 https://github.com/woowacourse-teams/2022-dallog/pull/726/files#diff-8fd9a4706fbb13b4b55a165b342318fe620c883525ff0816c1aebd217b7bcd52 에서 제거되었습니다.

<img width="1691" alt="스크린샷 2022-10-07 오후 2 38 02" src="https://user-images.githubusercontent.com/11745691/194475355-028672f6-e6e9-4415-a268-e1428d567dba.png">

😄👍

## 스크린샷

## 주의사항

Closes #721 
