### PR TITLE
[fix] 일정 더보기의 말줄임 표시를 추가한다.

### DIFF
--- a/frontend/src/pages/CalendarPage/CalendarPage.styles.ts
+++ b/frontend/src/pages/CalendarPage/CalendarPage.styles.ts
@@ -215,6 +215,8 @@ const moreStyle = ({ colors }: Theme) => css`
   font-size: 2.75rem;
   line-height: 2.75rem;
   white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
   font-weight: 200;
   color: ${colors.GRAY_500};
 


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [X] 🧹 불필요한 코드는 제거했나요?
- [X] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 💻 git rebase를 사용했나요?
- [x] 🌈 알록달록한가요?

## 작업 내용
일정 더보기의 말줄임 표시를 추가한다.
## 스크린샷

### 원래 이랬는데
![image](https://user-images.githubusercontent.com/32920566/196580675-fbfdbe5b-fc7e-4223-b8e9-79e6c2c5931c.png)

### 아래처럼 수정했어요.

![image](https://user-images.githubusercontent.com/32920566/196580707-d97883f3-d3b0-4734-87a1-58530c3e4680.png)


Closes #811 
