### PR TITLE
[refactor] 프로필 관련 query를 커스텀 훅으로 분리한다.

### DIFF
--- a/frontend/src/components/Profile/Profile.tsx
+++ b/frontend/src/components/Profile/Profile.tsx
@@ -1,7 +1,7 @@
 import { useRef, useState } from 'react';
-import { useMutation, useQueryClient } from 'react-query';
 import { useNavigate } from 'react-router-dom';
 
+import { usePatchProfile } from '@/hooks/@queries/profile';
 import useToggle from '@/hooks/useToggle';
 import useUserValue from '@/hooks/useUserValue';
 
@@ -11,13 +11,10 @@ import ModalPortal from '@/components/@common/ModalPortal/ModalPortal';
 import WithdrawalModal from '@/components/WithdrawalModal/WithdrawalModal';
 
 import { PATH } from '@/constants';
-import { CACHE_KEY } from '@/constants/api';
 import { CONFIRM_MESSAGE } from '@/constants/message';
 
 import { createPostBody } from '@/utils';
 import { removeAccessToken } from '@/utils/storage';
-
-import profileApi from '@/api/profile';
 
 import { MdOutlineCheck, MdOutlineModeEdit } from 'react-icons/md';
 
@@ -46,18 +43,9 @@ function Profile() {
     displayName: useRef<HTMLInputElement>(null),
   };
 
-  const queryClient = useQueryClient();
-  const { mutate } = useMutation(
-    (body: { displayName: string }) => profileApi.patch(user.accessToken, body),
-    {
-      onSuccess: () => {
-        queryClient.invalidateQueries(CACHE_KEY.PROFILE);
-        queryClient.invalidateQueries(CACHE_KEY.CATEGORIES);
-      },
-    }
-  );
-
   const { state: isWithdrawalModalOpen, toggleState: toggleWithdrawalModalOpen } = useToggle();
+
+  const { mutate } = usePatchProfile({ accessToken: user.accessToken });
 
   const handleClickModifyButton = () => {
     setEditingName(true);

--- a/frontend/src/components/WithdrawalModal/WithdrawalModal.tsx
+++ b/frontend/src/components/WithdrawalModal/WithdrawalModal.tsx
@@ -1,22 +1,13 @@
 import { validateWithdrawalCondition } from '@/validation';
-import { useMutation } from 'react-query';
-import { useNavigate } from 'react-router-dom';
-import { useRecoilValue } from 'recoil';
 
+import { useDeleteProfile } from '@/hooks/@queries/profile';
 import useControlledInput from '@/hooks/useControlledInput';
-
-import { userState } from '@/recoil/atoms';
 
 import Button from '@/components/@common/Button/Button';
 import Fieldset from '@/components/@common/Fieldset/Fieldset';
 
-import { PATH } from '@/constants';
 import { CONFIRM_MESSAGE } from '@/constants/message';
 import { VALIDATION_STRING } from '@/constants/validate';
-
-import { removeAccessToken } from '@/utils/storage';
-
-import profileApi from '@/api/profile';
 
 import {
   headerStyle,
@@ -30,27 +21,14 @@ interface WithdrawalModalProps {
 }
 
 function WithdrawalModal({ closeModal }: WithdrawalModalProps) {
-  const navigate = useNavigate();
-
-  const { accessToken } = useRecoilValue(userState);
-
   const { inputValue, onChangeValue } = useControlledInput();
 
-  const { mutate } = useMutation(() => profileApi.delete(accessToken), {
-    onSuccess: () => onSuccessWithdrawalUser(),
-  });
+  const { mutate } = useDeleteProfile({ onSuccess: closeModal });
 
   const handleClickWithdrawalButton = () => {
     if (window.confirm(CONFIRM_MESSAGE.WITHDRAWAL)) {
       mutate();
     }
-  };
-
-  const onSuccessWithdrawalUser = () => {
-    closeModal();
-    removeAccessToken();
-    navigate(PATH.MAIN);
-    location.reload();
   };
 
   return (

--- a/frontend/src/hooks/@queries/category.ts
+++ b/frontend/src/hooks/@queries/category.ts
@@ -52,12 +52,12 @@ interface UsePatchCategoryRoleParams {
   onSuccess?: () => void;
 }
 
-interface UsePostCategoryParams {
+interface UsePatchCategoryNameParams {
+  categoryId: number;
   onSuccess?: () => void;
 }
 
-interface UsePatchCategoryNameParams {
-  categoryId: number;
+interface UsePostCategoryParams {
   onSuccess?: () => void;
 }
 

--- a/frontend/src/hooks/@queries/category.ts
+++ b/frontend/src/hooks/@queries/category.ts
@@ -15,53 +15,53 @@ import { API, CACHE_KEY } from '@/constants/api';
 
 import categoryApi from '@/api/category';
 
-interface useDeleteCategoryProps {
+interface UseDeleteCategoryParams {
   categoryId: number;
   onSuccess?: () => void;
 }
 
-interface useGetAdminCategoriesProps {
+interface UseGetAdminCategoriesParams {
   enabled?: boolean;
 }
 
-interface useGetEditableCategoriesProps {
+interface UseGetEditableCategoriesParams {
   enabled?: boolean;
 }
 
-interface useGetEntireCategoriesProps {
+interface UseGetEntireCategoriesParams {
   keyword: string;
 }
 
-interface useGetSchedulesWithCategoryProps {
+interface UseGetSchedulesWithCategoryParams {
   categoryId: number;
   startDateTime: string;
   endDateTime: string;
 }
 
-interface useGetSingleCategoryProps {
+interface UseGetSingleCategoryParams {
   categoryId: number;
 }
 
-interface useGetSubscribersProps {
+interface UseGetSubscribersParams {
   categoryId: number;
 }
 
-interface usePatchCategoryRoleProps {
+interface UsePatchCategoryRoleParams {
   categoryId: number;
   memberId: number;
   onSuccess?: () => void;
 }
 
-interface usePostCategoryProps {
+interface UsePostCategoryParams {
   onSuccess?: () => void;
 }
 
-interface usePatchCategoryNameProps {
+interface UsePatchCategoryNameParams {
   categoryId: number;
   onSuccess?: () => void;
 }
 
-function useDeleteCategory({ categoryId, onSuccess }: useDeleteCategoryProps) {
+function useDeleteCategory({ categoryId, onSuccess }: UseDeleteCategoryParams) {
   const { accessToken } = useRecoilValue(userState);
   const queryClient = useQueryClient();
 
@@ -78,7 +78,7 @@ function useDeleteCategory({ categoryId, onSuccess }: useDeleteCategoryProps) {
   return { mutate };
 }
 
-function useGetAdminCategories({ enabled }: useGetAdminCategoriesProps) {
+function useGetAdminCategories({ enabled }: UseGetAdminCategoriesParams) {
   const { accessToken } = useRecoilValue(userState);
 
   const { isLoading, data } = useQuery<AxiosResponse<CategoryType[]>, AxiosError>(
@@ -92,7 +92,7 @@ function useGetAdminCategories({ enabled }: useGetAdminCategoriesProps) {
   return { isLoading, data };
 }
 
-function useGetEditableCategories({ enabled }: useGetEditableCategoriesProps) {
+function useGetEditableCategories({ enabled }: UseGetEditableCategoriesParams) {
   const { accessToken } = useRecoilValue(userState);
 
   const { isLoading, data } = useQuery<AxiosResponse<CategoryType[]>, AxiosError>(
@@ -106,7 +106,7 @@ function useGetEditableCategories({ enabled }: useGetEditableCategoriesProps) {
   return { isLoading, data };
 }
 
-function useGetEntireCategories({ keyword }: useGetEntireCategoriesProps) {
+function useGetEntireCategories({ keyword }: UseGetEntireCategoriesParams) {
   const { error, data, fetchNextPage, hasNextPage } = useInfiniteQuery<
     AxiosResponse<CategoriesGetResponseType>,
     AxiosError
@@ -140,7 +140,7 @@ function useGetSchedulesWithCategory({
   categoryId,
   startDateTime,
   endDateTime,
-}: useGetSchedulesWithCategoryProps) {
+}: UseGetSchedulesWithCategoryParams) {
   const { isLoading, data } = useQuery(
     [CACHE_KEY.SCHEDULES, categoryId],
     () => categoryApi.getSchedules(categoryId, startDateTime, endDateTime),
@@ -152,7 +152,7 @@ function useGetSchedulesWithCategory({
   return { isLoading, data };
 }
 
-function useGetSingleCategory({ categoryId }: useGetSingleCategoryProps) {
+function useGetSingleCategory({ categoryId }: UseGetSingleCategoryParams) {
   const { data } = useQuery<AxiosResponse<CategoryType>, AxiosError>(CACHE_KEY.CATEGORY, () =>
     categoryApi.getSingle(categoryId)
   );
@@ -160,7 +160,7 @@ function useGetSingleCategory({ categoryId }: useGetSingleCategoryProps) {
   return { data };
 }
 
-function useGetSubscribers({ categoryId }: useGetSubscribersProps) {
+function useGetSubscribers({ categoryId }: UseGetSubscribersParams) {
   const { accessToken } = useRecoilValue(userState);
 
   const { isLoading, data } = useQuery<AxiosResponse<CategorySubscriberType[]>, AxiosError>(
@@ -171,7 +171,7 @@ function useGetSubscribers({ categoryId }: useGetSubscribersProps) {
   return { isLoading, data };
 }
 
-function usePatchCategoryName({ categoryId, onSuccess }: usePatchCategoryNameProps) {
+function usePatchCategoryName({ categoryId, onSuccess }: UsePatchCategoryNameParams) {
   const { accessToken } = useRecoilValue(userState);
   const queryClient = useQueryClient();
 
@@ -193,7 +193,7 @@ function usePatchCategoryName({ categoryId, onSuccess }: usePatchCategoryNamePro
   return { mutate };
 }
 
-function usePatchCategoryRole({ categoryId, memberId, onSuccess }: usePatchCategoryRoleProps) {
+function usePatchCategoryRole({ categoryId, memberId, onSuccess }: UsePatchCategoryRoleParams) {
   const { accessToken } = useRecoilValue(userState);
   const queryClient = useQueryClient();
 
@@ -212,7 +212,7 @@ function usePatchCategoryRole({ categoryId, memberId, onSuccess }: usePatchCateg
   return { mutate };
 }
 
-function usePostCategory({ onSuccess }: usePostCategoryProps) {
+function usePostCategory({ onSuccess }: UsePostCategoryParams) {
   const { accessToken } = useRecoilValue(userState);
   const queryClient = useQueryClient();
 

--- a/frontend/src/hooks/@queries/googleCalendar.ts
+++ b/frontend/src/hooks/@queries/googleCalendar.ts
@@ -10,7 +10,7 @@ import { CACHE_KEY } from '@/constants/api';
 
 import googleCalendarApi from '@/api/googleCalendar';
 
-interface usePostGoogleCalendarCategoryProps {
+interface UsePostGoogleCalendarCategoryParams {
   onSuccess?: () => void;
 }
 
@@ -25,7 +25,7 @@ function useGetGoogleCalendar() {
   return { isLoading, data };
 }
 
-function usePostGoogleCalendarCategory({ onSuccess }: usePostGoogleCalendarCategoryProps) {
+function usePostGoogleCalendarCategory({ onSuccess }: UsePostGoogleCalendarCategoryParams) {
   const { accessToken } = useRecoilValue(userState);
   const queryClient = useQueryClient();
 

--- a/frontend/src/hooks/@queries/profile.ts
+++ b/frontend/src/hooks/@queries/profile.ts
@@ -11,15 +11,15 @@ import { removeAccessToken } from '@/utils/storage';
 
 import profileApi from '@/api/profile';
 
-interface useDeleteProfileProps {
+interface UseDeleteProfileParams {
   onSuccess?: () => void;
 }
 
-interface usePatchProfileProps {
+interface UsePatchProfileParams {
   accessToken: string;
 }
 
-function useDeleteProfile({ onSuccess }: useDeleteProfileProps) {
+function useDeleteProfile({ onSuccess }: UseDeleteProfileParams) {
   const navigate = useNavigate();
 
   const { accessToken } = useRecoilValue(userState);
@@ -36,7 +36,7 @@ function useDeleteProfile({ onSuccess }: useDeleteProfileProps) {
   return { mutate };
 }
 
-function usePatchProfile({ accessToken }: usePatchProfileProps) {
+function usePatchProfile({ accessToken }: UsePatchProfileParams) {
   const queryClient = useQueryClient();
 
   const { mutate } = useMutation(

--- a/frontend/src/hooks/@queries/profile.ts
+++ b/frontend/src/hooks/@queries/profile.ts
@@ -1,0 +1,55 @@
+import { useMutation, useQueryClient } from 'react-query';
+import { useNavigate } from 'react-router-dom';
+import { useRecoilValue } from 'recoil';
+
+import { userState } from '@/recoil/atoms';
+
+import { PATH } from '@/constants';
+import { CACHE_KEY } from '@/constants/api';
+
+import { removeAccessToken } from '@/utils/storage';
+
+import profileApi from '@/api/profile';
+
+interface useDeleteProfileProps {
+  onSuccess?: () => void;
+}
+
+interface usePatchProfileProps {
+  accessToken: string;
+}
+
+function useDeleteProfile({ onSuccess }: useDeleteProfileProps) {
+  const navigate = useNavigate();
+
+  const { accessToken } = useRecoilValue(userState);
+
+  const { mutate } = useMutation(() => profileApi.delete(accessToken), {
+    onSuccess: () => {
+      onSuccess && onSuccess();
+      removeAccessToken();
+      navigate(PATH.MAIN);
+      location.reload();
+    },
+  });
+
+  return { mutate };
+}
+
+function usePatchProfile({ accessToken }: usePatchProfileProps) {
+  const queryClient = useQueryClient();
+
+  const { mutate } = useMutation(
+    (body: { displayName: string }) => profileApi.patch(accessToken, body),
+    {
+      onSuccess: () => {
+        queryClient.invalidateQueries(CACHE_KEY.PROFILE);
+        queryClient.invalidateQueries(CACHE_KEY.CATEGORIES);
+      },
+    }
+  );
+
+  return { mutate };
+}
+
+export { useDeleteProfile, usePatchProfile };

--- a/frontend/src/hooks/@queries/schedule.ts
+++ b/frontend/src/hooks/@queries/schedule.ts
@@ -10,27 +10,27 @@ import { CACHE_KEY } from '@/constants/api';
 
 import scheduleApi from '@/api/schedule';
 
-interface useGetSchedulesProps {
+interface UseGetSchedulesParams {
   startDateTime: string;
   endDateTime: string;
 }
 
-interface useDeleteScheduleProps {
+interface UseDeleteScheduleParams {
   scheduleId: string;
   onSuccess?: () => void;
 }
 
-interface usePatchScheduleProps {
+interface UsePatchScheduleParams {
   scheduleId: string;
   onSuccess?: () => void;
 }
 
-interface usePostScheduleProps {
+interface UsePostScheduleParams {
   categoryId: string;
   onSuccess?: () => void;
 }
 
-function useDeleteSchedule({ scheduleId, onSuccess }: useDeleteScheduleProps) {
+function useDeleteSchedule({ scheduleId, onSuccess }: UseDeleteScheduleParams) {
   const { accessToken } = useRecoilValue(userState);
   const queryClient = useQueryClient();
 
@@ -47,7 +47,7 @@ function useDeleteSchedule({ scheduleId, onSuccess }: useDeleteScheduleProps) {
   return { mutate };
 }
 
-function useGetSchedules({ startDateTime, endDateTime }: useGetSchedulesProps) {
+function useGetSchedules({ startDateTime, endDateTime }: UseGetSchedulesParams) {
   const { accessToken } = useRecoilValue(userState);
 
   const { isLoading, data } = useQuery<AxiosResponse<ScheduleResponseType>, AxiosError>(
@@ -61,7 +61,7 @@ function useGetSchedules({ startDateTime, endDateTime }: useGetSchedulesProps) {
   };
 }
 
-function usePatchSchedule({ scheduleId, onSuccess }: usePatchScheduleProps) {
+function usePatchSchedule({ scheduleId, onSuccess }: UsePatchScheduleParams) {
   const { accessToken } = useRecoilValue(userState);
   const queryClient = useQueryClient();
 
@@ -80,7 +80,7 @@ function usePatchSchedule({ scheduleId, onSuccess }: usePatchScheduleProps) {
   return { mutate };
 }
 
-function usePostSchedule({ categoryId, onSuccess }: usePostScheduleProps) {
+function usePostSchedule({ categoryId, onSuccess }: UsePostScheduleParams) {
   const { accessToken } = useRecoilValue(userState);
   const queryClient = useQueryClient();
 

--- a/frontend/src/hooks/@queries/schedule.ts
+++ b/frontend/src/hooks/@queries/schedule.ts
@@ -10,14 +10,14 @@ import { CACHE_KEY } from '@/constants/api';
 
 import scheduleApi from '@/api/schedule';
 
-interface UseGetSchedulesParams {
-  startDateTime: string;
-  endDateTime: string;
-}
-
 interface UseDeleteScheduleParams {
   scheduleId: string;
   onSuccess?: () => void;
+}
+
+interface UseGetSchedulesParams {
+  startDateTime: string;
+  endDateTime: string;
 }
 
 interface UsePatchScheduleParams {

--- a/frontend/src/hooks/@queries/subscription.ts
+++ b/frontend/src/hooks/@queries/subscription.ts
@@ -10,26 +10,26 @@ import { CACHE_KEY } from '@/constants/api';
 
 import subscriptionApi from '@/api/subscription';
 
-interface useDeleteSubscriptionProps {
+interface UseDeleteSubscriptionParams {
   subscriptionId: number;
   onSuccess?: () => void;
 }
 
-interface useGetSubscriptionsProps {
+interface UseGetSubscriptionsParams {
   enabled?: boolean;
 }
 
-interface usePatchSubscriptionProps {
+interface UsePatchSubscriptionParams {
   subscriptionId: number;
   onSuccess?: () => void;
 }
 
-interface usePostSubscriptionProps {
+interface UsePostSubscriptionParams {
   categoryId: number;
   onSuccess?: () => void;
 }
 
-function useDeleteSubscriptions({ subscriptionId, onSuccess }: useDeleteSubscriptionProps) {
+function useDeleteSubscriptions({ subscriptionId, onSuccess }: UseDeleteSubscriptionParams) {
   const { accessToken } = useRecoilValue(userState);
   const queryClient = useQueryClient();
 
@@ -43,7 +43,7 @@ function useDeleteSubscriptions({ subscriptionId, onSuccess }: useDeleteSubscrip
   return { mutate };
 }
 
-function useGetSubscriptions({ enabled }: useGetSubscriptionsProps) {
+function useGetSubscriptions({ enabled }: UseGetSubscriptionsParams) {
   const { accessToken } = useRecoilValue(userState);
 
   const { isLoading, error, data } = useQuery<AxiosResponse<SubscriptionType[]>, AxiosError>(
@@ -57,7 +57,7 @@ function useGetSubscriptions({ enabled }: useGetSubscriptionsProps) {
   return { isLoading, error, data };
 }
 
-function usePatchSubscription({ subscriptionId, onSuccess }: usePatchSubscriptionProps) {
+function usePatchSubscription({ subscriptionId, onSuccess }: UsePatchSubscriptionParams) {
   const { accessToken } = useRecoilValue(userState);
   const queryClient = useQueryClient();
 
@@ -75,7 +75,7 @@ function usePatchSubscription({ subscriptionId, onSuccess }: usePatchSubscriptio
   return { isLoading, mutate };
 }
 
-function usePostSubscription({ categoryId, onSuccess }: usePostSubscriptionProps) {
+function usePostSubscription({ categoryId, onSuccess }: UsePostSubscriptionParams) {
   const { accessToken } = useRecoilValue(userState);
   const queryClient = useQueryClient();
 


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 💻 git rebase를 사용했나요?
- [x] 🌈 알록달록한가요?

## 주의사항

1. `useUserValue`의 user 값을 Profile 컴포넌트 안에서도 사용하고 `usePatchProfile`에서도 사용합니다. `useUserValue`를 각각 호출하는 것보다는 한 번 호출 후 값을 넘겨 사용하는 게 낫다고 판단해서 `usePatchProfile` 인수로 넘겨주었습니다. 나인의 의견도 궁금하네요 🤔
2. `useUserValue` 안에 profile을 get하는 query가 있습니다. 이것도 분리하자니 분리한 훅이 useUserValue 그 자체가 되어버릴 것 같기도 하고, 너무 억지스럽다는 느낌이 강하게 들어 분리하지 않았어요. 이에 대해서도 의견 부탁드립니다~!
3. 커스텀 훅에 사용되는 매개변수 interface 명 정리가 필요해요! 이전에 `useValidateSchedule` 훅을 만들 때에는 `useValidateScheduleParametersType`이라는 이름으로 만들었었네요 😮 query 관련 훅에서는 컴포넌트의 props 타입처럼 ({훅 이름}{Props}) 명명하고 있어요. 정리 한번 하고 넘어가는 거 어떨까요~!

Closes #734 
