### PR TITLE
[fix] 구글 카테고리 생성 직후 관리 버튼이 보이지 않는 에러를 해결한다.

### DIFF
--- a/frontend/src/hooks/@queries/googleCalendar.ts
+++ b/frontend/src/hooks/@queries/googleCalendar.ts
@@ -41,6 +41,7 @@ function usePostGoogleCalendarCategory({ onSuccess }: UsePostGoogleCalendarCateg
         queryClient.invalidateQueries(CACHE_KEY.MY_CATEGORIES);
         queryClient.invalidateQueries(CACHE_KEY.SUBSCRIPTIONS);
         queryClient.invalidateQueries(CACHE_KEY.SCHEDULES);
+        queryClient.invalidateQueries(CACHE_KEY.EDITABLE_CATEGORIES);
 
         openSnackBar(SUCCESS_MESSAGE.POST_CATEGORY);
         onSuccess && onSuccess();


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 💻 git rebase를 사용했나요?
- [x] 🌈 알록달록한가요?

## 작업 내용
구글 카테고리 생성 직후 관리 버튼이 보이지 않는 에러를 해결한다.

✨구글 카테고리 추가 후 편집가능한 목록이 변하지 않아서 판단을 제대로 못하고 있었습니다.

Closes #805
