### PR TITLE
[refactor] event를 통해 member와 auth의 다른 도메인 패키지에 대한 의존성을 제거한다.

### DIFF
--- a/backend/src/main/java/com/allog/dallog/domain/auth/domain/OAuthTokenRepository.java
+++ b/backend/src/main/java/com/allog/dallog/domain/auth/domain/OAuthTokenRepository.java
@@ -14,8 +14,6 @@ public interface OAuthTokenRepository extends JpaRepository<OAuthToken, Long> {
             + "WHERE o.member.id = :memberId")
     Optional<OAuthToken> findByMemberId(final Long memberId);
 
-    void deleteByMemberId(final Long memberId);
-
     default OAuthToken getByMemberId(final Long memberId) {
         return findByMemberId(memberId)
                 .orElseThrow(NoSuchOAuthTokenException::new);

--- a/backend/src/main/java/com/allog/dallog/domain/auth/event/MemberSavedEvent.java
+++ b/backend/src/main/java/com/allog/dallog/domain/auth/event/MemberSavedEvent.java
@@ -1,0 +1,14 @@
+package com.allog.dallog.domain.auth.event;
+
+public class MemberSavedEvent {
+
+    private final Long memberId;
+
+    public MemberSavedEvent(final Long memberId) {
+        this.memberId = memberId;
+    }
+
+    public Long getMemberId() {
+        return memberId;
+    }
+}

--- a/backend/src/main/java/com/allog/dallog/domain/category/application/CategoryService.java
+++ b/backend/src/main/java/com/allog/dallog/domain/category/application/CategoryService.java
@@ -103,7 +103,7 @@ public class CategoryService {
     }
 
     @Transactional
-    @EventListener(MemberSavedEvent.class)
+    @EventListener
     public void savePersonalCategory(final MemberSavedEvent event) {
         Member member = memberRepository.getById(event.getMemberId());
         Category category = categoryRepository.save(new Category(PERSONAL_CATEGORY_NAME, member, PERSONAL));

--- a/backend/src/main/java/com/allog/dallog/domain/category/application/CategoryService.java
+++ b/backend/src/main/java/com/allog/dallog/domain/category/application/CategoryService.java
@@ -78,16 +78,6 @@ public class CategoryService {
         return new CategoryResponse(savedCategory);
     }
 
-    private void subscribeCategory(final Member member, final Category category) {
-        Color color = Color.pick(colorPicker.pickNumber());
-        subscriptionRepository.save(new Subscription(member, category, color));
-    }
-
-    private void createCategoryRoleAsAdminToCreator(final Member member, final Category category) {
-        CategoryRole categoryRole = new CategoryRole(category, member, ADMIN);
-        categoryRoleRepository.save(categoryRole);
-    }
-
     @Transactional
     public CategoryResponse save(final Long memberId, final ExternalCategoryCreateRequest request) {
         List<Category> externalCategories = categoryRepository
@@ -110,6 +100,16 @@ public class CategoryService {
 
         subscribeCategory(member, category);
         createCategoryRoleAsAdminToCreator(member, category);
+    }
+
+    private void subscribeCategory(final Member member, final Category category) {
+        Color color = Color.pick(colorPicker.pickNumber());
+        subscriptionRepository.save(new Subscription(member, category, color));
+    }
+
+    private void createCategoryRoleAsAdminToCreator(final Member member, final Category category) {
+        CategoryRole categoryRole = new CategoryRole(category, member, ADMIN);
+        categoryRoleRepository.save(categoryRole);
     }
 
     public CategoriesResponse findNormalByName(final String name) {

--- a/backend/src/main/java/com/allog/dallog/domain/category/domain/CategoryRepository.java
+++ b/backend/src/main/java/com/allog/dallog/domain/category/domain/CategoryRepository.java
@@ -25,10 +25,6 @@ public interface CategoryRepository extends JpaRepository<Category, Long> {
             + "WHERE c.member.id = :memberId")
     List<Category> findByMemberId(final Long memberId);
 
-    boolean existsByIdAndMemberId(final Long id, final Long memberId);
-
-    void deleteByMemberId(final Long memberId);
-
     default Category getById(final Long id) {
         return this.findById(id)
                 .orElseThrow(NoSuchCategoryException::new);

--- a/backend/src/main/java/com/allog/dallog/domain/categoryrole/application/CategoryRoleService.java
+++ b/backend/src/main/java/com/allog/dallog/domain/categoryrole/application/CategoryRoleService.java
@@ -1,10 +1,13 @@
 package com.allog.dallog.domain.categoryrole.application;
 
+import static com.allog.dallog.domain.categoryrole.domain.CategoryAuthority.FIND_SUBSCRIBERS;
+
 import com.allog.dallog.domain.category.domain.Category;
 import com.allog.dallog.domain.categoryrole.domain.CategoryAuthority;
 import com.allog.dallog.domain.categoryrole.domain.CategoryRole;
 import com.allog.dallog.domain.categoryrole.domain.CategoryRoleRepository;
 import com.allog.dallog.domain.categoryrole.dto.request.CategoryRoleUpdateRequest;
+import com.allog.dallog.domain.categoryrole.dto.response.SubscribersResponse;
 import com.allog.dallog.domain.categoryrole.exception.NotAbleToChangeRoleException;
 import java.util.List;
 import org.springframework.orm.ObjectOptimisticLockingFailureException;
@@ -19,6 +22,14 @@ public class CategoryRoleService {
 
     public CategoryRoleService(final CategoryRoleRepository categoryRoleRepository) {
         this.categoryRoleRepository = categoryRoleRepository;
+    }
+
+    public SubscribersResponse findSubscribers(final Long loginMemberId, final Long categoryId) {
+        CategoryRole categoryRole = categoryRoleRepository.getByMemberIdAndCategoryId(loginMemberId, categoryId);
+        categoryRole.validateAuthority(FIND_SUBSCRIBERS);
+
+        List<CategoryRole> categoryRoles = categoryRoleRepository.findByCategoryId(categoryId);
+        return new SubscribersResponse(categoryRoles);
     }
 
     @Transactional

--- a/backend/src/main/java/com/allog/dallog/domain/categoryrole/dto/response/MemberWithRoleTypeResponse.java
+++ b/backend/src/main/java/com/allog/dallog/domain/categoryrole/dto/response/MemberWithRoleTypeResponse.java
@@ -1,7 +1,8 @@
-package com.allog.dallog.domain.member.dto.response;
+package com.allog.dallog.domain.categoryrole.dto.response;
 
 import com.allog.dallog.domain.categoryrole.domain.CategoryRole;
 import com.allog.dallog.domain.categoryrole.domain.CategoryRoleType;
+import com.allog.dallog.domain.member.dto.response.MemberResponse;
 
 public class MemberWithRoleTypeResponse {
 

--- a/backend/src/main/java/com/allog/dallog/domain/categoryrole/dto/response/SubscribersResponse.java
+++ b/backend/src/main/java/com/allog/dallog/domain/categoryrole/dto/response/SubscribersResponse.java
@@ -1,4 +1,4 @@
-package com.allog.dallog.domain.member.dto.response;
+package com.allog.dallog.domain.categoryrole.dto.response;
 
 import com.allog.dallog.domain.categoryrole.domain.CategoryRole;
 import java.util.List;

--- a/backend/src/main/java/com/allog/dallog/domain/member/application/MemberService.java
+++ b/backend/src/main/java/com/allog/dallog/domain/member/application/MemberService.java
@@ -1,15 +1,9 @@
 package com.allog.dallog.domain.member.application;
 
-import static com.allog.dallog.domain.categoryrole.domain.CategoryAuthority.FIND_SUBSCRIBERS;
-
-import com.allog.dallog.domain.categoryrole.domain.CategoryRole;
-import com.allog.dallog.domain.categoryrole.domain.CategoryRoleRepository;
 import com.allog.dallog.domain.member.domain.Member;
 import com.allog.dallog.domain.member.domain.MemberRepository;
 import com.allog.dallog.domain.member.dto.request.MemberUpdateRequest;
 import com.allog.dallog.domain.member.dto.response.MemberResponse;
-import com.allog.dallog.domain.member.dto.response.SubscribersResponse;
-import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,24 +12,13 @@ import org.springframework.transaction.annotation.Transactional;
 public class MemberService {
 
     private final MemberRepository memberRepository;
-    private final CategoryRoleRepository categoryRoleRepository;
 
-    public MemberService(final MemberRepository memberRepository,
-                         final CategoryRoleRepository categoryRoleRepository) {
+    public MemberService(final MemberRepository memberRepository) {
         this.memberRepository = memberRepository;
-        this.categoryRoleRepository = categoryRoleRepository;
     }
 
     public MemberResponse findById(final Long id) {
         return new MemberResponse(memberRepository.getById(id));
-    }
-
-    public SubscribersResponse findSubscribers(final Long loginMemberId, final Long categoryId) {
-        CategoryRole categoryRole = categoryRoleRepository.getByMemberIdAndCategoryId(loginMemberId, categoryId);
-        categoryRole.validateAuthority(FIND_SUBSCRIBERS);
-
-        List<CategoryRole> categoryRoles = categoryRoleRepository.findByCategoryId(categoryId);
-        return new SubscribersResponse(categoryRoles);
     }
 
     @Transactional

--- a/backend/src/main/java/com/allog/dallog/domain/member/application/MemberService.java
+++ b/backend/src/main/java/com/allog/dallog/domain/member/application/MemberService.java
@@ -9,8 +9,6 @@ import com.allog.dallog.domain.member.domain.MemberRepository;
 import com.allog.dallog.domain.member.dto.request.MemberUpdateRequest;
 import com.allog.dallog.domain.member.dto.response.MemberResponse;
 import com.allog.dallog.domain.member.dto.response.SubscribersResponse;
-import com.allog.dallog.domain.subscription.domain.Subscription;
-import com.allog.dallog.domain.subscription.domain.SubscriptionRepository;
 import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,26 +18,16 @@ import org.springframework.transaction.annotation.Transactional;
 public class MemberService {
 
     private final MemberRepository memberRepository;
-    private final SubscriptionRepository subscriptionRepository;
     private final CategoryRoleRepository categoryRoleRepository;
 
     public MemberService(final MemberRepository memberRepository,
-                         final SubscriptionRepository subscriptionRepository,
                          final CategoryRoleRepository categoryRoleRepository) {
         this.memberRepository = memberRepository;
-        this.subscriptionRepository = subscriptionRepository;
         this.categoryRoleRepository = categoryRoleRepository;
     }
 
     public MemberResponse findById(final Long id) {
         return new MemberResponse(memberRepository.getById(id));
-    }
-
-    public MemberResponse findBySubscriptionId(final Long subscriptionId) {
-        Subscription subscription = subscriptionRepository.getById(subscriptionId);
-
-        Member member = subscription.getMember();
-        return new MemberResponse(member);
     }
 
     public SubscribersResponse findSubscribers(final Long loginMemberId, final Long categoryId) {

--- a/backend/src/main/java/com/allog/dallog/domain/schedule/domain/ScheduleRepository.java
+++ b/backend/src/main/java/com/allog/dallog/domain/schedule/domain/ScheduleRepository.java
@@ -22,9 +22,6 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
     List<Schedule> findByCategoriesAndBetween(final List<Category> categories, final LocalDateTime startDate,
                                               final LocalDateTime endDate);
 
-    void deleteByCategoryId(final Long id);
-
-
     default Schedule getById(final Long id) {
         return this.findById(id)
                 .orElseThrow(NoSuchScheduleException::new);

--- a/backend/src/main/java/com/allog/dallog/domain/subscription/application/SubscriptionService.java
+++ b/backend/src/main/java/com/allog/dallog/domain/subscription/application/SubscriptionService.java
@@ -63,11 +63,6 @@ public class SubscriptionService {
         categoryRoleRepository.save(categoryRole);
     }
 
-    public SubscriptionResponse findById(final Long id) {
-        Subscription subscription = subscriptionRepository.getById(id);
-        return new SubscriptionResponse(subscription);
-    }
-
     public SubscriptionsResponse findByMemberId(final Long memberId) {
         List<Subscription> subscriptions = subscriptionRepository.findByMemberId(memberId);
 
@@ -76,13 +71,6 @@ public class SubscriptionService {
                 .collect(Collectors.toList());
 
         return new SubscriptionsResponse(subscriptionResponses);
-    }
-
-    public List<SubscriptionResponse> findByCategoryId(final Long categoryId) {
-        return subscriptionRepository.findByCategoryId(categoryId)
-                .stream()
-                .map(SubscriptionResponse::new)
-                .collect(Collectors.toList());
     }
 
     @Transactional

--- a/backend/src/main/java/com/allog/dallog/domain/subscription/domain/SubscriptionRepository.java
+++ b/backend/src/main/java/com/allog/dallog/domain/subscription/domain/SubscriptionRepository.java
@@ -19,13 +19,7 @@ public interface SubscriptionRepository extends JpaRepository<Subscription, Long
     @EntityGraph(attributePaths = {"category", "category.member"})
     List<Subscription> findByCategoryId(final Long categoryId);
 
-    void deleteByMemberId(final Long id);
-
-    void deleteByCategoryId(final Long id);
-
     void deleteByCategoryIdIn(final List<Long> id);
-
-    void deleteByMemberIdAndCategoryId(final Long memberId, final Long categoryId);
 
     default Subscription getById(final Long id) {
         return findById(id)

--- a/backend/src/main/java/com/allog/dallog/presentation/CategoryController.java
+++ b/backend/src/main/java/com/allog/dallog/presentation/CategoryController.java
@@ -9,8 +9,7 @@ import com.allog.dallog.domain.category.dto.response.CategoryDetailResponse;
 import com.allog.dallog.domain.category.dto.response.CategoryResponse;
 import com.allog.dallog.domain.categoryrole.application.CategoryRoleService;
 import com.allog.dallog.domain.categoryrole.dto.request.CategoryRoleUpdateRequest;
-import com.allog.dallog.domain.member.application.MemberService;
-import com.allog.dallog.domain.member.dto.response.SubscribersResponse;
+import com.allog.dallog.domain.categoryrole.dto.response.SubscribersResponse;
 import com.allog.dallog.presentation.auth.AuthenticationPrincipal;
 import java.net.URI;
 import javax.validation.Valid;
@@ -31,13 +30,10 @@ public class CategoryController {
 
     private final CategoryService categoryService;
     private final CategoryRoleService categoryRoleService;
-    private final MemberService memberService;
 
-    public CategoryController(final CategoryService categoryService, final CategoryRoleService categoryRoleService,
-                              final MemberService memberService) {
+    public CategoryController(final CategoryService categoryService, final CategoryRoleService categoryRoleService) {
         this.categoryService = categoryService;
         this.categoryRoleService = categoryRoleService;
-        this.memberService = memberService;
     }
 
     @PostMapping
@@ -87,7 +83,7 @@ public class CategoryController {
     @GetMapping("/{categoryId}/subscribers")
     public ResponseEntity<SubscribersResponse> findSubscribers(@AuthenticationPrincipal final LoginMember loginMember,
                                                                @PathVariable final Long categoryId) {
-        SubscribersResponse subscribers = memberService.findSubscribers(loginMember.getId(), categoryId);
+        SubscribersResponse subscribers = categoryRoleService.findSubscribers(loginMember.getId(), categoryId);
         return ResponseEntity.ok(subscribers);
     }
 

--- a/backend/src/test/java/com/allog/dallog/common/annotation/ServiceTest.java
+++ b/backend/src/test/java/com/allog/dallog/common/annotation/ServiceTest.java
@@ -3,6 +3,7 @@ package com.allog.dallog.common.annotation;
 import com.allog.dallog.common.DatabaseCleaner;
 import com.allog.dallog.common.config.ExternalApiConfig;
 import com.allog.dallog.domain.auth.application.AuthService;
+import com.allog.dallog.domain.auth.domain.TokenRepository;
 import com.allog.dallog.domain.auth.dto.OAuthMember;
 import com.allog.dallog.domain.auth.dto.response.AccessAndRefreshTokenResponse;
 import org.junit.jupiter.api.BeforeEach;
@@ -18,11 +19,15 @@ public class ServiceTest {
     private AuthService authService;
 
     @Autowired
+    private TokenRepository tokenRepository;
+
+    @Autowired
     private DatabaseCleaner databaseCleaner;
 
     @BeforeEach
     void setUp() {
         databaseCleaner.execute();
+        tokenRepository.deleteAll();
     }
 
     protected Long toMemberId(final OAuthMember oAuthMember) {

--- a/backend/src/test/java/com/allog/dallog/domain/auth/application/AuthServiceTest.java
+++ b/backend/src/test/java/com/allog/dallog/domain/auth/application/AuthServiceTest.java
@@ -13,6 +13,7 @@ import com.allog.dallog.domain.auth.dto.request.TokenRenewalRequest;
 import com.allog.dallog.domain.auth.dto.request.TokenRequest;
 import com.allog.dallog.domain.auth.dto.response.AccessAndRefreshTokenResponse;
 import com.allog.dallog.domain.auth.dto.response.AccessTokenResponse;
+import com.allog.dallog.domain.auth.event.MemberSavedEvent;
 import com.allog.dallog.domain.auth.exception.InvalidTokenException;
 import com.allog.dallog.domain.category.domain.Category;
 import com.allog.dallog.domain.categoryrole.domain.CategoryRole;
@@ -26,7 +27,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.event.ApplicationEvents;
+import org.springframework.test.context.event.RecordApplicationEvents;
 
+@RecordApplicationEvents
 class AuthServiceTest extends ServiceTest {
 
     @Autowired
@@ -44,10 +48,8 @@ class AuthServiceTest extends ServiceTest {
     @Autowired
     private CategoryRoleRepository categoryRoleRepository;
 
-    @BeforeEach
-    void setUp() {
-        tokenRepository.deleteAll();
-    }
+    @Autowired
+    private ApplicationEvents events;
 
     @DisplayName("토큰 생성을 하면 OAuth 서버에서 인증 후 토큰을 반환한다")
     @Test
@@ -88,6 +90,7 @@ class AuthServiceTest extends ServiceTest {
         // then
         assertAll(() -> {
             assertThat(actual.getName()).isEqualTo("내 일정");
+            assertThat(events.stream(MemberSavedEvent.class).count()).isEqualTo(1);
         });
     }
 
@@ -105,6 +108,7 @@ class AuthServiceTest extends ServiceTest {
         assertAll(() -> {
             assertThat(actual).hasSize(1);
             assertThat(actual.iterator().next().getCategory().getName()).isEqualTo("내 일정");
+            assertThat(events.stream(MemberSavedEvent.class).count()).isEqualTo(1);
         });
     }
 

--- a/backend/src/test/java/com/allog/dallog/domain/auth/application/AuthServiceTest.java
+++ b/backend/src/test/java/com/allog/dallog/domain/auth/application/AuthServiceTest.java
@@ -1,7 +1,6 @@
 package com.allog.dallog.domain.auth.application;
 
 import static com.allog.dallog.common.fixtures.AuthFixtures.MEMBER_이메일;
-import static com.allog.dallog.common.fixtures.AuthFixtures.STUB_MEMBER_인증_코드;
 import static com.allog.dallog.common.fixtures.OAuthFixtures.MEMBER;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -10,7 +9,6 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import com.allog.dallog.common.annotation.ServiceTest;
 import com.allog.dallog.domain.auth.domain.TokenRepository;
 import com.allog.dallog.domain.auth.dto.request.TokenRenewalRequest;
-import com.allog.dallog.domain.auth.dto.request.TokenRequest;
 import com.allog.dallog.domain.auth.dto.response.AccessAndRefreshTokenResponse;
 import com.allog.dallog.domain.auth.dto.response.AccessTokenResponse;
 import com.allog.dallog.domain.auth.event.MemberSavedEvent;
@@ -23,7 +21,6 @@ import com.allog.dallog.domain.member.domain.MemberRepository;
 import com.allog.dallog.domain.subscription.domain.Subscription;
 import com.allog.dallog.domain.subscription.domain.SubscriptionRepository;
 import java.util.List;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -81,7 +78,7 @@ class AuthServiceTest extends ServiceTest {
         // given
         authService.generateAccessAndRefreshToken(MEMBER.getOAuthMember());
 
-        Member member = memberRepository.findByEmail(MEMBER_이메일).get();
+        Member member = memberRepository.getByEmail(MEMBER_이메일);
         List<Subscription> subscriptions = subscriptionRepository.findByMemberId(member.getId());
 
         // when
@@ -99,7 +96,7 @@ class AuthServiceTest extends ServiceTest {
     void Authorization_Code를_받으면_회원_개인_카테고리에_대한_CategoryRole을_생성한다() {
         // given
         authService.generateAccessAndRefreshToken(MEMBER.getOAuthMember());
-        Member member = memberRepository.findByEmail(MEMBER_이메일).get();
+        Member member = memberRepository.getByEmail(MEMBER_이메일);
 
         // when
         List<CategoryRole> actual = categoryRoleRepository.findByMemberId(member.getId());
@@ -147,7 +144,6 @@ class AuthServiceTest extends ServiceTest {
     @Test
     void 리프레시_토큰으로_새로운_엑세스_토큰을_발급한다() {
         // given
-        TokenRequest tokenRequest = new TokenRequest(STUB_MEMBER_인증_코드, "https://dallog.me/oauth");
         AccessAndRefreshTokenResponse response = authService.generateAccessAndRefreshToken(MEMBER.getOAuthMember());
         TokenRenewalRequest tokenRenewalRequest = new TokenRenewalRequest(response.getRefreshToken());
 

--- a/backend/src/test/java/com/allog/dallog/domain/auth/application/AuthServiceTest.java
+++ b/backend/src/test/java/com/allog/dallog/domain/auth/application/AuthServiceTest.java
@@ -7,19 +7,13 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.allog.dallog.common.annotation.ServiceTest;
-import com.allog.dallog.domain.auth.domain.TokenRepository;
 import com.allog.dallog.domain.auth.dto.request.TokenRenewalRequest;
 import com.allog.dallog.domain.auth.dto.response.AccessAndRefreshTokenResponse;
 import com.allog.dallog.domain.auth.dto.response.AccessTokenResponse;
 import com.allog.dallog.domain.auth.event.MemberSavedEvent;
 import com.allog.dallog.domain.auth.exception.InvalidTokenException;
-import com.allog.dallog.domain.category.domain.Category;
-import com.allog.dallog.domain.categoryrole.domain.CategoryRole;
-import com.allog.dallog.domain.categoryrole.domain.CategoryRoleRepository;
 import com.allog.dallog.domain.member.domain.Member;
 import com.allog.dallog.domain.member.domain.MemberRepository;
-import com.allog.dallog.domain.subscription.domain.Subscription;
-import com.allog.dallog.domain.subscription.domain.SubscriptionRepository;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -37,15 +31,6 @@ class AuthServiceTest extends ServiceTest {
     private MemberRepository memberRepository;
 
     @Autowired
-    private TokenRepository tokenRepository;
-
-    @Autowired
-    private SubscriptionRepository subscriptionRepository;
-
-    @Autowired
-    private CategoryRoleRepository categoryRoleRepository;
-
-    @Autowired
     private ApplicationEvents events;
 
     @DisplayName("토큰 생성을 하면 OAuth 서버에서 인증 후 토큰을 반환한다")
@@ -58,53 +43,22 @@ class AuthServiceTest extends ServiceTest {
         assertAll(() -> {
             assertThat(actual.getAccessToken()).isNotEmpty();
             assertThat(actual.getRefreshToken()).isNotEmpty();
+            assertThat(events.stream(MemberSavedEvent.class).count()).isEqualTo(1);
         });
     }
 
     @DisplayName("Authorization Code를 받으면 회원이 데이터베이스에 저장된다.")
     @Test
     void Authorization_Code를_받으면_회원이_데이터베이스에_저장된다() {
-        // given
+        // given & when
         authService.generateAccessAndRefreshToken(MEMBER.getOAuthMember());
 
-        // when & then
+        // then
         assertThat(memberRepository.existsByEmail(MEMBER_이메일)).isTrue();
-        // SutbOAuthClient가 반환하는 OAuthMember의 이메일
-    }
 
-    @DisplayName("Authorization Code를 받으면 회원 개인 카테고리를 생성한다.")
-    @Test
-    void Authorization_Code를_받으면_회원_개인_카테고리를_생성한다() {
-        // given
-        authService.generateAccessAndRefreshToken(MEMBER.getOAuthMember());
-
-        Member member = memberRepository.getByEmail(MEMBER_이메일);
-        List<Subscription> subscriptions = subscriptionRepository.findByMemberId(member.getId());
-
-        // when
-        Category actual = subscriptions.iterator().next().getCategory();
-
-        // then
         assertAll(() -> {
-            assertThat(actual.getName()).isEqualTo("내 일정");
-            assertThat(events.stream(MemberSavedEvent.class).count()).isEqualTo(1);
-        });
-    }
-
-    @DisplayName("Authorization Code를 받으면 회원 개인 카테고리에 대한 CategoryRole을 생성한다.")
-    @Test
-    void Authorization_Code를_받으면_회원_개인_카테고리에_대한_CategoryRole을_생성한다() {
-        // given
-        authService.generateAccessAndRefreshToken(MEMBER.getOAuthMember());
-        Member member = memberRepository.getByEmail(MEMBER_이메일);
-
-        // when
-        List<CategoryRole> actual = categoryRoleRepository.findByMemberId(member.getId());
-
-        // then
-        assertAll(() -> {
-            assertThat(actual).hasSize(1);
-            assertThat(actual.iterator().next().getCategory().getName()).isEqualTo("내 일정");
+            // SutbOAuthClient가 반환하는 OAuthMember의 이메일
+            assertThat(memberRepository.existsByEmail(MEMBER_이메일)).isTrue();
             assertThat(events.stream(MemberSavedEvent.class).count()).isEqualTo(1);
         });
     }

--- a/backend/src/test/java/com/allog/dallog/domain/auth/domain/OAuthTokenRepositoryTest.java
+++ b/backend/src/test/java/com/allog/dallog/domain/auth/domain/OAuthTokenRepositoryTest.java
@@ -25,9 +25,7 @@ class OAuthTokenRepositoryTest extends RepositoryTest {
     void member_id의_OAuthToken이_존재할_경우_true를_반환한다() {
         // given
         Member 매트 = memberRepository.save(매트());
-
-        String refreshToken = REFRESH_TOKEN;
-        oAuthTokenRepository.save(new OAuthToken(매트, refreshToken));
+        oAuthTokenRepository.save(new OAuthToken(매트, REFRESH_TOKEN));
 
         // when
         boolean actual = oAuthTokenRepository.existsByMemberId(매트.getId());
@@ -51,9 +49,7 @@ class OAuthTokenRepositoryTest extends RepositoryTest {
     void member_id의_OAuthToken이_존재할_경우_Optional은_비어있지_않다() {
         // given
         Member 매트 = memberRepository.save(매트());
-
-        String refreshToken = REFRESH_TOKEN;
-        oAuthTokenRepository.save(new OAuthToken(매트, refreshToken));
+        oAuthTokenRepository.save(new OAuthToken(매트, REFRESH_TOKEN));
 
         // when
         Optional<OAuthToken> actual = oAuthTokenRepository.findByMemberId(매트.getId());
@@ -69,23 +65,6 @@ class OAuthTokenRepositoryTest extends RepositoryTest {
         Optional<OAuthToken> actual = oAuthTokenRepository.findByMemberId(0L);
 
         // then
-        assertThat(actual).isEmpty();
-    }
-
-    @DisplayName("member id의 OAuthToke을 삭제한다.")
-    @Test
-    void member_id의_OAuthToken을_삭제한다() {
-        // given
-        Member 매트 = memberRepository.save(매트());
-
-        String refreshToken = REFRESH_TOKEN;
-        oAuthTokenRepository.save(new OAuthToken(매트, refreshToken));
-
-        // when
-        oAuthTokenRepository.deleteByMemberId(매트.getId());
-
-        // then
-        Optional<OAuthToken> actual = oAuthTokenRepository.findByMemberId(매트.getId());
         assertThat(actual).isEmpty();
     }
 }

--- a/backend/src/test/java/com/allog/dallog/domain/category/application/CategoryServiceTest.java
+++ b/backend/src/test/java/com/allog/dallog/domain/category/application/CategoryServiceTest.java
@@ -55,9 +55,9 @@ import com.allog.dallog.domain.schedule.application.ScheduleService;
 import com.allog.dallog.domain.schedule.dto.response.ScheduleResponse;
 import com.allog.dallog.domain.schedule.exception.NoSuchScheduleException;
 import com.allog.dallog.domain.subscription.application.SubscriptionService;
+import com.allog.dallog.domain.subscription.domain.SubscriptionRepository;
 import com.allog.dallog.domain.subscription.dto.response.SubscriptionResponse;
 import com.allog.dallog.domain.subscription.dto.response.SubscriptionsResponse;
-import com.allog.dallog.domain.subscription.exception.NoSuchSubscriptionException;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.DisplayName;
@@ -74,6 +74,9 @@ class CategoryServiceTest extends ServiceTest {
 
     @Autowired
     private SubscriptionService subscriptionService;
+
+    @Autowired
+    private SubscriptionRepository subscriptionRepository;
 
     @Autowired
     private ScheduleService scheduleService;
@@ -114,7 +117,7 @@ class CategoryServiceTest extends ServiceTest {
 
         // when
         CategoryResponse 내_일정_응답 = categoryService.save(후디.getId(), 내_일정_생성_요청);
-        Category 내_일정 = categoryRepository.findById(내_일정_응답.getId()).get();
+        Category 내_일정 = categoryRepository.getById(내_일정_응답.getId());
 
         // then
         assertAll(() -> {
@@ -176,7 +179,7 @@ class CategoryServiceTest extends ServiceTest {
 
         // when
         CategoryResponse 후디_대한민국_공휴일_카테고리_응답 = categoryService.save(후디.getId(), 대한민국_공휴일_생성_요청);
-        Category 후디_대한민국_공휴일_카테고리 = categoryRepository.findById(후디_대한민국_공휴일_카테고리_응답.getId()).get();
+        Category 후디_대한민국_공휴일_카테고리 = categoryRepository.getById(후디_대한민국_공휴일_카테고리_응답.getId());
 
         // then
         assertAll(() -> {
@@ -528,8 +531,7 @@ class CategoryServiceTest extends ServiceTest {
         categoryService.delete(관리자.getId(), 공통_일정.getId());
 
         // then
-        assertThatThrownBy(() -> subscriptionService.findById(구독.getId()))
-                .isInstanceOf(NoSuchSubscriptionException.class);
+        assertThat(subscriptionRepository.existsById(구독.getId())).isFalse();
     }
 
     @Transactional

--- a/backend/src/test/java/com/allog/dallog/domain/category/application/CategoryServiceTest.java
+++ b/backend/src/test/java/com/allog/dallog/domain/category/application/CategoryServiceTest.java
@@ -6,6 +6,7 @@ import static com.allog.dallog.common.fixtures.CategoryFixtures.FE_일정_생성
 import static com.allog.dallog.common.fixtures.CategoryFixtures.FE_일정_이름;
 import static com.allog.dallog.common.fixtures.CategoryFixtures.공통_일정_생성_요청;
 import static com.allog.dallog.common.fixtures.CategoryFixtures.공통_일정_이름;
+import static com.allog.dallog.common.fixtures.CategoryFixtures.내_일정;
 import static com.allog.dallog.common.fixtures.CategoryFixtures.내_일정_생성_요청;
 import static com.allog.dallog.common.fixtures.CategoryFixtures.매트_아고라_생성_요청;
 import static com.allog.dallog.common.fixtures.CategoryFixtures.매트_아고라_이름;
@@ -16,8 +17,8 @@ import static com.allog.dallog.common.fixtures.ExternalCategoryFixtures.대한�
 import static com.allog.dallog.common.fixtures.ExternalCategoryFixtures.대한민국_공휴일_이름;
 import static com.allog.dallog.common.fixtures.MemberFixtures.관리자;
 import static com.allog.dallog.common.fixtures.MemberFixtures.매트;
+import static com.allog.dallog.common.fixtures.MemberFixtures.파랑;
 import static com.allog.dallog.common.fixtures.MemberFixtures.후디;
-import static com.allog.dallog.common.fixtures.OAuthFixtures.리버;
 import static com.allog.dallog.common.fixtures.OAuthFixtures.파랑;
 import static com.allog.dallog.common.fixtures.OAuthFixtures.후디;
 import static com.allog.dallog.common.fixtures.ScheduleFixtures.레벨_인터뷰_생성_요청;
@@ -33,8 +34,10 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import com.allog.dallog.common.annotation.ServiceTest;
 import com.allog.dallog.common.fixtures.CategoryFixtures;
 import com.allog.dallog.domain.auth.application.AuthService;
+import com.allog.dallog.domain.auth.event.MemberSavedEvent;
 import com.allog.dallog.domain.category.domain.Category;
 import com.allog.dallog.domain.category.domain.CategoryRepository;
+import com.allog.dallog.domain.category.domain.CategoryType;
 import com.allog.dallog.domain.category.dto.request.CategoryCreateRequest;
 import com.allog.dallog.domain.category.dto.request.CategoryUpdateRequest;
 import com.allog.dallog.domain.category.dto.response.CategoriesResponse;
@@ -55,11 +58,10 @@ import com.allog.dallog.domain.schedule.application.ScheduleService;
 import com.allog.dallog.domain.schedule.dto.response.ScheduleResponse;
 import com.allog.dallog.domain.schedule.exception.NoSuchScheduleException;
 import com.allog.dallog.domain.subscription.application.SubscriptionService;
+import com.allog.dallog.domain.subscription.domain.Subscription;
 import com.allog.dallog.domain.subscription.domain.SubscriptionRepository;
 import com.allog.dallog.domain.subscription.dto.response.SubscriptionResponse;
-import com.allog.dallog.domain.subscription.dto.response.SubscriptionsResponse;
 import java.util.List;
-import java.util.stream.Collectors;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -134,9 +136,7 @@ class CategoryServiceTest extends ServiceTest {
 
         // when
         categoryService.save(파랑_id, 공통_일정_생성_요청);
-
-        SubscriptionsResponse subscriptions = subscriptionService.findByMemberId(파랑_id);
-        List<SubscriptionResponse> actual = subscriptions.getSubscriptions();
+        List<Subscription> actual = subscriptionRepository.findByMemberId(파랑_id);
 
         // then
         assertThat(actual).hasSize(2);
@@ -211,12 +211,38 @@ class CategoryServiceTest extends ServiceTest {
 
         // when
         categoryService.save(파랑_id, 대한민국_공휴일_생성_요청);
-
-        SubscriptionsResponse subscriptions = subscriptionService.findByMemberId(파랑_id);
-        List<SubscriptionResponse> actual = subscriptions.getSubscriptions();
+        List<Subscription> actual = subscriptionRepository.findByMemberId(파랑_id);
 
         // then
         assertThat(actual).hasSize(2);
+    }
+
+    @DisplayName("저장된 회원의 개인 카테고리를 생성하고 자동으로 구독하고 카테고리 역할을 부여한다.")
+    @Test
+    void 저장된_회원의_개인_카테고리를_생성하고_자동으로_구독하고_카테고리_역할을_부여한다() {
+        // given
+        Member 파랑 = memberRepository.save(파랑());
+        MemberSavedEvent event = new MemberSavedEvent(파랑.getId());
+
+        // when
+        categoryService.savePersonalCategory(event);
+
+        // then
+        List<Category> categories = categoryRepository.findByMemberId(파랑.getId());
+        List<Subscription> subscriptions = subscriptionRepository.findByMemberId(파랑.getId());
+        List<CategoryRole> categoryRoles = categoryRoleRepository.findByMemberId(파랑.getId());
+
+        assertAll(() -> {
+            assertThat(categories).hasSize(1)
+                    .extracting("categoryType")
+                    .containsExactly(CategoryType.PERSONAL);
+            assertThat(subscriptions).hasSize(1)
+                    .extracting("checked")
+                    .containsExactly(true);
+            assertThat(categoryRoles).hasSize(1)
+                    .extracting("categoryRoleType")
+                    .containsExactly(ADMIN);
+        });
     }
 
     @DisplayName("검색어를 받아 제목에 검색어가 포함된 카테고리를 가져온다.")
@@ -245,8 +271,8 @@ class CategoryServiceTest extends ServiceTest {
     @Test
     void 개인_카테고리는_전체_조회_대상에서_제외된다() {
         // given
-        authService.generateAccessAndRefreshToken(후디.getOAuthMember());
-        authService.generateAccessAndRefreshToken(리버.getOAuthMember());
+        Member 파랑 = memberRepository.save(파랑());
+        categoryRepository.save(내_일정(파랑));
 
         // when
         CategoriesResponse response = categoryService.findNormalByName("");
@@ -279,11 +305,9 @@ class CategoryServiceTest extends ServiceTest {
         CategoriesResponse actual = categoryService.findScheduleEditableCategories(관리자.getId());
 
         // then
-        assertAll(() -> {
-            assertThat(actual.getCategories().size()).isEqualTo(5);
-            assertThat(actual.getCategories().stream().map(CategoryResponse::getName).collect(Collectors.toList()))
-                    .containsExactly(공통_일정_이름, BE_일정_이름, FE_일정_이름, 매트_아고라_이름, 후디_JPA_스터디_이름);
-        });
+        assertThat(actual.getCategories()).hasSize(5)
+                .extracting("name")
+                .containsExactly(공통_일정_이름, BE_일정_이름, FE_일정_이름, 매트_아고라_이름, 후디_JPA_스터디_이름);
     }
 
     @DisplayName("회원이 ADMIN으로 있는 카테고리 목록을 조회한다.")
@@ -310,11 +334,9 @@ class CategoryServiceTest extends ServiceTest {
         CategoriesResponse actual = categoryService.findAdminCategories(관리자.getId());
 
         // then
-        assertAll(() -> {
-            assertThat(actual.getCategories().size()).isEqualTo(5);
-            assertThat(actual.getCategories().stream().map(CategoryResponse::getName).collect(Collectors.toList()))
-                    .containsExactly(공통_일정_이름, BE_일정_이름, FE_일정_이름, 매트_아고라_이름, 후디_JPA_스터디_이름);
-        });
+        assertThat(actual.getCategories()).hasSize(5)
+                .extracting("name")
+                .containsExactly(공통_일정_이름, BE_일정_이름, FE_일정_이름, 매트_아고라_이름, 후디_JPA_스터디_이름);
     }
 
     @DisplayName("id를 통해 카테고리를 단건 조회한다.")

--- a/backend/src/test/java/com/allog/dallog/domain/category/domain/CategoryRepositoryTest.java
+++ b/backend/src/test/java/com/allog/dallog/domain/category/domain/CategoryRepositoryTest.java
@@ -171,48 +171,4 @@ class CategoryRepositoryTest extends RepositoryTest {
                     .isTrue();
         });
     }
-
-    @DisplayName("카테고리 id와 회원의 id가 모두 일치하는 카테고리가 있으면 true를 반환한다.")
-    @Test
-    void 카테고리_id와_회원의_id가_모두_일치하는_카테고리가_있으면_true를_반환한다() {
-        // given
-        Member 관리자 = memberRepository.save(관리자());
-        Category 공통_일정 = categoryRepository.save(공통_일정(관리자));
-
-        // when
-        boolean actual = categoryRepository.existsByIdAndMemberId(공통_일정.getId(), 관리자.getId());
-
-        // then
-        assertThat(actual).isTrue();
-    }
-
-    @DisplayName("카테고리 id와 회원의 id가 모두 일치하는 카테고리가 없으면 false를 반환한다.")
-    @Test
-    void 카테고리_id와_회원의_id가_모두_일치하는_카테고리가_없으면_false를_반환한다() {
-        // given
-        Member 관리자 = memberRepository.save(관리자());
-        Category 공통_일정 = categoryRepository.save(공통_일정(관리자));
-
-        // when
-        boolean actual = categoryRepository.existsByIdAndMemberId(공통_일정.getId(), 0L);
-
-        // then
-        assertThat(actual).isFalse();
-    }
-
-    @DisplayName("특정 회원이 만든 카테고리를 모두 삭제한다")
-    @Test
-    void 특정_회원이_만든_카테고리를_모두_삭제한다() {
-        // given
-        Member 관리자 = memberRepository.save(관리자());
-        categoryRepository.save(공통_일정(관리자));
-        categoryRepository.save(BE_일정(관리자));
-
-        // when
-        categoryRepository.deleteByMemberId(관리자.getId());
-
-        // then
-        assertThat(categoryRepository.findByMemberId(관리자.getId()))
-                .hasSize(0);
-    }
 }

--- a/backend/src/test/java/com/allog/dallog/domain/member/application/MemberServiceTest.java
+++ b/backend/src/test/java/com/allog/dallog/domain/member/application/MemberServiceTest.java
@@ -1,31 +1,12 @@
 package com.allog.dallog.domain.member.application;
 
-import static com.allog.dallog.common.fixtures.CategoryFixtures.공통_일정_생성_요청;
-import static com.allog.dallog.common.fixtures.MemberFixtures.관리자;
-import static com.allog.dallog.common.fixtures.MemberFixtures.관리자_이름;
-import static com.allog.dallog.common.fixtures.MemberFixtures.리버;
-import static com.allog.dallog.common.fixtures.MemberFixtures.리버_이름;
-import static com.allog.dallog.common.fixtures.MemberFixtures.매트;
-import static com.allog.dallog.common.fixtures.MemberFixtures.파랑;
-import static com.allog.dallog.common.fixtures.MemberFixtures.후디;
-import static com.allog.dallog.common.fixtures.MemberFixtures.후디_이름;
 import static com.allog.dallog.common.fixtures.OAuthFixtures.매트;
 import static com.allog.dallog.common.fixtures.OAuthFixtures.파랑;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.allog.dallog.common.annotation.ServiceTest;
-import com.allog.dallog.domain.category.application.CategoryService;
-import com.allog.dallog.domain.category.dto.response.CategoryResponse;
-import com.allog.dallog.domain.categoryrole.exception.NoCategoryAuthorityException;
-import com.allog.dallog.domain.member.domain.Member;
-import com.allog.dallog.domain.member.domain.MemberRepository;
 import com.allog.dallog.domain.member.dto.request.MemberUpdateRequest;
 import com.allog.dallog.domain.member.dto.response.MemberResponse;
-import com.allog.dallog.domain.member.dto.response.SubscribersResponse;
-import com.allog.dallog.domain.subscription.application.SubscriptionService;
-import java.util.stream.Collectors;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -34,15 +15,6 @@ class MemberServiceTest extends ServiceTest {
 
     @Autowired
     private MemberService memberService;
-
-    @Autowired
-    private MemberRepository memberRepository;
-
-    @Autowired
-    private SubscriptionService subscriptionService;
-
-    @Autowired
-    private CategoryService categoryService;
 
     @DisplayName("id를 통해 회원을 단건 조회한다.")
     @Test
@@ -70,48 +42,5 @@ class MemberServiceTest extends ServiceTest {
         // then
         MemberResponse actual = memberService.findById(매트_id);
         assertThat(actual.getDisplayName()).isEqualTo(패트_이름);
-    }
-
-    @DisplayName("특정 카테고리의 구독자 목록을 반환한다.")
-    @Test
-    void 특정_카테고리의_구독자_목록을_반환한다() {
-        // given
-        Member 관리자 = memberRepository.save(관리자());
-        Member 후디 = memberRepository.save(후디());
-        Member 리버 = memberRepository.save(리버());
-        memberRepository.save(파랑());
-        memberRepository.save(매트());
-
-        CategoryResponse 카테고리 = categoryService.save(관리자.getId(), 공통_일정_생성_요청);
-
-        subscriptionService.save(후디.getId(), 카테고리.getId());
-        subscriptionService.save(리버.getId(), 카테고리.getId());
-
-        // when
-        SubscribersResponse actual = memberService.findSubscribers(관리자.getId(), 카테고리.getId());
-
-        // then
-        assertAll(() -> {
-            assertThat(actual.getSubscribers().size()).isEqualTo(3);
-            assertThat(
-                    actual.getSubscribers().stream().map(it -> it.getMember().getDisplayName())
-                            .collect(Collectors.toList()))
-                    .containsExactly(관리자_이름, 후디_이름, 리버_이름);
-        });
-    }
-
-    @DisplayName("특정 카테고리의 구독자 목록을 ADMIN이 아닌 회원이 호출하면 예외가 발생한다.")
-    @Test
-    void 특정_카테고리의_구독자_목록을_ADMIN이_아닌_회원이_호출하면_예외가_발생한다() {
-        // given
-        Member 관리자 = memberRepository.save(관리자());
-        Member 후디 = memberRepository.save(후디());
-
-        CategoryResponse 카테고리 = categoryService.save(관리자.getId(), 공통_일정_생성_요청);
-        subscriptionService.save(후디.getId(), 카테고리.getId());
-
-        // when & then
-        assertThatThrownBy(() -> memberService.findSubscribers(후디.getId(), 카테고리.getId()))
-                .isInstanceOf(NoCategoryAuthorityException.class);
     }
 }

--- a/backend/src/test/java/com/allog/dallog/domain/member/application/MemberServiceTest.java
+++ b/backend/src/test/java/com/allog/dallog/domain/member/application/MemberServiceTest.java
@@ -1,6 +1,5 @@
 package com.allog.dallog.domain.member.application;
 
-import static com.allog.dallog.common.fixtures.CategoryFixtures.BE_일정;
 import static com.allog.dallog.common.fixtures.CategoryFixtures.공통_일정_생성_요청;
 import static com.allog.dallog.common.fixtures.MemberFixtures.관리자;
 import static com.allog.dallog.common.fixtures.MemberFixtures.관리자_이름;
@@ -17,10 +16,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.allog.dallog.common.annotation.ServiceTest;
-import com.allog.dallog.common.fixtures.SubscriptionFixtures;
 import com.allog.dallog.domain.category.application.CategoryService;
-import com.allog.dallog.domain.category.domain.Category;
-import com.allog.dallog.domain.category.domain.CategoryRepository;
 import com.allog.dallog.domain.category.dto.response.CategoryResponse;
 import com.allog.dallog.domain.categoryrole.exception.NoCategoryAuthorityException;
 import com.allog.dallog.domain.member.domain.Member;
@@ -29,8 +25,6 @@ import com.allog.dallog.domain.member.dto.request.MemberUpdateRequest;
 import com.allog.dallog.domain.member.dto.response.MemberResponse;
 import com.allog.dallog.domain.member.dto.response.SubscribersResponse;
 import com.allog.dallog.domain.subscription.application.SubscriptionService;
-import com.allog.dallog.domain.subscription.domain.Subscription;
-import com.allog.dallog.domain.subscription.domain.SubscriptionRepository;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -45,13 +39,7 @@ class MemberServiceTest extends ServiceTest {
     private MemberRepository memberRepository;
 
     @Autowired
-    private SubscriptionRepository subscriptionRepository;
-
-    @Autowired
     private SubscriptionService subscriptionService;
-
-    @Autowired
-    private CategoryRepository categoryRepository;
 
     @Autowired
     private CategoryService categoryService;
@@ -65,29 +53,6 @@ class MemberServiceTest extends ServiceTest {
         // when & then
         assertThat(memberService.findById(파랑_id).getId())
                 .isEqualTo(파랑_id);
-    }
-
-    @DisplayName("구독 id를 기반으로 member 정보를 조회한다.")
-    @Test
-    void 구독_id를_기반으로_member_정보를_조회한다() {
-        // given
-        Long 매트_id = toMemberId(매트.getOAuthMember());
-        Member 매트 = memberRepository.getById(매트_id);
-
-        Category BE_일정 = categoryRepository.save(BE_일정(매트));
-        Subscription 색상_1_BE_일정_구독 = subscriptionRepository.save(SubscriptionFixtures.색상1_구독(매트, BE_일정));
-
-        // when
-        MemberResponse actual = memberService.findBySubscriptionId(색상_1_BE_일정_구독.getId());
-
-        // then
-        assertAll(() -> {
-            assertThat(actual.getId()).isEqualTo(매트.getId());
-            assertThat(actual.getEmail()).isEqualTo(매트.getEmail());
-            assertThat(actual.getDisplayName()).isEqualTo(매트.getDisplayName());
-            assertThat(actual.getProfileImageUrl()).isEqualTo(매트.getProfileImageUrl());
-            assertThat(actual.getSocialType()).isEqualTo(매트.getSocialType());
-        });
     }
 
     @DisplayName("회원의 이름을 수정한다.")

--- a/backend/src/test/java/com/allog/dallog/domain/subscription/application/SubscriptionServiceTest.java
+++ b/backend/src/test/java/com/allog/dallog/domain/subscription/application/SubscriptionServiceTest.java
@@ -30,12 +30,13 @@ import com.allog.dallog.domain.categoryrole.exception.NoSuchCategoryRoleExceptio
 import com.allog.dallog.domain.member.domain.Member;
 import com.allog.dallog.domain.member.domain.MemberRepository;
 import com.allog.dallog.domain.subscription.domain.Color;
+import com.allog.dallog.domain.subscription.domain.Subscription;
+import com.allog.dallog.domain.subscription.domain.SubscriptionRepository;
 import com.allog.dallog.domain.subscription.dto.request.SubscriptionUpdateRequest;
 import com.allog.dallog.domain.subscription.dto.response.SubscriptionResponse;
 import com.allog.dallog.domain.subscription.dto.response.SubscriptionsResponse;
 import com.allog.dallog.domain.subscription.exception.ExistSubscriptionException;
 import com.allog.dallog.domain.subscription.exception.InvalidSubscriptionException;
-import com.allog.dallog.domain.subscription.exception.NoSuchSubscriptionException;
 import com.allog.dallog.domain.subscription.exception.NotAbleToUnsubscribeException;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -52,6 +53,9 @@ class SubscriptionServiceTest extends ServiceTest {
 
     @Autowired
     private SubscriptionService subscriptionService;
+
+    @Autowired
+    private SubscriptionRepository subscriptionRepository;
 
     @Autowired
     private CategoryRepository categoryRepository;
@@ -116,21 +120,13 @@ class SubscriptionServiceTest extends ServiceTest {
         SubscriptionResponse 빨간색_구독 = subscriptionService.save(리버_id, BE_일정.getId());
 
         // when
-        SubscriptionResponse foundResponse = subscriptionService.findById(빨간색_구독.getId());
+        Subscription subscription = subscriptionRepository.getById(빨간색_구독.getId());
 
         // then
         assertAll(() -> {
-            assertThat(foundResponse.getId()).isEqualTo(빨간색_구독.getId());
-            assertThat(foundResponse.getCategory().getId()).isEqualTo(BE_일정.getId());
+            assertThat(subscription.getId()).isEqualTo(빨간색_구독.getId());
+            assertThat(subscription.getCategory().getId()).isEqualTo(BE_일정.getId());
         });
-    }
-
-    @DisplayName("존재하지 않는 구독 정보인 경우 예외를 던진다.")
-    @Test
-    void 존재하지_않는_구독_정보인_경우_예외를_던진다() {
-        // given & when & then
-        assertThatThrownBy(() -> subscriptionService.findById(0L))
-                .isInstanceOf(NoSuchSubscriptionException.class);
     }
 
     @DisplayName("회원 정보를 기반으로 구독 정보를 조회한다.")
@@ -171,7 +167,7 @@ class SubscriptionServiceTest extends ServiceTest {
         subscriptionService.save(후디_id, BE_일정.getId());
 
         // when
-        List<SubscriptionResponse> actual = subscriptionService.findByCategoryId(BE_일정.getId());
+        List<Subscription> actual = subscriptionRepository.findByCategoryId(BE_일정.getId());
 
         // then
         assertThat(actual).hasSize(4);

--- a/backend/src/test/java/com/allog/dallog/presentation/CategoryControllerTest.java
+++ b/backend/src/test/java/com/allog/dallog/presentation/CategoryControllerTest.java
@@ -55,11 +55,10 @@ import com.allog.dallog.domain.categoryrole.domain.CategoryAuthority;
 import com.allog.dallog.domain.categoryrole.domain.CategoryRole;
 import com.allog.dallog.domain.categoryrole.domain.CategoryRoleType;
 import com.allog.dallog.domain.categoryrole.dto.request.CategoryRoleUpdateRequest;
+import com.allog.dallog.domain.categoryrole.dto.response.SubscribersResponse;
 import com.allog.dallog.domain.categoryrole.exception.NoCategoryAuthorityException;
 import com.allog.dallog.domain.categoryrole.exception.NoSuchCategoryRoleException;
 import com.allog.dallog.domain.categoryrole.exception.NotAbleToChangeRoleException;
-import com.allog.dallog.domain.member.application.MemberService;
-import com.allog.dallog.domain.member.dto.response.SubscribersResponse;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -84,9 +83,6 @@ class CategoryControllerTest extends ControllerTest {
 
     @MockBean
     private CategoryRoleService categoryRoleService;
-
-    @MockBean
-    private MemberService memberService;
 
     @DisplayName("카테고리를 생성한다.")
     @Test
@@ -594,7 +590,7 @@ class CategoryControllerTest extends ControllerTest {
                 new CategoryRole(카테고리, 후디(), NONE)
         );
 
-        given(memberService.findSubscribers(any(), any())).willReturn(new SubscribersResponse(categoryRoles));
+        given(categoryRoleService.findSubscribers(any(), any())).willReturn(new SubscribersResponse(categoryRoles));
 
         // when & then
         mockMvc.perform(RestDocumentationRequestBuilders.get("/api/categories/{categoryId}/subscribers", categoryId)
@@ -620,7 +616,7 @@ class CategoryControllerTest extends ControllerTest {
         // given
         long categoryId = 10;
 
-        given(memberService.findSubscribers(any(), any()))
+        given(categoryRoleService.findSubscribers(any(), any()))
                 .willThrow(new NoCategoryAuthorityException("카테고리 구독자 조회 권한이 없습니다."));
 
         // when & then


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 💻 git rebase를 사용했나요?
- [x] 🌈 알록달록한가요?

## 작업 내용

- MemberService의 findSubscriber 메서드를 categoryRole 쪽으로 이동
- AuthService에서 멤버 가입 시 이벤트를 발행하는 것으로 다른 도메인에 대한 의존성 제거

## 주의사항

[Could not autowire. No beans of type found. error 해결](https://shlee0882.tistory.com/288)
`AuthServiceTest`에서 `events` 필드에 자동주입할 수 없다는 error가 발생합니다. 하지만 실제로는 잘 동작합니다...
이유는 위 링크와 같다는데 굳이 인텔리제이 에러 때문에 componentscan을 붙여줘야하나 싶어서 무시했습니다. 의견 주세여.

## 고민!!

https://github.com/woowacourse-teams/2022-dallog/issues/902#issuecomment-1304604061

이벤트 테스트에 대한 고민이 있습니다. 이슈에서 함께 이야기해 보시죠.

Closes #902 
