### PR TITLE
[fix] 카테고리 구독 시 일정이 바로 보이지 않는 에러를 해결한다.

### DIFF
--- a/frontend/src/hooks/@queries/category.ts
+++ b/frontend/src/hooks/@queries/category.ts
@@ -99,7 +99,7 @@ function useGetAdminCategories({ enabled }: UseGetAdminCategoriesParams) {
   const { accessToken } = useRecoilValue(userState);
 
   const { isLoading, data } = useQuery<AxiosResponse<CategoryType[]>, AxiosError>(
-    [CACHE_KEY.ADMIN_CATEGORIES],
+    CACHE_KEY.ADMIN_CATEGORIES,
     () => categoryApi.getAdmin(accessToken),
     {
       enabled,
@@ -113,7 +113,7 @@ function useGetEditableCategories({ enabled }: UseGetEditableCategoriesParams) {
   const { accessToken } = useRecoilValue(userState);
 
   const { isLoading, data } = useQuery<AxiosResponse<CategoryType[]>, AxiosError>(
-    [CACHE_KEY.EDITABLE_CATEGORIES],
+    CACHE_KEY.EDITABLE_CATEGORIES,
     () => categoryApi.getEditable(accessToken),
     {
       enabled,
@@ -223,9 +223,9 @@ function usePatchCategoryRole({ categoryId, memberId, onSuccess }: UsePatchCateg
     unknown
   >((body) => categoryApi.patchRole(accessToken, categoryId, memberId, body), {
     onSuccess: () => {
-      queryClient.invalidateQueries([CACHE_KEY.SUBSCRIBERS]);
-      queryClient.invalidateQueries([CACHE_KEY.EDITABLE_CATEGORIES]);
-      queryClient.invalidateQueries([CACHE_KEY.SUBSCRIPTIONS]);
+      queryClient.invalidateQueries(CACHE_KEY.SUBSCRIBERS);
+      queryClient.invalidateQueries(CACHE_KEY.EDITABLE_CATEGORIES);
+      queryClient.invalidateQueries(CACHE_KEY.SUBSCRIPTIONS);
       onSuccess && onSuccess();
     },
   });
@@ -244,10 +244,10 @@ function usePostCategory({ onSuccess }: UsePostCategoryParams) {
     unknown
   >((body) => categoryApi.post(accessToken, body), {
     onSuccess: () => {
-      queryClient.invalidateQueries([CACHE_KEY.CATEGORIES]);
-      queryClient.invalidateQueries([CACHE_KEY.MY_CATEGORIES]);
-      queryClient.invalidateQueries([CACHE_KEY.SUBSCRIPTIONS]);
-      queryClient.invalidateQueries([CACHE_KEY.EDITABLE_CATEGORIES]);
+      queryClient.invalidateQueries(CACHE_KEY.CATEGORIES);
+      queryClient.invalidateQueries(CACHE_KEY.MY_CATEGORIES);
+      queryClient.invalidateQueries(CACHE_KEY.SUBSCRIPTIONS);
+      queryClient.invalidateQueries(CACHE_KEY.EDITABLE_CATEGORIES);
 
       onSuccess && onSuccess();
     },

--- a/frontend/src/hooks/@queries/schedule.ts
+++ b/frontend/src/hooks/@queries/schedule.ts
@@ -38,7 +38,7 @@ function useDeleteSchedule({ scheduleId, onSuccess }: UseDeleteScheduleParams) {
     () => scheduleApi.delete(accessToken, scheduleId),
     {
       onSuccess: () => {
-        queryClient.invalidateQueries([CACHE_KEY.SCHEDULES]);
+        queryClient.invalidateQueries(CACHE_KEY.SCHEDULES);
         onSuccess && onSuccess();
       },
     }
@@ -72,7 +72,7 @@ function usePatchSchedule({ scheduleId, onSuccess }: UsePatchScheduleParams) {
     unknown
   >(CACHE_KEY.SCHEDULE, (body) => scheduleApi.patch(accessToken, scheduleId, body), {
     onSuccess: () => {
-      queryClient.invalidateQueries([CACHE_KEY.SCHEDULES]);
+      queryClient.invalidateQueries(CACHE_KEY.SCHEDULES);
       onSuccess && onSuccess();
     },
   });
@@ -91,7 +91,7 @@ function usePostSchedule({ categoryId, onSuccess }: UsePostScheduleParams) {
     unknown
   >((body) => scheduleApi.post(accessToken, Number(categoryId), body), {
     onSuccess: () => {
-      queryClient.invalidateQueries([CACHE_KEY.SCHEDULES]);
+      queryClient.invalidateQueries(CACHE_KEY.SCHEDULES);
       onSuccess && onSuccess();
     },
   });

--- a/frontend/src/hooks/@queries/subscription.ts
+++ b/frontend/src/hooks/@queries/subscription.ts
@@ -36,6 +36,7 @@ function useDeleteSubscriptions({ subscriptionId, onSuccess }: UseDeleteSubscrip
   const { mutate } = useMutation(() => subscriptionApi.delete(accessToken, subscriptionId), {
     onSuccess: () => {
       queryClient.invalidateQueries(CACHE_KEY.SUBSCRIPTIONS);
+      queryClient.invalidateQueries(CACHE_KEY.SCHEDULES);
       onSuccess && onSuccess();
     },
   });
@@ -88,6 +89,7 @@ function usePostSubscription({ categoryId, onSuccess }: UsePostSubscriptionParam
   >((body) => subscriptionApi.post(accessToken, categoryId, body), {
     onSuccess: () => {
       queryClient.invalidateQueries(CACHE_KEY.SUBSCRIPTIONS);
+      queryClient.invalidateQueries(CACHE_KEY.SCHEDULES);
       onSuccess && onSuccess();
     },
   });

--- a/frontend/src/hooks/@queries/subscription.ts
+++ b/frontend/src/hooks/@queries/subscription.ts
@@ -48,7 +48,7 @@ function useGetSubscriptions({ enabled }: UseGetSubscriptionsParams) {
   const { accessToken } = useRecoilValue(userState);
 
   const { isLoading, error, data } = useQuery<AxiosResponse<SubscriptionType[]>, AxiosError>(
-    [CACHE_KEY.SUBSCRIPTIONS],
+    CACHE_KEY.SUBSCRIPTIONS,
     () => subscriptionApi.get(accessToken),
     {
       enabled,
@@ -67,8 +67,8 @@ function usePatchSubscription({ subscriptionId, onSuccess }: UsePatchSubscriptio
       subscriptionApi.patch(accessToken, subscriptionId, body),
     {
       onSuccess: async () => {
-        await queryClient.invalidateQueries([CACHE_KEY.SUBSCRIPTIONS]);
-        await queryClient.invalidateQueries([CACHE_KEY.SCHEDULES]);
+        await queryClient.invalidateQueries(CACHE_KEY.SUBSCRIPTIONS);
+        await queryClient.invalidateQueries(CACHE_KEY.SCHEDULES);
         onSuccess && onSuccess();
       },
     }


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 💻 git rebase를 사용했나요?
- [x] 🌈 알록달록한가요?

## 작업 내용
카테고리 구독 시 일정이 바로 보이지 않는 에러를 해결한다.

## 주의사항
`invalidationQueries`를 진행할 때 어떤 것은 배열 안에 키값을 넣어주고 있고 어떤 것은 그냥 넣어주고 있는데 통일하는게 어떨까요?

Closes #784
