### PR TITLE
[fix] 사이드바 카테고리 목록이 없는 경우 관련 문구를 표시한다.

### DIFF
--- a/frontend/src/components/SideGoogleList/SideGoogleList.styles.ts
+++ b/frontend/src/components/SideGoogleList/SideGoogleList.styles.ts
@@ -39,7 +39,7 @@ const contentStyle = ({ flex }: Theme, isListOpen: boolean, listLength: number) 
   overflow: hidden;
 
   width: 100%;
-  height: ${isListOpen ? `${9 * listLength}rem` : 0};
+  height: ${isListOpen ? `${9 * (listLength + 1)}rem` : 0};
   margin-bottom: 5rem;
 
   transition: height 0.3s ease-in-out;

--- a/frontend/src/components/SideSubscribedList/SideSubscribedList.styles.ts
+++ b/frontend/src/components/SideSubscribedList/SideSubscribedList.styles.ts
@@ -39,7 +39,7 @@ const contentStyle = ({ flex }: Theme, isListOpen: boolean, listLength: number) 
   overflow: hidden;
 
   width: 100%;
-  height: ${isListOpen ? `${9 * listLength}rem` : 0};
+  height: ${isListOpen ? `${9 * (listLength + 1)}rem` : 0};
   margin-bottom: 5rem;
 
   transition: height 0.3s ease-in-out;


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 💻 git rebase를 사용했나요?
- [x] 🌈 알록달록한가요?

## 작업 내용
사이드바 카테고리 목록이 없는 경우 관련 문구를 표시한다.

## 스크린샷

### 원래 이랬는데
![image](https://user-images.githubusercontent.com/32920566/196582645-86424a4e-d0cd-4836-9e16-5bb9275e485d.png)

### 이렇게 수정했어요.
![image](https://user-images.githubusercontent.com/32920566/196582728-c9c88bd2-1c92-48e3-ae17-3ddbb01878f1.png)


## 주의사항

저번 사이드바 스타일 관련 이슈를 해결할때 비어있는 경우를 생각하지 않았었네요 ㅠㅠ
다시 수정했씁니다 😂😂

Closes #827 
