### PR TITLE
[fix] 카테고리 단건 조회 시 타입 체크를 제거한다.

### DIFF
--- a/backend/src/main/java/com/allog/dallog/domain/category/application/CategoryService.java
+++ b/backend/src/main/java/com/allog/dallog/domain/category/application/CategoryService.java
@@ -133,8 +133,6 @@ public class CategoryService {
 
     public CategoryDetailResponse findDetailCategoryById(final Long id) {
         Category category = categoryRepository.getById(id);
-        category.validateNormalCategory();
-
         List<Subscription> subscriptions = subscriptionRepository.findByCategoryId(id);
         return new CategoryDetailResponse(category, subscriptions.size());
     }

--- a/backend/src/main/java/com/allog/dallog/domain/category/domain/Category.java
+++ b/backend/src/main/java/com/allog/dallog/domain/category/domain/Category.java
@@ -92,12 +92,6 @@ public class Category extends BaseEntity {
         }
     }
 
-    public void validateNormalCategory() {
-        if (categoryType != NORMAL) {
-            throw new NoPermissionException("기본 카테고리가 아니면 조회할 수 없습니다.");
-        }
-    }
-
     public boolean isCreatorId(final Long creatorId) {
         return member.hasSameId(creatorId);
     }

--- a/backend/src/test/java/com/allog/dallog/domain/category/application/CategoryServiceTest.java
+++ b/backend/src/test/java/com/allog/dallog/domain/category/application/CategoryServiceTest.java
@@ -33,7 +33,6 @@ import com.allog.dallog.common.annotation.ServiceTest;
 import com.allog.dallog.common.fixtures.AuthFixtures;
 import com.allog.dallog.common.fixtures.CategoryFixtures;
 import com.allog.dallog.domain.auth.application.AuthService;
-import com.allog.dallog.domain.auth.exception.NoPermissionException;
 import com.allog.dallog.domain.category.domain.Category;
 import com.allog.dallog.domain.category.domain.CategoryRepository;
 import com.allog.dallog.domain.category.dto.request.CategoryCreateRequest;
@@ -394,18 +393,6 @@ class CategoryServiceTest extends ServiceTest {
         // when & then
         assertThatThrownBy(() -> categoryService.findDetailCategoryById(공통_일정.getId() + 1))
                 .isInstanceOf(NoSuchCategoryException.class);
-    }
-
-    @DisplayName("normal 카테고리가 아닌 카테고리를 조회할 경우 예외를 던진다.")
-    @Test
-    void normal_카테고리가_아닌_카테고리를_조회할_경우_예외를_던진다() {
-        // given
-        Member 매트 = memberRepository.save(매트());
-        CategoryResponse 내_일정 = categoryService.save(매트.getId(), 내_일정_생성_요청);
-
-        // when & then
-        assertThatThrownBy(() -> categoryService.findDetailCategoryById(내_일정.getId()))
-                .isInstanceOf(NoPermissionException.class);
     }
 
     @DisplayName("ADMIN 역할의 멤버는 카테고리를 수정할 수 있다.")

--- a/backend/src/test/java/com/allog/dallog/domain/category/domain/CategoryTest.java
+++ b/backend/src/test/java/com/allog/dallog/domain/category/domain/CategoryTest.java
@@ -4,13 +4,11 @@ import static com.allog.dallog.common.fixtures.CategoryFixtures.BE_일정;
 import static com.allog.dallog.common.fixtures.CategoryFixtures.내_일정;
 import static com.allog.dallog.common.fixtures.CategoryFixtures.우아한테크코스_일정;
 import static com.allog.dallog.common.fixtures.MemberFixtures.관리자;
-import static com.allog.dallog.common.fixtures.MemberFixtures.매트;
 import static com.allog.dallog.common.fixtures.MemberFixtures.후디;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
-import com.allog.dallog.domain.auth.exception.NoPermissionException;
 import com.allog.dallog.domain.category.exception.InvalidCategoryException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -59,17 +57,6 @@ class CategoryTest {
         // when & then
         assertThatThrownBy(() -> 내_일정.changeName("바꿀 이름"))
                 .isInstanceOf(InvalidCategoryException.class);
-    }
-
-    @DisplayName("normal 카테고리가 아니면 예외를 던진다.")
-    @Test
-    void normal_카테고리가_아니면_예외를_던진다() {
-        // given
-        Category 내_일정 = 내_일정(매트());
-
-        // when & then
-        assertThatThrownBy(내_일정::validateNormalCategory)
-                .isInstanceOf(NoPermissionException.class);
     }
 
     @DisplayName("제공된 멤버의 ID와 카테고리를 생성한 멤버의 ID가 일치하지 않으면 false를 반환한다.")


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 💻 git rebase를 사용했나요?
- [x] 🌈 알록달록한가요?

## 작업 내용

카테고리 단건 조회 시 타입 체크를 제거한다. 범용적으로 사용하는 단 건 조회의 타입 체크 로직을 제거한다.

## 스크린샷

## 주의사항

Closes #742 
