### PR TITLE
[fix] 일정이 넘쳐 보이는 달력 에러를 해결한다.

### DIFF
--- a/frontend/src/pages/CalendarPage/CalendarPage.tsx
+++ b/frontend/src/pages/CalendarPage/CalendarPage.tsx
@@ -1,5 +1,5 @@
 import { useTheme } from '@emotion/react';
-import { useRef, useState } from 'react';
+import { useLayoutEffect, useRef, useState } from 'react';
 
 import { useGetSchedules } from '@/hooks/@queries/schedule';
 import useCalendar from '@/hooks/useCalendar';
@@ -54,9 +54,9 @@ import {
 
 function CalendarPage() {
   const theme = useTheme();
-
   const dateRef = useRef<HTMLDivElement>(null);
 
+  const [dateHeight, setDateHeight] = useState(0);
   const [hoveringId, setHoveringId] = useState('0');
   const [dateInfo, setDateInfo] = useState('');
   const [scheduleInfo, setScheduleInfo] = useState<ScheduleType | null>(null);
@@ -83,6 +83,16 @@ function CalendarPage() {
   const moreScheduleModal = useModalPosition();
 
   const { isLoading, data } = useGetSchedules({ startDateTime, endDateTime });
+
+  useLayoutEffect(() => {
+    if (!dateRef.current) return;
+
+    setDateHeight(dateRef.current.clientHeight);
+  }, [dateRef.current]);
+
+  const MAX_SCHEDULE_COUNT = Math.floor(
+    (dateHeight - SCHEDULE.HEIGHT * 4) / (SCHEDULE.HEIGHT_WITH_MARGIN * 4)
+  );
 
   const { year: currentYear, month: currentMonth } = extractDateTime(currentDateTime);
   const rowNum = Math.ceil(calendar.length / 7);
@@ -169,13 +179,6 @@ function CalendarPage() {
   const longTermSchedulesWithPriority = getLongTermSchedulesWithPriority(data.data.longTerms);
   const allDaySchedulesWithPriority = getSingleSchedulesWithPriority(data.data.allDays);
   const fewHourSchedulesWithPriority = getSingleSchedulesWithPriority(data.data.fewHours);
-
-  const MAX_SCHEDULE_COUNT =
-    dateRef.current !== null
-      ? Math.floor(
-          (dateRef.current.clientHeight - SCHEDULE.HEIGHT * 4) / (SCHEDULE.HEIGHT_WITH_MARGIN * 4)
-        )
-      : CALENDAR.MAX_SCHEDULE_COUNT;
 
   const onMouseEnter = (scheduleId: string) => {
     setHoveringId(scheduleId);

--- a/frontend/src/pages/CalendarPage/CalendarPage.tsx
+++ b/frontend/src/pages/CalendarPage/CalendarPage.tsx
@@ -92,7 +92,7 @@ function CalendarPage() {
         (dateRef.current.clientHeight - SCHEDULE.HEIGHT * 4) / (SCHEDULE.HEIGHT_WITH_MARGIN * 4)
       )
     );
-  });
+  }, [dateRef.current]);
 
   const { year: currentYear, month: currentMonth } = extractDateTime(currentDateTime);
   const rowNum = Math.ceil(calendar.length / 7);

--- a/frontend/src/pages/CalendarPage/CalendarPage.tsx
+++ b/frontend/src/pages/CalendarPage/CalendarPage.tsx
@@ -56,7 +56,7 @@ function CalendarPage() {
   const theme = useTheme();
   const dateRef = useRef<HTMLDivElement>(null);
 
-  const [dateHeight, setDateHeight] = useState(0);
+  const [maxScheduleCount, setMaxScheduleCount] = useState(0);
   const [hoveringId, setHoveringId] = useState('0');
   const [dateInfo, setDateInfo] = useState('');
   const [scheduleInfo, setScheduleInfo] = useState<ScheduleType | null>(null);
@@ -87,12 +87,12 @@ function CalendarPage() {
   useLayoutEffect(() => {
     if (!(dateRef.current instanceof HTMLDivElement)) return;
 
-    setDateHeight(dateRef.current.clientHeight);
+    setMaxScheduleCount(
+      Math.floor(
+        (dateRef.current.clientHeight - SCHEDULE.HEIGHT * 4) / (SCHEDULE.HEIGHT_WITH_MARGIN * 4)
+      )
+    );
   });
-
-  const MAX_SCHEDULE_COUNT = Math.floor(
-    (dateHeight - SCHEDULE.HEIGHT * 4) / (SCHEDULE.HEIGHT_WITH_MARGIN * 4)
-  );
 
   const { year: currentYear, month: currentMonth } = extractDateTime(currentDateTime);
   const rowNum = Math.ceil(calendar.length / 7);
@@ -249,7 +249,7 @@ function CalendarPage() {
                           priority,
                           schedule.colorCode,
                           hoveringId === schedule.id,
-                          MAX_SCHEDULE_COUNT,
+                          maxScheduleCount,
                           currentDate === endDate
                         )}
                         onMouseEnter={() => onMouseEnter(schedule.id)}
@@ -276,7 +276,7 @@ function CalendarPage() {
                           priority,
                           schedule.colorCode,
                           hoveringId === schedule.id,
-                          MAX_SCHEDULE_COUNT,
+                          maxScheduleCount,
                           true
                         )}
                         onMouseEnter={() => onMouseEnter(schedule.id)}
@@ -303,7 +303,7 @@ function CalendarPage() {
                           priority,
                           schedule.colorCode,
                           hoveringId === schedule.id,
-                          MAX_SCHEDULE_COUNT,
+                          maxScheduleCount,
                           false
                         )}
                         onMouseEnter={() => onMouseEnter(schedule.id)}
@@ -318,7 +318,7 @@ function CalendarPage() {
                   })}
 
                   {calendarWithPriority[getISODateString(dateTime)].findIndex((el) => !el) + 1 >
-                    MAX_SCHEDULE_COUNT && (
+                    maxScheduleCount && (
                     <span
                       css={moreStyle}
                       onClick={(e) =>

--- a/frontend/src/pages/CalendarPage/CalendarPage.tsx
+++ b/frontend/src/pages/CalendarPage/CalendarPage.tsx
@@ -85,10 +85,10 @@ function CalendarPage() {
   const { isLoading, data } = useGetSchedules({ startDateTime, endDateTime });
 
   useLayoutEffect(() => {
-    if (!dateRef.current) return;
+    if (!(dateRef.current instanceof HTMLDivElement)) return;
 
     setDateHeight(dateRef.current.clientHeight);
-  }, [dateRef.current]);
+  });
 
   const MAX_SCHEDULE_COUNT = Math.floor(
     (dateHeight - SCHEDULE.HEIGHT * 4) / (SCHEDULE.HEIGHT_WITH_MARGIN * 4)


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 💻 git rebase를 사용했나요?
- [x] 🌈 알록달록한가요?

## 작업 내용
일정이 넘쳐 보이는 달력 에러를 해결한다.

## 주의사항
음... 고민을 많이 했는데 `useLayoutEffect`를 사용하게 되었습니다.
1. 어짜피 리렌더링이 많이 발생할 수 밖에 없는 달력페이지 특성상 `useLayoutEffect`를 사용함으로써 더 손해보는 일은 없다고 판단했습니다.
2. 높이를 계산하기 위해 아래처럼 `innerHeight`를 사용한다면 Navbar 헤더부터 계산하는 로직이 너무 복잡해집니단.
```ts
const MAX_SCHEDULE_COUNT = Math.floor(
    ((window.innerHeight - 64 - 23 - 29 - 56) / (calendar.length / 7) - SCHEDULE.HEIGHT * 4) /
      (SCHEDULE.HEIGHT_WITH_MARGIN * 4)
  );
```
3. `useEffect` 대신 `useLayoutEffect`를 쓴 이유는 render(요소들의 스타일 속성 계산) 이후, paint(실제 그리기) 이전에 실행되고 동기적으로 실행되기 때문에  실제 그리기 전에 useState의 값을 계산하고 그려지게 됩니다. 즉, `useState`의 값이 0인 상태를 화면에 보여주지 않기 때문에 더 매끄러운 화면을 보여줄 것이라고 기대했습니다.
[useEffect vs useLayoutEffect](https://medium.com/@jnso5072/react-useeffect-%EC%99%80-uselayouteffect-%EC%9D%98-%EC%B0%A8%EC%9D%B4%EB%8A%94-%EB%AC%B4%EC%97%87%EC%9D%BC%EA%B9%8C-e1a13adf1cd5)

Closes #782 
