### PR TITLE
[feat] 카테고리의 관리자가 한 명인 경우 관리 모달에서 권한 포기 영역을 제거한다.

### DIFF
--- a/frontend/src/components/AdminCategoryManageModal/AdminCategoryManageModal.styles.ts
+++ b/frontend/src/components/AdminCategoryManageModal/AdminCategoryManageModal.styles.ts
@@ -19,6 +19,10 @@ const deleteButtonStyle = ({ colors }: Theme) => css`
   color: ${colors.WHITE};
 `;
 
+const errorMessageStyle = ({ colors }: Theme) => css`
+  color: ${colors.RED_400};
+`;
+
 const headerStyle = css`
   font-size: 6rem;
 `;
@@ -137,6 +141,7 @@ const titleStyle = css`
 export {
   closeModalButtonStyle,
   deleteButtonStyle,
+  errorMessageStyle,
   forgiveButtonStyle,
   headerStyle,
   layoutStyle,

--- a/frontend/src/components/AdminCategoryManageModal/AdminCategoryManageModal.tsx
+++ b/frontend/src/components/AdminCategoryManageModal/AdminCategoryManageModal.tsx
@@ -27,6 +27,7 @@ import { MdClose } from 'react-icons/md';
 import {
   closeModalButtonStyle,
   deleteButtonStyle,
+  errorMessageStyle,
   forgiveButtonStyle,
   headerStyle,
   layoutStyle,
@@ -179,10 +180,17 @@ function AdminCategoryManageModal({ subscription, closeModal }: AdminCategoryMan
         <h2 css={titleStyle}>관리 권한 포기</h2>
         <div css={spaceBetweenStyle}>
           <span>일정 추가/삭제/수정 및 카테고리 수정/삭제 권한을 포기합니다.</span>
-          <Button cssProp={forgiveButtonStyle} onClick={handleClickForgiveAdminButton}>
+          <Button
+            cssProp={forgiveButtonStyle}
+            onClick={handleClickForgiveAdminButton}
+            disabled={admins.length === 1}
+          >
             포기
           </Button>
         </div>
+        {admins.length === 1 && (
+          <span css={errorMessageStyle}>권한을 본인만 가지고 있다면 포기할 수 없습니다.</span>
+        )}
       </section>
     </div>
   );


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 💻 git rebase를 사용했나요?
- [x] 🌈 알록달록한가요?

## 작업 내용
카테고리의 관리자가 한 명인 경우 관리 모달에서 권한 포기 영역을 제거한다.

## 스크린샷

### 이거보다는
![image](https://user-images.githubusercontent.com/32920566/196038847-f3a9c36c-ea2c-442d-800d-73678364a914.png)

### 이게 UX가 더 좋은 것 같아요
![image](https://user-images.githubusercontent.com/32920566/196038882-0ab5edde-5ff5-4333-9b24-1c07440be5e8.png)


## 주의사항
💥 권한 포기 섹션을 지우지 않고 에러메세지와 버튼 disabled 처리를 했습니다. 
(왜 한명일 때 권한 포기 영역이 안보이는지 궁금해하는 유저가 있을수도 있으니까)

Closes #799 
