### PR TITLE
[refactor] 불필요하게 join을 활용하는 조회 로직을 개선한다.

### DIFF
--- a/backend/src/main/java/com/allog/dallog/domain/auth/domain/OAuthTokenRepository.java
+++ b/backend/src/main/java/com/allog/dallog/domain/auth/domain/OAuthTokenRepository.java
@@ -3,11 +3,15 @@ package com.allog.dallog.domain.auth.domain;
 import com.allog.dallog.domain.auth.exception.NoSuchOAuthTokenException;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface OAuthTokenRepository extends JpaRepository<OAuthToken, Long> {
 
     boolean existsByMemberId(final Long memberId);
 
+    @Query("SELECT o "
+            + "FROM OAuthToken o "
+            + "WHERE o.member.id = :memberId")
     Optional<OAuthToken> findByMemberId(final Long memberId);
 
     void deleteByMemberId(final Long memberId);

--- a/backend/src/main/java/com/allog/dallog/domain/category/domain/CategoryRepository.java
+++ b/backend/src/main/java/com/allog/dallog/domain/category/domain/CategoryRepository.java
@@ -23,8 +23,14 @@ public interface CategoryRepository extends JpaRepository<Category, Long> {
     Slice<Category> findByCategoryTypeAndNameContaining(final CategoryType categoryType, final String name,
                                                         final Pageable pageable);
 
+    @Query("SELECT c "
+            + "FROM Category c "
+            + "WHERE c.member.id = :memberId AND c.categoryType = :categoryType")
     List<Category> findByMemberIdAndCategoryType(final Long memberId, final CategoryType categoryType);
 
+    @Query("SELECT c "
+            + "FROM Category c "
+            + "WHERE c.member.id = :memberId")
     List<Category> findByMemberId(final Long memberId);
 
     boolean existsByIdAndMemberId(final Long id, final Long memberId);

--- a/backend/src/main/java/com/allog/dallog/domain/categoryrole/domain/CategoryRoleRepository.java
+++ b/backend/src/main/java/com/allog/dallog/domain/categoryrole/domain/CategoryRoleRepository.java
@@ -5,9 +5,13 @@ import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface CategoryRoleRepository extends JpaRepository<CategoryRole, Long> {
 
+    @Query("SELECT cr "
+            + "FROM CategoryRole cr "
+            + "WHERE cr.member.id = :memberId AND cr.category.id = :categoryId")
     Optional<CategoryRole> findByMemberIdAndCategoryId(final Long memberId, final Long categoryId);
 
     @EntityGraph(attributePaths = {"member"})

--- a/backend/src/main/java/com/allog/dallog/domain/subscription/domain/SubscriptionRepository.java
+++ b/backend/src/main/java/com/allog/dallog/domain/subscription/domain/SubscriptionRepository.java
@@ -19,8 +19,6 @@ public interface SubscriptionRepository extends JpaRepository<Subscription, Long
     @EntityGraph(attributePaths = {"category", "category.member"})
     List<Subscription> findByCategoryId(final Long categoryId);
 
-    List<Subscription> findByMemberIdIn(final List<Long> memberIds);
-
     void deleteByCategoryIdIn(final List<Long> categoryIds);
 
     default Subscription getById(final Long id) {

--- a/backend/src/test/java/com/allog/dallog/domain/category/application/CategoryServiceTest.java
+++ b/backend/src/test/java/com/allog/dallog/domain/category/application/CategoryServiceTest.java
@@ -152,7 +152,7 @@ class CategoryServiceTest extends ServiceTest {
         CategoryResponse JPA_스터디 = categoryService.save(후디_id, 후디_JPA_스터디_생성_요청);
 
         // when
-        CategoryRole actual = categoryRoleRepository.findByMemberIdAndCategoryId(후디_id, JPA_스터디.getId()).get();
+        CategoryRole actual = categoryRoleRepository.getByMemberIdAndCategoryId(후디_id, JPA_스터디.getId());
 
         // then
         assertThat(actual.getCategoryRoleType()).isEqualTo(ADMIN);
@@ -580,7 +580,7 @@ class CategoryServiceTest extends ServiceTest {
         Member 후디 = memberRepository.save(후디());
         subscriptionService.save(후디.getId(), 공통_일정.getId());
 
-        CategoryRole 역할 = categoryRoleRepository.findByMemberIdAndCategoryId(후디.getId(), 공통_일정.getId()).get();
+        CategoryRole 역할 = categoryRoleRepository.getByMemberIdAndCategoryId(후디.getId(), 공통_일정.getId());
 
         // when
         categoryService.delete(관리자.getId(), 공통_일정.getId());

--- a/backend/src/test/java/com/allog/dallog/domain/category/domain/CategoryRepositoryTest.java
+++ b/backend/src/test/java/com/allog/dallog/domain/category/domain/CategoryRepositoryTest.java
@@ -171,6 +171,24 @@ class CategoryRepositoryTest extends RepositoryTest {
         });
     }
 
+    @DisplayName("member id와 categoryType을 기반으로 조회한다.")
+    @Test
+    void member_id와_categoryType을_기반으로_조회한다() {
+        // given
+        Member 매트 = memberRepository.save(매트());
+        categoryRepository.save(공통_일정(매트));
+        categoryRepository.save(BE_일정(매트));
+        categoryRepository.save(FE_일정(매트));
+        categoryRepository.save(매트_아고라(매트));
+        categoryRepository.save(후디_JPA_스터디(매트));
+
+        // when
+        List<Category> actual = categoryRepository.findByMemberIdAndCategoryType(매트.getId(), NORMAL);
+
+        // then
+        assertThat(actual).hasSize(5);
+    }
+
     @DisplayName("특정 멤버가 생성한 카테고리를 조회한다.")
     @Test
     void 특정_멤버가_생성한_카테고리를_조회한다() {

--- a/backend/src/test/java/com/allog/dallog/domain/categoryrole/application/CategoryRoleServiceTest.java
+++ b/backend/src/test/java/com/allog/dallog/domain/categoryrole/application/CategoryRoleServiceTest.java
@@ -58,7 +58,7 @@ class CategoryRoleServiceTest extends ServiceTest {
         CategoryRoleUpdateRequest request = new CategoryRoleUpdateRequest(ADMIN);
         categoryRoleService.updateRole(관리자.getId(), 후디.getId(), BE_일정.getId(), request);
 
-        CategoryRole actual = categoryRoleRepository.findByMemberIdAndCategoryId(후디.getId(), BE_일정.getId()).get();
+        CategoryRole actual = categoryRoleRepository.getByMemberIdAndCategoryId(후디.getId(), BE_일정.getId());
 
         // then
         assertThat(actual.getCategoryRoleType()).isEqualTo(ADMIN);
@@ -103,7 +103,7 @@ class CategoryRoleServiceTest extends ServiceTest {
 
         // when
         categoryRoleService.updateRole(후디.getId(), 매트.getId(), BE_일정.getId(), new CategoryRoleUpdateRequest(NONE));
-        CategoryRole actual = categoryRoleRepository.findByMemberIdAndCategoryId(매트.getId(), BE_일정.getId()).get();
+        CategoryRole actual = categoryRoleRepository.getByMemberIdAndCategoryId(매트.getId(), BE_일정.getId());
 
         // then
         assertThat(actual.getCategoryRoleType()).isEqualTo(NONE);
@@ -125,7 +125,7 @@ class CategoryRoleServiceTest extends ServiceTest {
         CategoryRoleUpdateRequest request = new CategoryRoleUpdateRequest(NONE);
         categoryRoleService.updateRole(관리자.getId(), 관리자.getId(), BE_일정.getId(), request);
 
-        CategoryRole actual = categoryRoleRepository.findByMemberIdAndCategoryId(관리자.getId(), BE_일정.getId()).get();
+        CategoryRole actual = categoryRoleRepository.getByMemberIdAndCategoryId(관리자.getId(), BE_일정.getId());
 
         // then
         assertThat(actual.getCategoryRoleType()).isEqualTo(NONE);

--- a/backend/src/test/java/com/allog/dallog/domain/categoryrole/domain/CategoryRoleRepositoryTest.java
+++ b/backend/src/test/java/com/allog/dallog/domain/categoryrole/domain/CategoryRoleRepositoryTest.java
@@ -1,0 +1,74 @@
+package com.allog.dallog.domain.categoryrole.domain;
+
+import static com.allog.dallog.common.fixtures.CategoryFixtures.BE_일정;
+import static com.allog.dallog.common.fixtures.MemberFixtures.매트;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.allog.dallog.common.annotation.RepositoryTest;
+import com.allog.dallog.domain.category.domain.Category;
+import com.allog.dallog.domain.category.domain.CategoryRepository;
+import com.allog.dallog.domain.member.domain.Member;
+import com.allog.dallog.domain.member.domain.MemberRepository;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class CategoryRoleRepositoryTest extends RepositoryTest {
+
+    @Autowired
+    private CategoryRoleRepository categoryRoleRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private CategoryRepository categoryRepository;
+
+    @DisplayName("member id와 category id를 기반으로 조회한다.")
+    @Test
+    void member_id와_category_id를_기반으로_조회한다() {
+        // given
+        Member 매트 = memberRepository.save(매트());
+        Category BE_일정 = categoryRepository.save(BE_일정(매트));
+
+        CategoryRole savedCategoryRoleType = categoryRoleRepository.save(
+                new CategoryRole(BE_일정, 매트, CategoryRoleType.ADMIN));
+
+        // when
+        CategoryRole actual = categoryRoleRepository.getByMemberIdAndCategoryId(매트.getId(), BE_일정.getId());
+
+        // then
+        assertThat(actual).isEqualTo(savedCategoryRoleType);
+    }
+
+    @DisplayName("category id를 기반으로 조회한다.")
+    @Test
+    void category_id를_기반으로_조회한다() {
+        // given
+        Member 매트 = memberRepository.save(매트());
+        Category BE_일정 = categoryRepository.save(BE_일정(매트));
+        categoryRoleRepository.save(new CategoryRole(BE_일정, 매트, CategoryRoleType.ADMIN));
+
+        // when
+        List<CategoryRole> actual = categoryRoleRepository.findByMemberId(매트.getId());
+
+        // then
+        assertThat(actual).hasSize(1);
+    }
+
+    @DisplayName("특정 카테고리에 admin이 혼자인지 확인한다.")
+    @Test
+    void 특정_카테고리에_admin이_혼자인지_확인한다() {
+        // given
+        Member 매트 = memberRepository.save(매트());
+        Category BE_일정 = categoryRepository.save(BE_일정(매트));
+        categoryRoleRepository.save(new CategoryRole(BE_일정, 매트, CategoryRoleType.ADMIN));
+
+        // when
+        boolean actual = categoryRoleRepository.isMemberSoleAdminInCategory(매트.getId(), BE_일정.getId());
+
+        // then
+        assertThat(actual).isTrue();
+    }
+}

--- a/backend/src/test/java/com/allog/dallog/domain/subscription/application/SubscriptionServiceTest.java
+++ b/backend/src/test/java/com/allog/dallog/domain/subscription/application/SubscriptionServiceTest.java
@@ -26,6 +26,7 @@ import com.allog.dallog.domain.category.dto.response.CategoryResponse;
 import com.allog.dallog.domain.categoryrole.domain.CategoryRole;
 import com.allog.dallog.domain.categoryrole.domain.CategoryRoleRepository;
 import com.allog.dallog.domain.categoryrole.domain.CategoryRoleType;
+import com.allog.dallog.domain.categoryrole.exception.NoSuchCategoryRoleException;
 import com.allog.dallog.domain.member.domain.Member;
 import com.allog.dallog.domain.member.domain.MemberRepository;
 import com.allog.dallog.domain.subscription.domain.Color;
@@ -269,7 +270,7 @@ class SubscriptionServiceTest extends ServiceTest {
         Member 후디 = memberRepository.save(후디());
         subscriptionService.save(후디.getId(), 공통_일정.getId());
 
-        CategoryRole actual = categoryRoleRepository.findByMemberIdAndCategoryId(후디.getId(), 공통_일정.getId()).get();
+        CategoryRole actual = categoryRoleRepository.getByMemberIdAndCategoryId(후디.getId(), 공통_일정.getId());
 
         // then
         assertThat(actual.getCategoryRoleType()).isEqualTo(CategoryRoleType.NONE);
@@ -287,10 +288,10 @@ class SubscriptionServiceTest extends ServiceTest {
 
         // when
         subscriptionService.delete(공통_일정_구독.getId(), 후디.getId());
-        boolean actual = categoryRoleRepository.findByMemberIdAndCategoryId(후디.getId(), 공통_일정.getId()).isPresent();
 
         // then
-        assertThat(actual).isFalse();
+        assertThatThrownBy(() -> categoryRoleRepository.getByMemberIdAndCategoryId(후디.getId(), 공통_일정.getId()))
+                .isInstanceOf(NoSuchCategoryRoleException.class);
     }
 
     @Transactional
@@ -304,7 +305,7 @@ class SubscriptionServiceTest extends ServiceTest {
         Member 후디 = memberRepository.save(후디());
         SubscriptionResponse 공통_일정_구독 = subscriptionService.save(후디.getId(), 공통_일정.getId());
 
-        CategoryRole 역할 = categoryRoleRepository.findByMemberIdAndCategoryId(후디.getId(), 공통_일정.getId()).get();
+        CategoryRole 역할 = categoryRoleRepository.getByMemberIdAndCategoryId(후디.getId(), 공통_일정.getId());
         역할.changeRole(CategoryRoleType.ADMIN);
 
         // when & then

--- a/backend/src/test/java/com/allog/dallog/domain/subscription/domain/SubscriptionRepositoryTest.java
+++ b/backend/src/test/java/com/allog/dallog/domain/subscription/domain/SubscriptionRepositoryTest.java
@@ -4,7 +4,6 @@ import static com.allog.dallog.common.fixtures.CategoryFixtures.BE_일정;
 import static com.allog.dallog.common.fixtures.CategoryFixtures.FE_일정;
 import static com.allog.dallog.common.fixtures.CategoryFixtures.공통_일정;
 import static com.allog.dallog.common.fixtures.MemberFixtures.관리자;
-import static com.allog.dallog.common.fixtures.MemberFixtures.리버;
 import static com.allog.dallog.common.fixtures.MemberFixtures.매트;
 import static com.allog.dallog.common.fixtures.MemberFixtures.파랑;
 import static com.allog.dallog.common.fixtures.MemberFixtures.후디;
@@ -23,8 +22,6 @@ import com.allog.dallog.domain.member.domain.MemberRepository;
 import com.allog.dallog.domain.subscription.exception.ExistSubscriptionException;
 import com.allog.dallog.domain.subscription.exception.NoSuchSubscriptionException;
 import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -136,47 +133,6 @@ class SubscriptionRepositoryTest extends RepositoryTest {
 
         // then
         assertThat(subscriptions).isEmpty();
-    }
-
-    @DisplayName("member id 리스트를 기반으로 구독 정보를 조회한다.")
-    @Test
-    void member_id_리스트를_기반으로_구독_정보를_조회한다() {
-        // given
-        Member 관리자 = memberRepository.save(관리자());
-        Category 공통_일정 = categoryRepository.save(공통_일정(관리자));
-
-        Member 매트 = memberRepository.save(매트());
-        Member 리버 = memberRepository.save(리버());
-        Member 파랑 = memberRepository.save(파랑());
-        Member 후디 = memberRepository.save(후디());
-
-        subscriptionRepository.save(색상1_구독(매트, 공통_일정));
-        subscriptionRepository.save(색상1_구독(리버, 공통_일정));
-        subscriptionRepository.save(색상1_구독(파랑, 공통_일정));
-        subscriptionRepository.save(색상1_구독(후디, 공통_일정));
-
-        List<Long> memberIds = Stream.of(매트, 리버, 파랑, 후디)
-                .map(Member::getId)
-                .collect(Collectors.toList());
-
-        // when
-        List<Subscription> actual = subscriptionRepository.findByMemberIdIn(memberIds);
-
-        // then
-        assertThat(actual).hasSize(4);
-    }
-
-    @DisplayName("member id 리스트가 비어있는 경우 빈 리스트를 반환한다.")
-    @Test
-    void member_id_리스트가_비어있는_경우_빈_리스트를_반환한다() {
-        // given
-        List<Long> memberIds = List.of();
-
-        // when
-        List<Subscription> actual = subscriptionRepository.findByMemberIdIn(memberIds);
-
-        // then
-        assertThat(actual).isEmpty();
     }
 
     @DisplayName("특정 카테고리들에 속한 구독을 전부 삭제한다")


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 💻 git rebase를 사용했나요?
- [x] 🌈 알록달록한가요?

## 작업 내용

불필요하게 join을 활용하는 조회 로직을 개선한다.

### 예시

```java
Optional<OAuthToken> findByMemberId(final Long memberId);
```

### 개선 전

```java
Hibernate: 
    select
        oauthtoken0_.id as id1_4_,
        oauthtoken0_.created_at as created_2_4_,
        oauthtoken0_.updated_at as updated_3_4_,
        oauthtoken0_.members_id as members_5_4_,
        oauthtoken0_.refresh_token as refresh_4_4_ 
    from
        oauth_tokens oauthtoken0_ 
    left outer join
        members member1_ 
            on oauthtoken0_.members_id=member1_.id 
    where
        member1_.id=?
```

### 개선 후

```java
Hibernate: 
    select
        oauthtoken0_.id as id1_4_,
        oauthtoken0_.created_at as created_2_4_,
        oauthtoken0_.updated_at as updated_3_4_,
        oauthtoken0_.members_id as members_5_4_,
        oauthtoken0_.refresh_token as refresh_4_4_ 
    from
        oauth_tokens oauthtoken0_ 
    where
        oauthtoken0_.members_id=?
```

## 스크린샷

## 주의사항

Closes #725 
