### PR TITLE
[feat] 한 사람이 관리할 수 있는 최대 카테고리 개수 제한을 추가한다. 

### DIFF
--- a/backend/src/main/java/com/allog/dallog/domain/category/application/CategoryService.java
+++ b/backend/src/main/java/com/allog/dallog/domain/category/application/CategoryService.java
@@ -22,7 +22,6 @@ import com.allog.dallog.domain.categoryrole.domain.CategoryAuthority;
 import com.allog.dallog.domain.categoryrole.domain.CategoryRole;
 import com.allog.dallog.domain.categoryrole.domain.CategoryRoleRepository;
 import com.allog.dallog.domain.categoryrole.domain.CategoryRoleType;
-import com.allog.dallog.domain.categoryrole.exception.ManagingCategoryLimitExcessException;
 import com.allog.dallog.domain.member.domain.Member;
 import com.allog.dallog.domain.member.domain.MemberRepository;
 import com.allog.dallog.domain.schedule.domain.ScheduleRepository;
@@ -65,7 +64,7 @@ public class CategoryService {
 
     @Transactional
     public CategoryResponse save(final Long memberId, final CategoryCreateRequest request) {
-        validateManagingCategoryLimit(memberId);
+        categoryRoleRepository.validateManagingCategoryLimit(memberId, ADMIN);
 
         Member member = memberRepository.getById(memberId);
         Category category = request.toEntity(member);
@@ -79,14 +78,6 @@ public class CategoryService {
     private void subscribeCategory(final Member member, final Category category) {
         Color color = Color.pick(colorPicker.pickNumber());
         subscriptionRepository.save(new Subscription(member, category, color));
-    }
-
-    private void validateManagingCategoryLimit(final Long memberId) {
-        int memberAdminCount = categoryRoleRepository.countByMemberIdAndCategoryRoleType(memberId, ADMIN);
-
-        if (memberAdminCount >= CategoryRole.MAX_MANAGING_CATEGORY_COUNT) {
-            throw new ManagingCategoryLimitExcessException();
-        }
     }
 
     private void createCategoryRoleAsAdminToCreator(final Member member, final Category category) {

--- a/backend/src/main/java/com/allog/dallog/domain/category/application/CategoryService.java
+++ b/backend/src/main/java/com/allog/dallog/domain/category/application/CategoryService.java
@@ -82,7 +82,7 @@ public class CategoryService {
     }
 
     private void validateManagingCategoryLimit(final Long memberId) {
-        int memberAdminCount = categoryRoleRepository.countAdminByMemberId(memberId);
+        int memberAdminCount = categoryRoleRepository.countByMemberIdAndCategoryRoleType(memberId, ADMIN);
 
         if (memberAdminCount >= CategoryRole.MAX_MANAGING_CATEGORY_COUNT) {
             throw new ManagingCategoryLimitExcessException();

--- a/backend/src/main/java/com/allog/dallog/domain/categoryrole/application/CategoryRoleService.java
+++ b/backend/src/main/java/com/allog/dallog/domain/categoryrole/application/CategoryRoleService.java
@@ -1,14 +1,11 @@
 package com.allog.dallog.domain.categoryrole.application;
 
-import static com.allog.dallog.domain.categoryrole.domain.CategoryRoleType.ADMIN;
-
 import com.allog.dallog.domain.category.domain.Category;
 import com.allog.dallog.domain.categoryrole.domain.CategoryAuthority;
 import com.allog.dallog.domain.categoryrole.domain.CategoryRole;
 import com.allog.dallog.domain.categoryrole.domain.CategoryRoleRepository;
 import com.allog.dallog.domain.categoryrole.domain.CategoryRoleType;
 import com.allog.dallog.domain.categoryrole.dto.request.CategoryRoleUpdateRequest;
-import com.allog.dallog.domain.categoryrole.exception.ManagingCategoryLimitExcessException;
 import com.allog.dallog.domain.categoryrole.exception.NotAbleToChangeRoleException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -30,7 +27,7 @@ public class CategoryRoleService {
 
         validateAuthority(loginMemberId, categoryId);
         validateSoleAdmin(memberId, categoryId);
-        validateManagingCategoryLimit(memberId, roleType);
+        categoryRoleRepository.validateManagingCategoryLimit(memberId, roleType);
 
         CategoryRole categoryRole = categoryRoleRepository.getByMemberIdAndCategoryId(memberId, categoryId);
 
@@ -49,14 +46,6 @@ public class CategoryRoleService {
         boolean isSoleAdmin = categoryRoleRepository.isMemberSoleAdminInCategory(memberId, categoryId);
         if (isSoleAdmin) {
             throw new NotAbleToChangeRoleException("변경 대상 회원이 유일한 ADMIN이므로 다른 역할로 변경할 수 없습니다.");
-        }
-    }
-
-    private void validateManagingCategoryLimit(final Long memberId, final CategoryRoleType roleType) {
-        int memberAdminCount = categoryRoleRepository.countByMemberIdAndCategoryRoleType(memberId, ADMIN);
-
-        if (roleType.equals(ADMIN) && memberAdminCount >= CategoryRole.MAX_MANAGING_CATEGORY_COUNT) {
-            throw new ManagingCategoryLimitExcessException();
         }
     }
 

--- a/backend/src/main/java/com/allog/dallog/domain/categoryrole/application/CategoryRoleService.java
+++ b/backend/src/main/java/com/allog/dallog/domain/categoryrole/application/CategoryRoleService.java
@@ -53,7 +53,7 @@ public class CategoryRoleService {
     }
 
     private void validateManagingCategoryLimit(final Long memberId, final CategoryRoleType roleType) {
-        int memberAdminCount = categoryRoleRepository.countAdminByMemberId(memberId);
+        int memberAdminCount = categoryRoleRepository.countByMemberIdAndCategoryRoleType(memberId, ADMIN);
 
         if (roleType.equals(ADMIN) && memberAdminCount >= CategoryRole.MAX_MANAGING_CATEGORY_COUNT) {
             throw new ManagingCategoryLimitExcessException();

--- a/backend/src/main/java/com/allog/dallog/domain/categoryrole/application/CategoryRoleService.java
+++ b/backend/src/main/java/com/allog/dallog/domain/categoryrole/application/CategoryRoleService.java
@@ -17,8 +17,6 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class CategoryRoleService {
 
-    private static final int MAX_MANAGING_CATEGORY_COUNT = 50;
-
     private final CategoryRoleRepository categoryRoleRepository;
 
     public CategoryRoleService(final CategoryRoleRepository categoryRoleRepository) {
@@ -55,12 +53,9 @@ public class CategoryRoleService {
     }
 
     private void validateManagingCategoryLimit(final Long memberId, final CategoryRoleType roleType) {
-        long memberAdminCount = categoryRoleRepository.findByMemberId(memberId)
-                .stream()
-                .filter(CategoryRole::isAdmin)
-                .count();
+        int memberAdminCount = categoryRoleRepository.countAdminByMemberId(memberId);
 
-        if (roleType.equals(ADMIN) && memberAdminCount >= MAX_MANAGING_CATEGORY_COUNT) {
+        if (roleType.equals(ADMIN) && memberAdminCount >= CategoryRole.MAX_MANAGING_CATEGORY_COUNT) {
             throw new ManagingCategoryLimitExcessException();
         }
     }

--- a/backend/src/main/java/com/allog/dallog/domain/categoryrole/application/CategoryRoleService.java
+++ b/backend/src/main/java/com/allog/dallog/domain/categoryrole/application/CategoryRoleService.java
@@ -17,6 +17,8 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class CategoryRoleService {
 
+    private static final int MAX_MANAGING_CATEGORY_COUNT = 50;
+
     private final CategoryRoleRepository categoryRoleRepository;
 
     public CategoryRoleService(final CategoryRoleRepository categoryRoleRepository) {
@@ -58,7 +60,7 @@ public class CategoryRoleService {
                 .filter(CategoryRole::isAdmin)
                 .count();
 
-        if (roleType.equals(ADMIN) && memberAdminCount >= 50) {
+        if (roleType.equals(ADMIN) && memberAdminCount >= MAX_MANAGING_CATEGORY_COUNT) {
             throw new ManagingCategoryLimitExcessException();
         }
     }

--- a/backend/src/main/java/com/allog/dallog/domain/categoryrole/domain/CategoryRole.java
+++ b/backend/src/main/java/com/allog/dallog/domain/categoryrole/domain/CategoryRole.java
@@ -19,6 +19,8 @@ import javax.persistence.Table;
 @Entity
 public class CategoryRole extends BaseEntity {
 
+    public static final int MAX_MANAGING_CATEGORY_COUNT = 50;
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/backend/src/main/java/com/allog/dallog/domain/categoryrole/domain/CategoryRoleRepository.java
+++ b/backend/src/main/java/com/allog/dallog/domain/categoryrole/domain/CategoryRoleRepository.java
@@ -25,8 +25,9 @@ public interface CategoryRoleRepository extends JpaRepository<CategoryRole, Long
 
     @Query("SELECT count(cr) "
             + "FROM CategoryRole cr "
-            + "WHERE cr.categoryRoleType = 'ADMIN' AND cr.member.id = :memberId")
-    int countAdminByMemberId(final Long memberId);
+            + "WHERE cr.categoryRoleType = :categoryRoleType "
+            + "AND cr.member.id = :memberId")
+    int countByMemberIdAndCategoryRoleType(final Long memberId, final CategoryRoleType categoryRoleType);
 
     int countByCategoryIdAndCategoryRoleType(final Long categoryId, final CategoryRoleType categoryRoleType);
 

--- a/backend/src/main/java/com/allog/dallog/domain/categoryrole/domain/CategoryRoleRepository.java
+++ b/backend/src/main/java/com/allog/dallog/domain/categoryrole/domain/CategoryRoleRepository.java
@@ -1,5 +1,9 @@
 package com.allog.dallog.domain.categoryrole.domain;
 
+import static com.allog.dallog.domain.categoryrole.domain.CategoryRoleType.ADMIN;
+import static com.allog.dallog.domain.categoryrole.domain.CategoryRoleType.NONE;
+
+import com.allog.dallog.domain.categoryrole.exception.ManagingCategoryLimitExcessException;
 import com.allog.dallog.domain.categoryrole.exception.NoSuchCategoryRoleException;
 import java.util.List;
 import java.util.Optional;
@@ -45,5 +49,13 @@ public interface CategoryRoleRepository extends JpaRepository<CategoryRole, Long
         int adminCount = countByCategoryIdAndCategoryRoleType(categoryId, CategoryRoleType.ADMIN);
 
         return categoryRole.isAdmin() && adminCount == 1;
+    }
+
+    default void validateManagingCategoryLimit(final Long memberId, final CategoryRoleType categoryRoleType) {
+        int memberAdminCount = countByMemberIdAndCategoryRoleType(memberId, ADMIN);
+
+        if (!categoryRoleType.equals(NONE) && memberAdminCount >= CategoryRole.MAX_MANAGING_CATEGORY_COUNT) {
+            throw new ManagingCategoryLimitExcessException();
+        }
     }
 }

--- a/backend/src/main/java/com/allog/dallog/domain/categoryrole/domain/CategoryRoleRepository.java
+++ b/backend/src/main/java/com/allog/dallog/domain/categoryrole/domain/CategoryRoleRepository.java
@@ -23,6 +23,11 @@ public interface CategoryRoleRepository extends JpaRepository<CategoryRole, Long
     List<CategoryRole> findByCategoryIdAndCategoryRoleType(final Long categoryId,
                                                            final CategoryRoleType categoryRoleType);
 
+    @Query("SELECT count(cr) "
+            + "FROM CategoryRole cr "
+            + "WHERE cr.categoryRoleType = 'ADMIN' AND cr.member.id = :memberId")
+    int countAdminByMemberId(final Long memberId);
+
     int countByCategoryIdAndCategoryRoleType(final Long categoryId, final CategoryRoleType categoryRoleType);
 
     void deleteByCategoryId(final Long categoryId);

--- a/backend/src/main/java/com/allog/dallog/domain/categoryrole/exception/ManagingCategoryLimitExcessException.java
+++ b/backend/src/main/java/com/allog/dallog/domain/categoryrole/exception/ManagingCategoryLimitExcessException.java
@@ -1,0 +1,10 @@
+package com.allog.dallog.domain.categoryrole.exception;
+
+public class ManagingCategoryLimitExcessException extends RuntimeException {
+
+    private static final int MAX_MANAGING_CATEGORY_COUNT = 50;
+
+    public ManagingCategoryLimitExcessException() {
+        super("한 사람이 관리할 수 있는 카테고리는 최대 " + MAX_MANAGING_CATEGORY_COUNT + "개 입니다.");
+    }
+}

--- a/backend/src/main/java/com/allog/dallog/global/error/ControllerAdvice.java
+++ b/backend/src/main/java/com/allog/dallog/global/error/ControllerAdvice.java
@@ -8,6 +8,7 @@ import com.allog.dallog.domain.auth.exception.NoSuchTokenException;
 import com.allog.dallog.domain.category.exception.ExistExternalCategoryException;
 import com.allog.dallog.domain.category.exception.InvalidCategoryException;
 import com.allog.dallog.domain.category.exception.NoSuchCategoryException;
+import com.allog.dallog.domain.categoryrole.exception.ManagingCategoryLimitExcessException;
 import com.allog.dallog.domain.categoryrole.exception.NoCategoryAuthorityException;
 import com.allog.dallog.domain.categoryrole.exception.NoSuchCategoryRoleException;
 import com.allog.dallog.domain.categoryrole.exception.NotAbleToChangeRoleException;
@@ -47,7 +48,8 @@ public class ControllerAdvice {
             InvalidSubscriptionException.class,
             ExistSubscriptionException.class,
             ExistExternalCategoryException.class,
-            NotAbleToChangeRoleException.class
+            NotAbleToChangeRoleException.class,
+            ManagingCategoryLimitExcessException.class
     })
     public ResponseEntity<ErrorResponse> handleInvalidData(final RuntimeException e) {
         ErrorResponse errorResponse = new ErrorResponse(e.getMessage());

--- a/backend/src/test/java/com/allog/dallog/domain/category/application/CategoryServiceTest.java
+++ b/backend/src/test/java/com/allog/dallog/domain/category/application/CategoryServiceTest.java
@@ -48,6 +48,7 @@ import com.allog.dallog.domain.categoryrole.application.CategoryRoleService;
 import com.allog.dallog.domain.categoryrole.domain.CategoryRole;
 import com.allog.dallog.domain.categoryrole.domain.CategoryRoleRepository;
 import com.allog.dallog.domain.categoryrole.dto.request.CategoryRoleUpdateRequest;
+import com.allog.dallog.domain.categoryrole.exception.ManagingCategoryLimitExcessException;
 import com.allog.dallog.domain.categoryrole.exception.NoCategoryAuthorityException;
 import com.allog.dallog.domain.member.application.MemberService;
 import com.allog.dallog.domain.member.domain.Member;
@@ -517,6 +518,21 @@ class CategoryServiceTest extends ServiceTest {
         assertThatThrownBy(
                 () -> categoryService.delete(관리자.getId(), 공통_일정.getId()))
                 .isInstanceOf(NoCategoryAuthorityException.class);
+    }
+
+    @DisplayName("카테고리를 생성 시 이미 관리자로 참여중인 카테고리 개수가 50개 이상이면 예외를 던진다.")
+    @Test
+    void 카테고리를_생성_시_이미_관리자로_참여중인_카테고리_개수가_50개_이상이면_예외를_던진다() {
+        // given
+        Member 후디 = memberRepository.save(후디());
+        for (int i = 0; i < 50; i++) {
+            CategoryCreateRequest request = new CategoryCreateRequest("카테고리 " + i, NORMAL);
+            categoryService.save(후디.getId(), request);
+        }
+
+        // when & then
+        assertThatThrownBy(() -> categoryService.save(후디.getId(), BE_일정_생성_요청))
+                .isInstanceOf(ManagingCategoryLimitExcessException.class);
     }
 
     @DisplayName("존재하지 않는 카테고리를 삭제할 경우 예외를 던진다.")


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 💻 git rebase를 사용했나요?
- [x] 🌈 알록달록한가요?

## 작업 내용

> 관리자 != `ADMIN`

> 관리자는 `NONE` 보다 상위 역할을 모두 통칭하는 용어입니다. 그런데 지금은 `NONE` 상위 역할이 `ADMIN` 밖에 없음.

- 카테고리 생성 시 해당 유저가 이미 관리자로 참여하고 있는 카테고리 수가 50개 이상이라면 예외 발생
- 다른 사람이 구독자의 카테고리 역할을 관리자로 변경시, 변경 대상 유저가 이미 관리자로 참여하고 있는 카테고리수가 50개 이상이라면 예외 발생 

## 스크린샷

## 주의사항

Closes #746 
