### PR TITLE
[feat] 스프링 부트 time zone을 Asia/Seoul로 설정한다.

### DIFF
--- a/backend/src/main/java/com/allog/dallog/global/config/TimeZoneConfig.java
+++ b/backend/src/main/java/com/allog/dallog/global/config/TimeZoneConfig.java
@@ -1,0 +1,16 @@
+package com.allog.dallog.global.config;
+
+import java.util.TimeZone;
+import javax.annotation.PostConstruct;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class TimeZoneConfig {
+
+    public static final String DEFAULT_TIME_ZONE = "Asia/Seoul";
+
+    @PostConstruct
+    public void setDefaultTimeZone() {
+        TimeZone.setDefault(TimeZone.getTimeZone(DEFAULT_TIME_ZONE));
+    }
+}

--- a/backend/src/test/java/com/allog/dallog/domain/category/domain/CategoryRepositoryTest.java
+++ b/backend/src/test/java/com/allog/dallog/domain/category/domain/CategoryRepositoryTest.java
@@ -21,7 +21,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.allog.dallog.common.annotation.RepositoryTest;
-import com.allog.dallog.domain.categoryrole.domain.CategoryRoleRepository;
 import com.allog.dallog.domain.member.domain.Member;
 import com.allog.dallog.domain.member.domain.MemberRepository;
 import com.allog.dallog.domain.subscription.domain.SubscriptionRepository;
@@ -40,9 +39,6 @@ class CategoryRepositoryTest extends RepositoryTest {
 
     @Autowired
     private MemberRepository memberRepository;
-
-    @Autowired
-    private CategoryRoleRepository categoryRoleRepository;
 
     @Autowired
     private SubscriptionRepository subscriptionRepository;

--- a/backend/src/test/java/com/allog/dallog/domain/member/domain/MemberRepositoryTest.java
+++ b/backend/src/test/java/com/allog/dallog/domain/member/domain/MemberRepositoryTest.java
@@ -6,9 +6,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.allog.dallog.common.annotation.RepositoryTest;
-import com.allog.dallog.domain.category.domain.CategoryRepository;
 import com.allog.dallog.domain.member.exception.NoSuchMemberException;
-import com.allog.dallog.domain.subscription.domain.SubscriptionRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -17,12 +15,6 @@ class MemberRepositoryTest extends RepositoryTest {
 
     @Autowired
     private MemberRepository memberRepository;
-
-    @Autowired
-    private CategoryRepository categoryRepository;
-
-    @Autowired
-    private SubscriptionRepository subscriptionRepository;
 
     @DisplayName("중복된 이메일이 존재하는 경우 true를 반환한다.")
     @Test

--- a/backend/src/test/java/com/allog/dallog/domain/subscription/application/SubscriptionServiceTest.java
+++ b/backend/src/test/java/com/allog/dallog/domain/subscription/application/SubscriptionServiceTest.java
@@ -30,7 +30,6 @@ import com.allog.dallog.domain.categoryrole.exception.NoSuchCategoryRoleExceptio
 import com.allog.dallog.domain.member.domain.Member;
 import com.allog.dallog.domain.member.domain.MemberRepository;
 import com.allog.dallog.domain.subscription.domain.Color;
-import com.allog.dallog.domain.subscription.domain.SubscriptionRepository;
 import com.allog.dallog.domain.subscription.dto.request.SubscriptionUpdateRequest;
 import com.allog.dallog.domain.subscription.dto.response.SubscriptionResponse;
 import com.allog.dallog.domain.subscription.dto.response.SubscriptionsResponse;
@@ -56,9 +55,6 @@ class SubscriptionServiceTest extends ServiceTest {
 
     @Autowired
     private CategoryRepository categoryRepository;
-
-    @Autowired
-    private SubscriptionRepository subscriptionRepository;
 
     @Autowired
     private MemberRepository memberRepository;


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 💻 git rebase를 사용했나요?
- [x] 🌈 알록달록한가요?

## 작업 내용

스프링 부트 time zone을 위해 configuration 파일을 만들었습니다.
`@PostConstructor` 어노테이션은 메서드가 스프링을 띄울 때 한 번만 실행되게 하는 어노테이션입니다.


## 주의사항

- 배포 시 배포 스크립트에서 time zone 설정 옵션을 제거해주어야 합니다.

Closes #786 