### PR TITLE
[fix] 카테고리 페이지에서 카테고리 구독 시 구독 수가 증가하도록 재요청한다.

### DIFF
--- a/frontend/src/hooks/@queries/subscription.ts
+++ b/frontend/src/hooks/@queries/subscription.ts
@@ -37,6 +37,7 @@ function useDeleteSubscriptions({ subscriptionId, onSuccess }: UseDeleteSubscrip
     onSuccess: () => {
       queryClient.invalidateQueries(CACHE_KEY.SUBSCRIPTIONS);
       queryClient.invalidateQueries(CACHE_KEY.SCHEDULES);
+      queryClient.invalidateQueries(CACHE_KEY.CATEGORY);
 
       onSuccess && onSuccess();
     },
@@ -92,6 +93,8 @@ function usePostSubscription({ categoryId, onSuccess }: UsePostSubscriptionParam
     onSuccess: () => {
       queryClient.invalidateQueries(CACHE_KEY.SUBSCRIPTIONS);
       queryClient.invalidateQueries(CACHE_KEY.SCHEDULES);
+      queryClient.invalidateQueries([CACHE_KEY.CATEGORY, categoryId]);
+
       onSuccess && onSuccess();
     },
   });


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 💻 git rebase를 사용했나요?
- [x] 🌈 알록달록한가요?

## 작업 내용
카테고리 페이지에서 카테고리 구독 시 구독 수가 증가하도록 재요청한다.

## 주의사항

1. CACHE_KEY는 기본적으로 `CATEGORY`입니다.
2. `카테고리 단건 (상세)조회` 같은 경우 `[CACHE_KEY.CATEGORY, categoryId]` 로 들어옵니다.
3. `구독`할 때에는 categoryId에 대한 정보가 있어서 invalidationQueries를  `[CACHE_KEY.CATEGORY, categoryId]` 로 진행했습니다.
4. `구독해제`할 때에는 subscriptionId에 대한 정보만으로 mutate가 진행되어서 categoryId에 대한 정보가 없습니다. 그래서 단순히 `CATEGORY`만을 키값으로 주었습니다.

괜찮나요?

Closes #800 
