### PR TITLE
[feat] 외부 캘린더 요청 API 결과를 캐싱하여 성능을 최적화한다. 

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -27,7 +27,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
-
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
+    
     runtimeOnly 'mysql:mysql-connector-java'
     runtimeOnly 'com.h2database:h2'
 

--- a/backend/src/main/java/com/allog/dallog/global/config/cache/CacheConfig.java
+++ b/backend/src/main/java/com/allog/dallog/global/config/cache/CacheConfig.java
@@ -12,7 +12,7 @@ import org.springframework.context.annotation.Configuration;
 public class CacheConfig {
 
     public static final String GOOGLE_CALENDAR = "googleCalendar";
-    private static final long EXPIRE_AFTER = 60 * 15;
+    private static final long EXPIRE_AFTER = 60 * 60 * 3;
 
     @Bean
     public CacheManager cacheManager() {

--- a/backend/src/main/java/com/allog/dallog/global/config/cache/CacheConfig.java
+++ b/backend/src/main/java/com/allog/dallog/global/config/cache/CacheConfig.java
@@ -1,0 +1,23 @@
+package com.allog.dallog.global.config.cache;
+
+import java.util.List;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.support.SimpleCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableCaching
+public class CacheConfig {
+
+    private static final long EXPIRE_AFTER = 60 * 15;
+
+    @Bean
+    public CacheManager cacheManager() {
+        SimpleCacheManager simpleCacheManager = new SimpleCacheManager();
+        simpleCacheManager.setCaches(List.of(new ExpiringConcurrentMapCache("googleCalendar", EXPIRE_AFTER)));
+
+        return simpleCacheManager;
+    }
+}

--- a/backend/src/main/java/com/allog/dallog/global/config/cache/CacheConfig.java
+++ b/backend/src/main/java/com/allog/dallog/global/config/cache/CacheConfig.java
@@ -6,9 +6,12 @@ import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.cache.support.SimpleCacheManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
 
 @Configuration
 @EnableCaching
+@EnableScheduling
 public class CacheConfig {
 
     public static final String GOOGLE_CALENDAR = "googleCalendar";
@@ -20,5 +23,11 @@ public class CacheConfig {
         simpleCacheManager.setCaches(List.of(new ExpiringConcurrentMapCache(GOOGLE_CALENDAR, EXPIRE_AFTER)));
 
         return simpleCacheManager;
+    }
+
+    @Scheduled(cron = "0 0 0 * * *")
+    private void evict() {
+        ExpiringConcurrentMapCache cache = (ExpiringConcurrentMapCache) cacheManager().getCache(GOOGLE_CALENDAR);
+        cache.evictAllExpired();
     }
 }

--- a/backend/src/main/java/com/allog/dallog/global/config/cache/CacheConfig.java
+++ b/backend/src/main/java/com/allog/dallog/global/config/cache/CacheConfig.java
@@ -11,12 +11,13 @@ import org.springframework.context.annotation.Configuration;
 @EnableCaching
 public class CacheConfig {
 
+    public static final String GOOGLE_CALENDAR = "googleCalendar";
     private static final long EXPIRE_AFTER = 60 * 15;
 
     @Bean
     public CacheManager cacheManager() {
         SimpleCacheManager simpleCacheManager = new SimpleCacheManager();
-        simpleCacheManager.setCaches(List.of(new ExpiringConcurrentMapCache("googleCalendar", EXPIRE_AFTER)));
+        simpleCacheManager.setCaches(List.of(new ExpiringConcurrentMapCache(GOOGLE_CALENDAR, EXPIRE_AFTER)));
 
         return simpleCacheManager;
     }

--- a/backend/src/main/java/com/allog/dallog/global/config/cache/ExpiringConcurrentMapCache.java
+++ b/backend/src/main/java/com/allog/dallog/global/config/cache/ExpiringConcurrentMapCache.java
@@ -1,0 +1,38 @@
+package com.allog.dallog.global.config.cache;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import org.springframework.cache.concurrent.ConcurrentMapCache;
+
+public class ExpiringConcurrentMapCache extends ConcurrentMapCache {
+
+    private final Map<Object, LocalDateTime> expires = new HashMap<>();
+    private final long expireAfter;
+
+    public ExpiringConcurrentMapCache(final String name, final long expireAfter) {
+        super(name);
+
+        this.expireAfter = expireAfter;
+    }
+
+    @Override
+    protected Object lookup(final Object key) {
+        LocalDateTime expiredDate = expires.get(key);
+        if (Objects.isNull(expiredDate) || LocalDateTime.now().isBefore(expiredDate)) {
+            return super.lookup(key);
+        }
+
+        expires.remove(key);
+        return null;
+    }
+
+    @Override
+    public void put(final Object key, final Object value) {
+        LocalDateTime expiredAt = LocalDateTime.now().plusSeconds(expireAfter);
+        expires.put(key, expiredAt);
+
+        super.put(key, value);
+    }
+}

--- a/backend/src/main/java/com/allog/dallog/global/config/cache/ExpiringConcurrentMapCache.java
+++ b/backend/src/main/java/com/allog/dallog/global/config/cache/ExpiringConcurrentMapCache.java
@@ -1,14 +1,14 @@
 package com.allog.dallog.global.config.cache;
 
 import java.time.LocalDateTime;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
 import org.springframework.cache.concurrent.ConcurrentMapCache;
 
 public class ExpiringConcurrentMapCache extends ConcurrentMapCache {
 
-    private final Map<Object, LocalDateTime> expires = new HashMap<>();
+    private final Map<Object, LocalDateTime> expires = new ConcurrentHashMap<>();
     private final long expireAfter;
 
     public ExpiringConcurrentMapCache(final String name, final long expireAfter) {

--- a/backend/src/main/java/com/allog/dallog/global/config/cache/ExpiringConcurrentMapCache.java
+++ b/backend/src/main/java/com/allog/dallog/global/config/cache/ExpiringConcurrentMapCache.java
@@ -25,6 +25,7 @@ public class ExpiringConcurrentMapCache extends ConcurrentMapCache {
         }
 
         expires.remove(key);
+        super.evict(key);
         return null;
     }
 

--- a/backend/src/main/java/com/allog/dallog/infrastructure/oauth/client/GoogleExternalCalendarClient.java
+++ b/backend/src/main/java/com/allog/dallog/infrastructure/oauth/client/GoogleExternalCalendarClient.java
@@ -3,6 +3,7 @@ package com.allog.dallog.infrastructure.oauth.client;
 import com.allog.dallog.domain.externalcalendar.application.ExternalCalendarClient;
 import com.allog.dallog.domain.externalcalendar.dto.ExternalCalendar;
 import com.allog.dallog.domain.schedule.domain.IntegrationSchedule;
+import com.allog.dallog.global.config.cache.CacheConfig;
 import com.allog.dallog.infrastructure.oauth.dto.GoogleCalendarEventsResponse;
 import com.allog.dallog.infrastructure.oauth.dto.GoogleCalendarListResponse;
 import com.allog.dallog.infrastructure.oauth.exception.OAuthException;
@@ -57,7 +58,7 @@ public class GoogleExternalCalendarClient implements ExternalCalendarClient {
     }
 
     @Override
-    @Cacheable(value = "googleCalendar", key = "#internalCategoryId+#externalCalendarId+#startDateTime+#endDateTime")
+    @Cacheable(value = CacheConfig.GOOGLE_CALENDAR, key = "#internalCategoryId+#externalCalendarId+#startDateTime+#endDateTime")
     public List<IntegrationSchedule> getExternalCalendarSchedules(final String accessToken,
                                                                   final Long internalCategoryId,
                                                                   final String externalCalendarId,

--- a/backend/src/main/java/com/allog/dallog/infrastructure/oauth/client/GoogleExternalCalendarClient.java
+++ b/backend/src/main/java/com/allog/dallog/infrastructure/oauth/client/GoogleExternalCalendarClient.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
@@ -56,6 +57,7 @@ public class GoogleExternalCalendarClient implements ExternalCalendarClient {
     }
 
     @Override
+    @Cacheable(value = "googleCalendar", key = "#internalCategoryId+#externalCalendarId+#startDateTime+#endDateTime")
     public List<IntegrationSchedule> getExternalCalendarSchedules(final String accessToken,
                                                                   final Long internalCategoryId,
                                                                   final String externalCalendarId,


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 💻 git rebase를 사용했나요?
- [x] 🌈 알록달록한가요?

## 작업 내용

`GoogleExternalCalendarClient` 의 `getExternalCalendarSchedules()` 메소드에서 구글 캘린더의 API (외부 API) 를 직접 호출합니다. 이 메소드에 캐시를 적용하여 성능을 개선하였습니다.

### 캐시 만료 정책

캐시 만료 정책에 대해 고민했는데, 일단 15분으로 설정하였습니다. 구글 캘린더는 저희가 통제하고 있는 데이터베이스 같은것이 아니다 보니까 실제 구글 캘린더 일정이 변경되었는지, 변경되지 않았는지는 실제 요청을 하지 않는 이상 알 수가 없어요. 따라서 만료 기한을 너무 길게 잡아두면 유저가 최신 구글 캘린더 정보를 볼 수 없습니다. 그렇다고 너무 짧게 만료 기한을 잡아버리면 너무 자주 캐시 미스가 발생해서 성능이 저하될 수 있어요. 적절한 기한이 필요했습니다.

15분으로 설정한 이유는 다음과 같습니다. 우선 달력 도메인 특성상 유저가 매우 오래 머물며 활동하지 않습니다. 일정을 확인하거나 등록하기 위해 잠깐 방문하는 것이 대부분입니다. 다만 일정을 확인하기 위해 접속 빈도는 높겠죠. 한번 접속하고 일정을 확인하고 관리하고 이탈하는데 시간을 15분가량으로 어림잡았습니다. 정확한 유저 행동 분석은 나중에 [Hotjar](https://www.hotjar.com/) 같은 분석 도구를 사용하면 좋을 것 같습니다.

### ConcurrentMapCache를 상속하여 직접 캐시 구현

제목은 거창한데 별거는 아닙니다. 스프링은 `ConcurrentHashMap` 을 사용한 `ConcurrentMapCache` 라는 캐시 구현체를 기본으로 제공합니다. 이 친구는 별도 설정없어도 바로 사용할 수 있는 장점이 있는데, 기능이 매우 빈약합니다. 특히 TTL (time-to-live) 를 설정할 수 없어요. 캐시된 데이터의 만료 기한을 설정할 수 없고, 한번 캐시된 데이터를 지우려면 스케줄링을 돌려서 일괄 삭제해야합니다. 

모든 유저에게 동일하게 보이는 데이터에 대해서는 이렇게 일정 주기로 전체 캐시를 지우는 만료 정책을 설정해도 괜찮습니다. 그런데 저희가 캐시하려고 하는 데이터는 각 유저별 고유한 데이터입니다. 일정 주기로 일괄삭제할 수 없어요. 따라서 캐시가 개별적인 만료 기한을 가져야합니다. 이런 기능을 사용하려면 `EhCache` 나 `CaffeinCache` 같은 서드파티 로컬 캐시 구현체를 사용하거나 `Redis` 같은 캐시를 별도로 사용해야합니다. 그런데, 겨우 TTL 기능 하나 때문에 라이브러리를 사용하고 싶지는 않았습니다. 

따라서 `ConcurrentMapCache` 를 상속받은 `ExpiringConcurrentMapCache` 라는 구현체를 직접 만들었습니다. 별거는 아니고, 데이터가 캐시에 등록되면 캐시 키와 `LocalDateTime.now()` 쌍을 별도의 해시맵에 저장합니다. 그리고 해당 캐시 데이터가 조회될 때 마다 저장된 LocalDateTime과 현재 시각을 비교하여 만료 여부를 판단합니다. 말이 좀 복잡한데 코드로 보시면 바로 아실거예요.
 
### 성능 개선

성능 개선 정도를 확인하기 위해 Jmeter를 사용하여 실제 API의 평균 응답 시간을 분석했습니다. 실제 구글 캘린더 API를 호출해야 의미가 있으므로 요청과 요청간 간격은 1초정도로 설정해서 부하가 없게끔 설정했습니다. 1초 간격으로 100번의 요청을 보내 평균 응답 시간을 냈습니다.

구글 캘린더는 1개만 연동해놓았습니다. 

#### 캐시 적용 전

![](https://user-images.githubusercontent.com/11745691/201038685-c30e1958-48a5-43c7-a603-8f626823c9c6.png)

캐시를 적용하지 않은 상태에서는 `734ms` 의 응답 시간을 보였습니다. 꽤나 느립니다. 구글 캘린더가 1개만 연동되어 있는 상황이므로 2개 연동하면 약 2배, 3개 연동하면 약 3배로 늘어날 것입니다. 굉장히 좋지 않은 사용자 경험이겠죠?

#### 캐시 적용 후

![](https://user-images.githubusercontent.com/11745691/201039298-12ecbafb-8229-4484-bb26-475d8c014aa2.png)

최초에 캐시 미스가 발생해서 실제 API를 호출하는 요청에 대한 응답 시간은 제외하고, 캐시된 이후의 평균 응답시간만 측정했습니다. `156ms` 정도가 나옵니다. 캘린더 1개 연동 기준 약 4.7배 성능이 개선되었습니다.

## 스크린샷

## 주의사항

Closes #910 
