### PR TITLE
[feat] 관리 모달에서 카테고리 이름 수정 시 피드백을 제공한다.

### DIFF
--- a/frontend/src/components/AdminCategoryManageModal/AdminCategoryManageModal.tsx
+++ b/frontend/src/components/AdminCategoryManageModal/AdminCategoryManageModal.tsx
@@ -7,7 +7,6 @@ import {
   usePatchCategoryRole,
 } from '@/hooks/@queries/category';
 import { useDeleteSubscriptions } from '@/hooks/@queries/subscription';
-import useSnackBar from '@/hooks/useSnackBar';
 import useValidateCategory from '@/hooks/useValidateCategory';
 
 import { SubscriptionType } from '@/@types/subscription';
@@ -21,7 +20,7 @@ import AdminItem from '@/components/AdminItem/AdminItem';
 import SubscriberItem from '@/components/SubscriberItem/SubscriberItem';
 
 import { ROLE } from '@/constants/category';
-import { CONFIRM_MESSAGE, SUCCESS_MESSAGE } from '@/constants/message';
+import { CONFIRM_MESSAGE } from '@/constants/message';
 
 import { MdClose } from 'react-icons/md';
 
@@ -48,8 +47,6 @@ interface AdminCategoryManageModalProps {
 }
 
 function AdminCategoryManageModal({ subscription, closeModal }: AdminCategoryManageModalProps) {
-  const { openSnackBar } = useSnackBar();
-
   const { id } = useRecoilValue(userState);
 
   const { categoryValue, getCategoryErrorMessage, isValidCategory } = useValidateCategory(
@@ -60,7 +57,6 @@ function AdminCategoryManageModal({ subscription, closeModal }: AdminCategoryMan
 
   const { mutate: patchCategoryName } = usePatchCategoryName({
     categoryId: subscription.category.id,
-    onSuccess: () => openSnackBar(SUCCESS_MESSAGE.EDIT_CATEGORY),
   });
 
   const { mutate: deleteCategory } = useDeleteCategory({

--- a/frontend/src/components/AdminCategoryManageModal/AdminCategoryManageModal.tsx
+++ b/frontend/src/components/AdminCategoryManageModal/AdminCategoryManageModal.tsx
@@ -7,6 +7,7 @@ import {
   usePatchCategoryRole,
 } from '@/hooks/@queries/category';
 import { useDeleteSubscriptions } from '@/hooks/@queries/subscription';
+import useSnackBar from '@/hooks/useSnackBar';
 import useValidateCategory from '@/hooks/useValidateCategory';
 
 import { SubscriptionType } from '@/@types/subscription';
@@ -20,7 +21,7 @@ import AdminItem from '@/components/AdminItem/AdminItem';
 import SubscriberItem from '@/components/SubscriberItem/SubscriberItem';
 
 import { ROLE } from '@/constants/category';
-import { CONFIRM_MESSAGE } from '@/constants/message';
+import { CONFIRM_MESSAGE, SUCCESS_MESSAGE } from '@/constants/message';
 
 import { MdClose } from 'react-icons/md';
 
@@ -47,6 +48,8 @@ interface AdminCategoryManageModalProps {
 }
 
 function AdminCategoryManageModal({ subscription, closeModal }: AdminCategoryManageModalProps) {
+  const { openSnackBar } = useSnackBar();
+
   const { id } = useRecoilValue(userState);
 
   const { categoryValue, getCategoryErrorMessage, isValidCategory } = useValidateCategory(
@@ -57,6 +60,7 @@ function AdminCategoryManageModal({ subscription, closeModal }: AdminCategoryMan
 
   const { mutate: patchCategoryName } = usePatchCategoryName({
     categoryId: subscription.category.id,
+    onSuccess: () => openSnackBar(SUCCESS_MESSAGE.EDIT_CATEGORY),
   });
 
   const { mutate: deleteCategory } = useDeleteCategory({

--- a/frontend/src/constants/message.ts
+++ b/frontend/src/constants/message.ts
@@ -12,9 +12,13 @@ const ERROR_MESSAGE = {
   DEFAULT: '에러가 발생했습니다. 잠시 후에 다시 시도해주세요.',
 };
 
+const SUCCESS_MESSAGE = {
+  EDIT_CATEGORY: '카테고리 이름이 변경되었습니다.',
+};
+
 const TOOLTIP_MESSAGE = {
   CANNOT_UNSUBSCRIBE_MINE: '나의 카테고리는 구독 취소할 수 없습니다.',
   CANNOT_EDIT_DELETE_DEFAULT_CATEGORY: '기본 카테고리는 수정/삭제가 불가능합니다.',
 };
 
-export { CONFIRM_MESSAGE, ERROR_MESSAGE, TOOLTIP_MESSAGE };
+export { CONFIRM_MESSAGE, ERROR_MESSAGE, SUCCESS_MESSAGE, TOOLTIP_MESSAGE };

--- a/frontend/src/constants/message.ts
+++ b/frontend/src/constants/message.ts
@@ -13,7 +13,17 @@ const ERROR_MESSAGE = {
 };
 
 const SUCCESS_MESSAGE = {
-  EDIT_CATEGORY: '카테고리 이름이 변경되었습니다.',
+  DELETE_CATEGORY: '카테고리를 삭제했습니다.',
+  DELETE_PROFILE: '회원 탈퇴되었습니다.',
+  DELETE_SCHEDULE: '일정을 삭제했습니다.',
+  PATCH_CATEGORY_NAME: '카테고리 이름이 변경되었습니다.',
+  PATCH_CATEGORY_ROLE: '편집 권한을 변경하였습니다.',
+  PATCH_PROFILE_NAME: '이름을 변경하였습니다.',
+  PATCH_SCHEDULE: '일정을 변경하였습니다.',
+
+  POST_CATEGORY: '카테고리를 생성하였습니다.',
+  POST_LOGIN: '로그인에 성공했습니다.',
+  POST_SCHEDULE: '일정을 생성했습니다.',
 };
 
 const TOOLTIP_MESSAGE = {

--- a/frontend/src/hooks/@queries/category.ts
+++ b/frontend/src/hooks/@queries/category.ts
@@ -9,6 +9,8 @@ import {
 } from 'react-query';
 import { useRecoilValue } from 'recoil';
 
+import useSnackBar from '@/hooks/useSnackBar';
+
 import {
   CategoriesGetResponseType,
   CategoryRoleType,
@@ -20,6 +22,7 @@ import {
 import { userState } from '@/recoil/atoms';
 
 import { API, CACHE_KEY } from '@/constants/api';
+import { SUCCESS_MESSAGE } from '@/constants/message';
 
 import categoryApi from '@/api/category';
 
@@ -81,6 +84,7 @@ interface UsePostCategoryParams {
 function useDeleteCategory({ categoryId, onSuccess }: UseDeleteCategoryParams) {
   const { accessToken } = useRecoilValue(userState);
   const queryClient = useQueryClient();
+  const { openSnackBar } = useSnackBar();
 
   const { mutate } = useMutation(() => categoryApi.delete(accessToken, categoryId), {
     onSuccess: () => {
@@ -88,6 +92,7 @@ function useDeleteCategory({ categoryId, onSuccess }: UseDeleteCategoryParams) {
       queryClient.invalidateQueries(CACHE_KEY.MY_CATEGORIES);
       queryClient.invalidateQueries(CACHE_KEY.SUBSCRIPTIONS);
 
+      openSnackBar(SUCCESS_MESSAGE.DELETE_CATEGORY);
       onSuccess && onSuccess();
     },
   });
@@ -193,6 +198,7 @@ function useGetSubscribers({ categoryId }: UseGetSubscribersParams) {
 function usePatchCategoryName({ categoryId, onSuccess }: UsePatchCategoryNameParams) {
   const { accessToken } = useRecoilValue(userState);
   const queryClient = useQueryClient();
+  const { openSnackBar } = useSnackBar();
 
   const { mutate } = useMutation<
     AxiosResponse<Pick<CategoryType, 'name'>>,
@@ -205,6 +211,7 @@ function usePatchCategoryName({ categoryId, onSuccess }: UsePatchCategoryNamePar
       queryClient.invalidateQueries(CACHE_KEY.MY_CATEGORIES);
       queryClient.invalidateQueries(CACHE_KEY.SUBSCRIPTIONS);
 
+      openSnackBar(SUCCESS_MESSAGE.PATCH_CATEGORY_NAME);
       onSuccess && onSuccess();
     },
   });
@@ -215,6 +222,7 @@ function usePatchCategoryName({ categoryId, onSuccess }: UsePatchCategoryNamePar
 function usePatchCategoryRole({ categoryId, memberId, onSuccess }: UsePatchCategoryRoleParams) {
   const { accessToken } = useRecoilValue(userState);
   const queryClient = useQueryClient();
+  const { openSnackBar } = useSnackBar();
 
   const { mutate } = useMutation<
     AxiosResponse<{ categoryRoleType: CategoryRoleType }>,
@@ -236,6 +244,7 @@ function usePatchCategoryRole({ categoryId, memberId, onSuccess }: UsePatchCateg
 function usePostCategory({ onSuccess }: UsePostCategoryParams) {
   const { accessToken } = useRecoilValue(userState);
   const queryClient = useQueryClient();
+  const { openSnackBar } = useSnackBar();
 
   const { mutate } = useMutation<
     AxiosResponse<CategoryType>,
@@ -249,6 +258,7 @@ function usePostCategory({ onSuccess }: UsePostCategoryParams) {
       queryClient.invalidateQueries(CACHE_KEY.SUBSCRIPTIONS);
       queryClient.invalidateQueries(CACHE_KEY.EDITABLE_CATEGORIES);
 
+      openSnackBar(SUCCESS_MESSAGE.POST_CATEGORY);
       onSuccess && onSuccess();
     },
   });

--- a/frontend/src/hooks/@queries/category.ts
+++ b/frontend/src/hooks/@queries/category.ts
@@ -234,6 +234,8 @@ function usePatchCategoryRole({ categoryId, memberId, onSuccess }: UsePatchCateg
       queryClient.invalidateQueries(CACHE_KEY.SUBSCRIBERS);
       queryClient.invalidateQueries(CACHE_KEY.EDITABLE_CATEGORIES);
       queryClient.invalidateQueries(CACHE_KEY.SUBSCRIPTIONS);
+
+      openSnackBar(SUCCESS_MESSAGE.PATCH_CATEGORY_ROLE);
       onSuccess && onSuccess();
     },
   });

--- a/frontend/src/hooks/@queries/googleCalendar.ts
+++ b/frontend/src/hooks/@queries/googleCalendar.ts
@@ -2,11 +2,14 @@ import { AxiosError, AxiosResponse } from 'axios';
 import { useMutation, useQuery, useQueryClient } from 'react-query';
 import { useRecoilValue } from 'recoil';
 
+import useSnackBar from '@/hooks/useSnackBar';
+
 import { GoogleCalendarGetResponseType, GoogleCalendarPostBodyType } from '@/@types/googleCalendar';
 
 import { userState } from '@/recoil/atoms';
 
 import { CACHE_KEY } from '@/constants/api';
+import { SUCCESS_MESSAGE } from '@/constants/message';
 
 import googleCalendarApi from '@/api/googleCalendar';
 
@@ -28,6 +31,7 @@ function useGetGoogleCalendar() {
 function usePostGoogleCalendarCategory({ onSuccess }: UsePostGoogleCalendarCategoryParams) {
   const { accessToken } = useRecoilValue(userState);
   const queryClient = useQueryClient();
+  const { openSnackBar } = useSnackBar();
 
   const { mutate } = useMutation(
     (body: GoogleCalendarPostBodyType) => googleCalendarApi.post(accessToken, body),
@@ -38,6 +42,7 @@ function usePostGoogleCalendarCategory({ onSuccess }: UsePostGoogleCalendarCateg
         queryClient.invalidateQueries(CACHE_KEY.SUBSCRIPTIONS);
         queryClient.invalidateQueries(CACHE_KEY.SCHEDULES);
 
+        openSnackBar(SUCCESS_MESSAGE.POST_CATEGORY);
         onSuccess && onSuccess();
       },
     }

--- a/frontend/src/hooks/@queries/login.ts
+++ b/frontend/src/hooks/@queries/login.ts
@@ -9,6 +9,7 @@ import { sideBarState, userState, UserStateType } from '@/recoil/atoms';
 
 import { PATH } from '@/constants';
 import { CACHE_KEY, RESPONSE } from '@/constants/api';
+import { SUCCESS_MESSAGE } from '@/constants/message';
 
 import {
   removeAccessToken,
@@ -22,11 +23,13 @@ import loginApi from '@/api/login';
 function useAuth(code: string | null) {
   const [user, setUser] = useRecoilState(userState);
   const navigate = useNavigate();
+  const { openSnackBar } = useSnackBar();
 
   const { mutate } = useMutation<UserStateType, AxiosError>(() => loginApi.auth(code), {
     onError: () => onErrorAuth(),
     onSuccess: ({ accessToken, refreshToken }) => {
       onSuccessAuth(accessToken, refreshToken);
+      openSnackBar(SUCCESS_MESSAGE.POST_LOGIN);
     },
   });
 

--- a/frontend/src/hooks/@queries/profile.ts
+++ b/frontend/src/hooks/@queries/profile.ts
@@ -2,10 +2,13 @@ import { useMutation, useQueryClient } from 'react-query';
 import { useNavigate } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
 
+import useSnackBar from '@/hooks/useSnackBar';
+
 import { userState } from '@/recoil/atoms';
 
 import { PATH } from '@/constants';
 import { CACHE_KEY } from '@/constants/api';
+import { SUCCESS_MESSAGE } from '@/constants/message';
 
 import { removeAccessToken, removeRefreshToken } from '@/utils/storage';
 
@@ -21,8 +24,8 @@ interface UsePatchProfileParams {
 
 function useDeleteProfile({ onSuccess }: UseDeleteProfileParams) {
   const navigate = useNavigate();
-
   const { accessToken } = useRecoilValue(userState);
+  const { openSnackBar } = useSnackBar();
 
   const { mutate } = useMutation(() => profileApi.delete(accessToken), {
     onSuccess: () => {
@@ -31,6 +34,7 @@ function useDeleteProfile({ onSuccess }: UseDeleteProfileParams) {
       removeRefreshToken();
       navigate(PATH.MAIN);
       location.reload();
+      openSnackBar(SUCCESS_MESSAGE.DELETE_PROFILE);
     },
   });
 
@@ -39,6 +43,7 @@ function useDeleteProfile({ onSuccess }: UseDeleteProfileParams) {
 
 function usePatchProfile({ accessToken }: UsePatchProfileParams) {
   const queryClient = useQueryClient();
+  const { openSnackBar } = useSnackBar();
 
   const { mutate } = useMutation(
     (body: { displayName: string }) => profileApi.patch(accessToken, body),
@@ -46,6 +51,8 @@ function usePatchProfile({ accessToken }: UsePatchProfileParams) {
       onSuccess: () => {
         queryClient.invalidateQueries(CACHE_KEY.PROFILE);
         queryClient.invalidateQueries(CACHE_KEY.CATEGORIES);
+
+        openSnackBar(SUCCESS_MESSAGE.PATCH_PROFILE_NAME);
       },
     }
   );

--- a/frontend/src/hooks/@queries/schedule.ts
+++ b/frontend/src/hooks/@queries/schedule.ts
@@ -2,11 +2,14 @@ import { AxiosError, AxiosResponse } from 'axios';
 import { useMutation, useQuery, useQueryClient } from 'react-query';
 import { useRecoilValue } from 'recoil';
 
+import useSnackBar from '@/hooks/useSnackBar';
+
 import { ScheduleResponseType, ScheduleType } from '@/@types/schedule';
 
 import { userState } from '@/recoil/atoms';
 
 import { CACHE_KEY } from '@/constants/api';
+import { SUCCESS_MESSAGE } from '@/constants/message';
 
 import scheduleApi from '@/api/schedule';
 
@@ -33,12 +36,15 @@ interface UsePostScheduleParams {
 function useDeleteSchedule({ scheduleId, onSuccess }: UseDeleteScheduleParams) {
   const { accessToken } = useRecoilValue(userState);
   const queryClient = useQueryClient();
+  const { openSnackBar } = useSnackBar();
 
   const { mutate } = useMutation<AxiosResponse, AxiosError>(
     () => scheduleApi.delete(accessToken, scheduleId),
     {
       onSuccess: () => {
         queryClient.invalidateQueries(CACHE_KEY.SCHEDULES);
+
+        openSnackBar(SUCCESS_MESSAGE.DELETE_SCHEDULE);
         onSuccess && onSuccess();
       },
     }
@@ -64,6 +70,7 @@ function useGetSchedules({ startDateTime, endDateTime }: UseGetSchedulesParams) 
 function usePatchSchedule({ scheduleId, onSuccess }: UsePatchScheduleParams) {
   const { accessToken } = useRecoilValue(userState);
   const queryClient = useQueryClient();
+  const { openSnackBar } = useSnackBar();
 
   const { mutate } = useMutation<
     AxiosResponse,
@@ -73,6 +80,8 @@ function usePatchSchedule({ scheduleId, onSuccess }: UsePatchScheduleParams) {
   >(CACHE_KEY.SCHEDULE, (body) => scheduleApi.patch(accessToken, scheduleId, body), {
     onSuccess: () => {
       queryClient.invalidateQueries(CACHE_KEY.SCHEDULES);
+
+      openSnackBar(SUCCESS_MESSAGE.PATCH_SCHEDULE);
       onSuccess && onSuccess();
     },
   });
@@ -83,6 +92,7 @@ function usePatchSchedule({ scheduleId, onSuccess }: UsePatchScheduleParams) {
 function usePostSchedule({ categoryId, onSuccess }: UsePostScheduleParams) {
   const { accessToken } = useRecoilValue(userState);
   const queryClient = useQueryClient();
+  const { openSnackBar } = useSnackBar();
 
   const { mutate } = useMutation<
     AxiosResponse<{ schedules: ScheduleType[] }>,
@@ -92,6 +102,8 @@ function usePostSchedule({ categoryId, onSuccess }: UsePostScheduleParams) {
   >((body) => scheduleApi.post(accessToken, Number(categoryId), body), {
     onSuccess: () => {
       queryClient.invalidateQueries(CACHE_KEY.SCHEDULES);
+
+      openSnackBar(SUCCESS_MESSAGE.POST_SCHEDULE);
       onSuccess && onSuccess();
     },
   });

--- a/frontend/src/hooks/@queries/subscription.ts
+++ b/frontend/src/hooks/@queries/subscription.ts
@@ -37,6 +37,7 @@ function useDeleteSubscriptions({ subscriptionId, onSuccess }: UseDeleteSubscrip
     onSuccess: () => {
       queryClient.invalidateQueries(CACHE_KEY.SUBSCRIPTIONS);
       queryClient.invalidateQueries(CACHE_KEY.SCHEDULES);
+
       onSuccess && onSuccess();
     },
   });
@@ -69,6 +70,7 @@ function usePatchSubscription({ subscriptionId, onSuccess }: UsePatchSubscriptio
       onSuccess: async () => {
         await queryClient.invalidateQueries(CACHE_KEY.SUBSCRIPTIONS);
         await queryClient.invalidateQueries(CACHE_KEY.SCHEDULES);
+
         onSuccess && onSuccess();
       },
     }


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 💻 git rebase를 사용했나요?
- [x] 🌈 알록달록한가요?

## 작업 내용
관리 모달에서 카테고리 이름 수정 시 피드백을 제공한다.
## 스크린샷
![image](https://user-images.githubusercontent.com/32920566/196037775-680ecc74-ff59-4b7b-91ef-d39eaf36d7b6.png)

## 주의사항
`mutate`는 데이터가 변경되기 때문에 스낵바를 이용하여 피드백을 주는것이 좋다고 느꼈어요.

> 스낵바를 조금 더 적극적으로 사용해 보는건 어떨까요?

✋ queries custom hook들에서 `onSuccess` 로직에 기본적으로 스낵바를 포함시켜주면 좋을것 같은데 어떻게 생각하시나요?

Closes #798 
