### PR TITLE
[fix] 자신이 생성했던 카테고리를 관리 권한이 없는 상태에서 구독해제 하지 못하는 에러를 해결한다.

### DIFF
--- a/frontend/src/components/SubscribedCategoryItem/SubscribedCategoryItem.styles.ts
+++ b/frontend/src/components/SubscribedCategoryItem/SubscribedCategoryItem.styles.ts
@@ -44,27 +44,6 @@ const unsubscribeButton = ({ colors }: Theme) => css`
   &:hover {
     filter: none;
   }
-
-  &:hover span {
-    visibility: visible;
-  }
-`;
-
-const menuTitle = ({ colors }: Theme) => css`
-  visibility: hidden;
-  position: absolute;
-  top: 120%;
-  left: 50%;
-  transform: translateX(-50%);
-
-  padding: 2rem 3rem;
-
-  background: ${colors.GRAY_700}ee;
-
-  font-size: 3rem;
-  font-weight: normal;
-  color: ${colors.WHITE};
-  white-space: nowrap;
 `;
 
 const detailStyle = ({ colors }: Theme, hoveringUpside: boolean) => css`
@@ -98,4 +77,4 @@ const detailStyle = ({ colors }: Theme, hoveringUpside: boolean) => css`
   }
 `;
 
-export { categoryItem, detailStyle, item, menuTitle, unsubscribeButton };
+export { categoryItem, detailStyle, item, unsubscribeButton };

--- a/frontend/src/components/SubscribedCategoryItem/SubscribedCategoryItem.tsx
+++ b/frontend/src/components/SubscribedCategoryItem/SubscribedCategoryItem.tsx
@@ -1,13 +1,10 @@
 import { useTheme } from '@emotion/react';
-import { useRecoilValue } from 'recoil';
 
-import { useGetSingleCategory } from '@/hooks/@queries/category';
+import { useGetEditableCategories, useGetSingleCategory } from '@/hooks/@queries/category';
 import { useDeleteSubscriptions } from '@/hooks/@queries/subscription';
 import useHoverCategoryItem from '@/hooks/useHoverCategoryItem';
 
 import { CategoryType } from '@/@types/category';
-
-import { userState } from '@/recoil/atoms';
 
 import Button from '@/components/@common/Button/Button';
 
@@ -36,14 +33,14 @@ function SubscribedCategoryItem({
 }: SubscribedCategoryItemProps) {
   const theme = useTheme();
 
-  const user = useRecoilValue(userState);
-
   const { hoveringPosY, handleHoverCategoryItem } = useHoverCategoryItem();
 
-  const { data } = useGetSingleCategory({
+  const { data: getSingleCategoryResponse } = useGetSingleCategory({
     categoryId: category.id,
     enabled: !!hoveringPosY,
   });
+
+  const { data: getEditableCategoriesResponse } = useGetEditableCategories({});
 
   const { mutate } = useDeleteSubscriptions({ subscriptionId });
 
@@ -53,7 +50,9 @@ function SubscribedCategoryItem({
     }
   };
 
-  const canUnsubscribeCategory = category.creator.id !== user.id;
+  const canUnsubscribeCategory = !getEditableCategoriesResponse?.data.some(
+    (el) => el.id === category.id
+  );
 
   return (
     <div
@@ -72,7 +71,7 @@ function SubscribedCategoryItem({
         >
           <p>구독중</p>
           {!canUnsubscribeCategory ? (
-            <span css={menuTitle}>{TOOLTIP_MESSAGE.CANNOT_UNSUBSCRIBE_MINE}</span>
+            <span css={menuTitle}>{TOOLTIP_MESSAGE.CANNOT_UNSUBSCRIBE_EDITABLE_CATEGORY}</span>
           ) : (
             <></>
           )}
@@ -80,9 +79,9 @@ function SubscribedCategoryItem({
       </div>
       {hoveringPosY !== null && (
         <div css={detailStyle(theme, hoveringPosY < innerHeight / 2)}>
-          {`구독자 ${data?.data.subscriberCount ?? '-'}명 • 개설일 ${getISODateString(
-            category.createdAt
-          )}`}
+          {`구독자 ${
+            getSingleCategoryResponse?.data.subscriberCount ?? '-'
+          }명 • 개설일 ${getISODateString(category.createdAt)}`}
         </div>
       )}
     </div>

--- a/frontend/src/components/SubscribedCategoryItem/SubscribedCategoryItem.tsx
+++ b/frontend/src/components/SubscribedCategoryItem/SubscribedCategoryItem.tsx
@@ -8,7 +8,7 @@ import { CategoryType } from '@/@types/category';
 
 import Button from '@/components/@common/Button/Button';
 
-import { CONFIRM_MESSAGE, TOOLTIP_MESSAGE } from '@/constants/message';
+import { CONFIRM_MESSAGE } from '@/constants/message';
 
 import { getISODateString } from '@/utils/date';
 
@@ -16,7 +16,6 @@ import {
   categoryItem,
   detailStyle,
   item,
-  menuTitle,
   unsubscribeButton,
 } from './SubscribedCategoryItem.styles';
 
@@ -69,12 +68,7 @@ function SubscribedCategoryItem({
           onClick={handleClickUnsubscribeButton}
           disabled={!canUnsubscribeCategory}
         >
-          <p>구독중</p>
-          {!canUnsubscribeCategory ? (
-            <span css={menuTitle}>{TOOLTIP_MESSAGE.CANNOT_UNSUBSCRIBE_EDITABLE_CATEGORY}</span>
-          ) : (
-            <></>
-          )}
+          구독중
         </Button>
       </div>
       {hoveringPosY !== null && (

--- a/frontend/src/constants/message.ts
+++ b/frontend/src/constants/message.ts
@@ -27,7 +27,7 @@ const SUCCESS_MESSAGE = {
 };
 
 const TOOLTIP_MESSAGE = {
-  CANNOT_UNSUBSCRIBE_MINE: '나의 카테고리는 구독 취소할 수 없습니다.',
+  CANNOT_UNSUBSCRIBE_EDITABLE_CATEGORY: '편집 권한이 있는 카테고리는 구독을 해제할 수 없습니다.',
   CANNOT_EDIT_DELETE_DEFAULT_CATEGORY: '기본 카테고리는 수정/삭제가 불가능합니다.',
 };
 


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 💻 git rebase를 사용했나요?
- [x] 🌈 알록달록한가요?

## 작업 내용
자신이 생성했던 카테고리를 관리 권한이 없는 상태에서 구독해제 하지 못하는 에러를 해결한다.

✨버튼 disabled 처리를 `creator.id === 내 아이디`로 했었는데 이제는 편집 권한의 여부로 판단하도록 변경했습니다.

## 스크린샷
![image](https://user-images.githubusercontent.com/32920566/196062327-0fdad5e1-ba11-400f-a62f-3136360a83ff.png)

이렇게 잘리는 부분을 해결해야할 것 같아요. 답이 떠오르지는 않네요

Closes #803 
