### PR TITLE
[refactor] ServiceTest의 중첩클래스를 제거한다.

### DIFF
--- a/backend/src/test/java/com/allog/dallog/acceptance/AcceptanceTest.java
+++ b/backend/src/test/java/com/allog/dallog/acceptance/AcceptanceTest.java
@@ -1,8 +1,8 @@
 package com.allog.dallog.acceptance;
 
+import com.allog.dallog.auth.domain.TokenRepository;
 import com.allog.dallog.common.DatabaseCleaner;
 import com.allog.dallog.common.config.ExternalApiConfig;
-import com.allog.dallog.auth.domain.TokenRepository;
 import io.restassured.RestAssured;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/backend/src/test/java/com/allog/dallog/acceptance/AuthAcceptanceTest.java
+++ b/backend/src/test/java/com/allog/dallog/acceptance/AuthAcceptanceTest.java
@@ -12,11 +12,11 @@ import static com.allog.dallog.common.fixtures.AuthFixtures.STUB_MEMBER_인증_�
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
-import com.allog.dallog.common.config.TokenConfig;
 import com.allog.dallog.auth.dto.request.TokenRenewalRequest;
 import com.allog.dallog.auth.dto.response.AccessAndRefreshTokenResponse;
 import com.allog.dallog.auth.dto.response.AccessTokenResponse;
 import com.allog.dallog.auth.dto.response.OAuthUriResponse;
+import com.allog.dallog.common.config.TokenConfig;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import org.junit.jupiter.api.DisplayName;

--- a/backend/src/test/java/com/allog/dallog/acceptance/CategoryAcceptanceTest.java
+++ b/backend/src/test/java/com/allog/dallog/acceptance/CategoryAcceptanceTest.java
@@ -13,6 +13,7 @@ import static com.allog.dallog.acceptance.fixtures.CommonAcceptanceFixtures.상�
 import static com.allog.dallog.acceptance.fixtures.CommonAcceptanceFixtures.상태코드_204가_반환된다;
 import static com.allog.dallog.acceptance.fixtures.MemberAcceptanceFixtures.자신의_정보를_조회한다;
 import static com.allog.dallog.acceptance.fixtures.SubscriptionAcceptanceFixtures.카테고리를_구독한다;
+import static com.allog.dallog.categoryrole.domain.CategoryRoleType.ADMIN;
 import static com.allog.dallog.common.fixtures.AuthFixtures.GOOGLE_PROVIDER;
 import static com.allog.dallog.common.fixtures.AuthFixtures.STUB_MEMBER_인증_코드;
 import static com.allog.dallog.common.fixtures.CategoryFixtures.BE_일정_생성_요청;
@@ -21,15 +22,14 @@ import static com.allog.dallog.common.fixtures.CategoryFixtures.공통_일정_�
 import static com.allog.dallog.common.fixtures.CategoryFixtures.내_일정_생성_요청;
 import static com.allog.dallog.common.fixtures.CategoryFixtures.매트_아고라_생성_요청;
 import static com.allog.dallog.common.fixtures.CategoryFixtures.후디_JPA_스터디_생성_요청;
-import static com.allog.dallog.categoryrole.domain.CategoryRoleType.ADMIN;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
-import com.allog.dallog.common.fixtures.OAuthFixtures;
 import com.allog.dallog.category.dto.response.CategoriesResponse;
 import com.allog.dallog.category.dto.response.CategoryDetailResponse;
 import com.allog.dallog.category.dto.response.CategoryResponse;
 import com.allog.dallog.categoryrole.dto.request.CategoryRoleUpdateRequest;
+import com.allog.dallog.common.fixtures.OAuthFixtures;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import org.junit.jupiter.api.DisplayName;

--- a/backend/src/test/java/com/allog/dallog/acceptance/ScheduleAcceptanceTest.java
+++ b/backend/src/test/java/com/allog/dallog/acceptance/ScheduleAcceptanceTest.java
@@ -31,8 +31,8 @@ import static com.allog.dallog.common.fixtures.ScheduleFixtures.종일_두번째
 import static com.allog.dallog.common.fixtures.ScheduleFixtures.종일_세번째_일정;
 import static com.allog.dallog.common.fixtures.ScheduleFixtures.종일_첫번째_일정;
 
-import com.allog.dallog.common.fixtures.OAuthFixtures;
 import com.allog.dallog.category.dto.response.CategoryResponse;
+import com.allog.dallog.common.fixtures.OAuthFixtures;
 import com.allog.dallog.schedule.dto.request.ScheduleUpdateRequest;
 import com.allog.dallog.schedule.dto.response.ScheduleResponse;
 import io.restassured.response.ExtractableResponse;

--- a/backend/src/test/java/com/allog/dallog/auth/presentation/AuthControllerTest.java
+++ b/backend/src/test/java/com/allog/dallog/auth/presentation/AuthControllerTest.java
@@ -25,7 +25,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.allog.dallog.auth.exception.InvalidTokenException;
-import com.allog.dallog.common.ControllerTest;
+import com.allog.dallog.common.annotation.ControllerTest;
 import com.allog.dallog.infrastructure.oauth.exception.OAuthException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/backend/src/test/java/com/allog/dallog/category/application/CategoryServiceTest.java
+++ b/backend/src/test/java/com/allog/dallog/category/application/CategoryServiceTest.java
@@ -4,11 +4,7 @@ import static com.allog.dallog.category.domain.CategoryType.GOOGLE;
 import static com.allog.dallog.category.domain.CategoryType.NORMAL;
 import static com.allog.dallog.category.domain.CategoryType.PERSONAL;
 import static com.allog.dallog.categoryrole.domain.CategoryRoleType.ADMIN;
-import static com.allog.dallog.categoryrole.domain.CategoryRoleType.NONE;
 import static com.allog.dallog.common.Constants.개인_카테고리_이름;
-import static com.allog.dallog.common.Constants.나인_이름;
-import static com.allog.dallog.common.Constants.나인_이메일;
-import static com.allog.dallog.common.Constants.나인_프로필_URL;
 import static com.allog.dallog.common.Constants.스터디_카테고리_이름;
 import static com.allog.dallog.common.Constants.외부_카테고리_ID;
 import static com.allog.dallog.common.Constants.외부_카테고리_이름;
@@ -17,11 +13,7 @@ import static com.allog.dallog.common.Constants.취업_일정_시작일;
 import static com.allog.dallog.common.Constants.취업_일정_제목;
 import static com.allog.dallog.common.Constants.취업_일정_종료일;
 import static com.allog.dallog.common.Constants.취업_카테고리_이름;
-import static com.allog.dallog.common.Constants.티거_이름;
-import static com.allog.dallog.common.Constants.티거_이메일;
-import static com.allog.dallog.common.Constants.티거_프로필_URL;
 import static com.allog.dallog.common.fixtures.CategoryFixtures.BE_일정_생성_요청;
-import static com.allog.dallog.subscription.domain.Color.COLOR_1;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -44,16 +36,13 @@ import com.allog.dallog.categoryrole.domain.CategoryRoleRepository;
 import com.allog.dallog.categoryrole.exception.ManagingCategoryLimitExcessException;
 import com.allog.dallog.categoryrole.exception.NoCategoryAuthorityException;
 import com.allog.dallog.common.annotation.ServiceTest;
-import com.allog.dallog.member.domain.Member;
+import com.allog.dallog.common.builder.GivenBuilder;
 import com.allog.dallog.member.domain.MemberRepository;
-import com.allog.dallog.member.domain.SocialType;
-import com.allog.dallog.schedule.domain.Schedule;
 import com.allog.dallog.schedule.domain.ScheduleRepository;
 import com.allog.dallog.schedule.exception.NoSuchScheduleException;
 import com.allog.dallog.subscription.domain.Subscription;
 import com.allog.dallog.subscription.domain.SubscriptionRepository;
 import com.allog.dallog.subscription.exception.NoSuchSubscriptionException;
-import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -89,7 +78,7 @@ class CategoryServiceTest extends ServiceTest {
     @Test
     void 카테고리를_생성한다() {
         // given
-        GivenBuilder 나인 = 나인().회원_가입을_한다(나인_이메일, 나인_이름, 나인_프로필_URL);
+        GivenBuilder 나인 = 나인();
 
         // when
         CategoryResponse actual = categoryService.save(나인.회원().getId(), 취업_카테고리_생성_요청);
@@ -101,7 +90,7 @@ class CategoryServiceTest extends ServiceTest {
     @Test
     void 개인_카테고리를_생성한다() {
         // given
-        GivenBuilder 나인 = 나인().회원_가입을_한다(나인_이메일, 나인_이름, 나인_프로필_URL);
+        GivenBuilder 나인 = 나인();
 
         // when
         CategoryResponse 개인_카테고리_응답 = categoryService.save(나인.회원().getId(), 개인_카테고리_생성_요청);
@@ -118,7 +107,7 @@ class CategoryServiceTest extends ServiceTest {
     @Test
     void 카테고리를_생성할_때_자동으로_구독한다() {
         // given
-        GivenBuilder 나인 = 나인().회원_가입을_한다(나인_이메일, 나인_이름, 나인_프로필_URL);
+        GivenBuilder 나인 = 나인();
 
         // when
         categoryService.save(나인.회원().getId(), 취업_카테고리_생성_요청);
@@ -132,7 +121,7 @@ class CategoryServiceTest extends ServiceTest {
     @Test
     void 카테고리를_생성할_때_권한을_최고_관리자로_생성한다() {
         // given
-        GivenBuilder 나인 = 나인().회원_가입을_한다(나인_이메일, 나인_이름, 나인_프로필_URL);
+        GivenBuilder 나인 = 나인();
 
         // when
         CategoryResponse 응답 = categoryService.save(나인.회원().getId(), 취업_카테고리_생성_요청);
@@ -146,7 +135,7 @@ class CategoryServiceTest extends ServiceTest {
     @ValueSource(strings = {"", "일이삼사오육칠팔구십일이삼사오육칠팔구십일", "알록달록 알록달록 알록달록 알록달록 알록달록 알록달록 카테고리"})
     void 카테고리를_생성할_때_이름이_공백이거나_길이가_20을_초과하면_예외가_발생한다(final String invalidName) {
         // given
-        GivenBuilder 나인 = 나인().회원_가입을_한다(나인_이메일, 나인_이름, 나인_프로필_URL);
+        GivenBuilder 나인 = 나인();
 
         CategoryCreateRequest 카테고리_생성_요청 = new CategoryCreateRequest(invalidName, NORMAL);
 
@@ -158,7 +147,7 @@ class CategoryServiceTest extends ServiceTest {
     @Test
     void 외부_카테고리를_생성한다() {
         // given
-        GivenBuilder 나인 = 나인().회원_가입을_한다(나인_이메일, 나인_이름, 나인_프로필_URL);
+        GivenBuilder 나인 = 나인();
 
         // when
         CategoryResponse 응답 = categoryService.save(나인.회원().getId(), 외부_카테고리_생성_요청);
@@ -174,7 +163,7 @@ class CategoryServiceTest extends ServiceTest {
     @Test
     void 중복되는_외부_카테고리를_생성하면_예외가_발생한다() {
         // given
-        GivenBuilder 나인 = 나인().회원_가입을_한다(나인_이메일, 나인_이름, 나인_프로필_URL);
+        GivenBuilder 나인 = 나인();
 
         categoryService.save(나인.회원().getId(), 외부_카테고리_생성_요청);
 
@@ -186,7 +175,7 @@ class CategoryServiceTest extends ServiceTest {
     @Test
     void 외부_카테고리를_생성할_때_자동으로_구독한다() {
         // given
-        GivenBuilder 나인 = 나인().회원_가입을_한다(나인_이메일, 나인_이름, 나인_프로필_URL);
+        GivenBuilder 나인 = 나인();
 
         // when
         categoryService.save(나인.회원().getId(), 외부_카테고리_생성_요청);
@@ -199,7 +188,7 @@ class CategoryServiceTest extends ServiceTest {
     @Test
     void 저장된_회원의_개인_카테고리를_생성하고_자동으로_구독하고_카테고리_역할을_부여한다() {
         // given
-        GivenBuilder 나인 = 나인().회원_가입을_한다(나인_이메일, 나인_이름, 나인_프로필_URL);
+        GivenBuilder 나인 = 나인();
 
         MemberSavedEvent event = new MemberSavedEvent(나인.회원().getId());
 
@@ -227,8 +216,7 @@ class CategoryServiceTest extends ServiceTest {
     @Test
     void 제목에_검색어가_포함된_카테고리를_가져온다() {
         // given
-        나인().회원_가입을_한다(나인_이메일, 나인_이름, 나인_프로필_URL)
-                .카테고리를_생성한다(외부_카테고리_이름, GOOGLE)
+        나인().카테고리를_생성한다(외부_카테고리_이름, GOOGLE)
                 .카테고리를_생성한다(취업_카테고리_이름, NORMAL)
                 .카테고리를_생성한다(스터디_카테고리_이름, NORMAL);
 
@@ -242,8 +230,7 @@ class CategoryServiceTest extends ServiceTest {
     @Test
     void 제목에_검색어가_포함된_카테고리를_가져올때_개인_카테고리는_제외한다() {
         // given
-        나인().회원_가입을_한다(나인_이메일, 나인_이름, 나인_프로필_URL)
-                .카테고리를_생성한다(개인_카테고리_이름, PERSONAL)
+        나인().카테고리를_생성한다(개인_카테고리_이름, PERSONAL)
                 .카테고리를_생성한다(취업_카테고리_이름, NORMAL)
                 .카테고리를_생성한다(스터디_카테고리_이름, NORMAL);
 
@@ -258,15 +245,13 @@ class CategoryServiceTest extends ServiceTest {
     @Test
     void 관리권한이_최고_관리자인_카테고리_목록을_조회한다() {
         // given
-        GivenBuilder 나인 = 나인().회원_가입을_한다(나인_이메일, 나인_이름, 나인_프로필_URL)
-                .카테고리를_생성한다(스터디_카테고리_이름, NORMAL);
+        GivenBuilder 나인 = 나인().카테고리를_생성한다(스터디_카테고리_이름, NORMAL);
 
-        GivenBuilder 티거 = 티거().회원_가입을_한다(티거_이메일, 티거_이름, 티거_프로필_URL)
-                .카테고리를_생성한다(스터디_카테고리_이름, NORMAL)
+        GivenBuilder 티거 = 티거().카테고리를_생성한다(스터디_카테고리_이름, NORMAL)
                 .카테고리를_생성한다(취업_카테고리_이름, NORMAL)
                 .카테고리를_구독한다(나인.카테고리());
 
-        나인.내_카테고리에_대한_관리_권한을_부여한다(티거.회원());
+        나인.카테고리_관리_권한을_부여한다(티거.회원(), 나인.카테고리());
 
         // when
         CategoriesResponse actual = categoryService.findScheduleEditableCategories(티거.회원().getId());
@@ -278,8 +263,7 @@ class CategoryServiceTest extends ServiceTest {
     @Test
     void id로_카테고리_단건_조회한다() {
         // given
-        GivenBuilder 나인 = 나인().회원_가입을_한다(나인_이메일, 나인_이름, 나인_프로필_URL)
-                .카테고리를_생성한다(취업_카테고리_이름, NORMAL);
+        GivenBuilder 나인 = 나인().카테고리를_생성한다(취업_카테고리_이름, NORMAL);
 
         // when
         CategoryDetailResponse actual = categoryService.findDetailCategoryById(나인.카테고리().getId());
@@ -294,8 +278,7 @@ class CategoryServiceTest extends ServiceTest {
     @Test
     void id로_카테고리_단건_조회할_때_없으면_예외가_발생한다() {
         // given
-        GivenBuilder 나인 = 나인().회원_가입을_한다(나인_이메일, 나인_이름, 나인_프로필_URL)
-                .카테고리를_생성한다(취업_카테고리_이름, NORMAL);
+        GivenBuilder 나인 = 나인().카테고리를_생성한다(취업_카테고리_이름, NORMAL);
 
         // when & then
         assertThatThrownBy(() -> categoryService.findDetailCategoryById(나인.카테고리().getId() + 1))
@@ -305,8 +288,7 @@ class CategoryServiceTest extends ServiceTest {
     @Test
     void 권한이_최고_관리자인_카테고리를_수정한다() {
         // given
-        GivenBuilder 나인 = 나인().회원_가입을_한다(나인_이메일, 나인_이름, 나인_프로필_URL)
-                .카테고리를_생성한다(취업_카테고리_이름, NORMAL);
+        GivenBuilder 나인 = 나인().카테고리를_생성한다(취업_카테고리_이름, NORMAL);
 
         CategoryUpdateRequest 카테고리_수정_요청 = new CategoryUpdateRequest("새로운 취업 카테고리 이름");
 
@@ -321,11 +303,9 @@ class CategoryServiceTest extends ServiceTest {
     @Test
     void 권한이_최고_관리자가_아닌_카테고리를_수정하면_예외가_발생한다() {
         // given
-        GivenBuilder 나인 = 나인().회원_가입을_한다(나인_이메일, 나인_이름, 나인_프로필_URL)
-                .카테고리를_생성한다(취업_카테고리_이름, NORMAL);
+        GivenBuilder 나인 = 나인().카테고리를_생성한다(취업_카테고리_이름, NORMAL);
 
-        GivenBuilder 티거 = 티거().회원_가입을_한다(티거_이메일, 티거_이름, 티거_프로필_URL)
-                .카테고리를_구독한다(나인.카테고리());
+        GivenBuilder 티거 = 티거().카테고리를_구독한다(나인.카테고리());
 
         CategoryUpdateRequest 카테고리_수정_요청 = new CategoryUpdateRequest("새로운 취업 카테고리 이름");
 
@@ -337,7 +317,7 @@ class CategoryServiceTest extends ServiceTest {
     @Test
     void 카테고리를_수정할_때_카테고리가_없으면_예외가_발생한다() {
         // given
-        GivenBuilder 나인 = 나인().회원_가입을_한다(나인_이메일, 나인_이름, 나인_프로필_URL);
+        GivenBuilder 나인 = 나인();
 
         CategoryUpdateRequest 카테고리_수정_요청 = new CategoryUpdateRequest("새로운 취업 카테고리 이름");
 
@@ -349,8 +329,7 @@ class CategoryServiceTest extends ServiceTest {
     @Test
     void 권한이_최고_관리자인_카테고리를_삭제한다() {
         // given
-        GivenBuilder 나인 = 나인().회원_가입을_한다(나인_이메일, 나인_이름, 나인_프로필_URL)
-                .카테고리를_생성한다(취업_카테고리_이름, NORMAL);
+        GivenBuilder 나인 = 나인().카테고리를_생성한다(취업_카테고리_이름, NORMAL);
 
         // when
         categoryService.delete(나인.회원().getId(), 나인.카테고리().getId());
@@ -363,11 +342,9 @@ class CategoryServiceTest extends ServiceTest {
     @Test
     void 권한이_최고_관리자가_아닌_카테고리를_삭제하려_하면_예외가_발생한다() {
         // given
-        GivenBuilder 나인 = 나인().회원_가입을_한다(나인_이메일, 나인_이름, 나인_프로필_URL)
-                .카테고리를_생성한다(취업_카테고리_이름, NORMAL);
+        GivenBuilder 나인 = 나인().카테고리를_생성한다(취업_카테고리_이름, NORMAL);
 
-        GivenBuilder 티거 = 티거().회원_가입을_한다(티거_이메일, 티거_이름, 티거_프로필_URL)
-                .카테고리를_구독한다(나인.카테고리());
+        GivenBuilder 티거 = 티거().카테고리를_구독한다(나인.카테고리());
 
         // when & then
         assertThatThrownBy(() -> categoryService.delete(티거.회원().getId(), 나인.카테고리().getId()))
@@ -377,7 +354,7 @@ class CategoryServiceTest extends ServiceTest {
     @Test
     void 카테고리를_생성할_때_최고_관리자인_카테고리가_50개면_예외가_발생한다() {
         // given
-        GivenBuilder 나인 = 나인().회원_가입을_한다(나인_이메일, 나인_이름, 나인_프로필_URL);
+        GivenBuilder 나인 = 나인();
         for (int i = 0; i < 50; i++) {
             나인.카테고리를_생성한다("카테고리 " + i, NORMAL);
         }
@@ -390,7 +367,7 @@ class CategoryServiceTest extends ServiceTest {
     @Test
     void 없는_카테고리를_삭제하려_하면_예외가_발생한다() {
         // given
-        GivenBuilder 나인 = 나인().회원_가입을_한다(나인_이메일, 나인_이름, 나인_프로필_URL);
+        GivenBuilder 나인 = 나인();
 
         // when & then
         assertThatThrownBy(() -> categoryService.delete(나인.회원().getId(), -1L))
@@ -400,8 +377,7 @@ class CategoryServiceTest extends ServiceTest {
     @Test
     void 카테고리를_삭제할_때_생성한_일정도_모두_삭제한다() {
         // given
-        GivenBuilder 나인 = 나인().회원_가입을_한다(나인_이메일, 나인_이름, 나인_프로필_URL)
-                .카테고리를_생성한다(취업_카테고리_이름, NORMAL)
+        GivenBuilder 나인 = 나인().카테고리를_생성한다(취업_카테고리_이름, NORMAL)
                 .일정을_생성한다(취업_일정_제목, 취업_일정_시작일, 취업_일정_종료일, 취업_일정_메모);
 
         // when
@@ -417,11 +393,9 @@ class CategoryServiceTest extends ServiceTest {
     @Test
     void 카테고리를_삭제할_때_구독_정보도_모두_삭제한다() {
         // given
-        GivenBuilder 나인 = 나인().회원_가입을_한다(나인_이메일, 나인_이름, 나인_프로필_URL)
-                .카테고리를_생성한다(취업_카테고리_이름, NORMAL);
+        GivenBuilder 나인 = 나인().카테고리를_생성한다(취업_카테고리_이름, NORMAL);
 
-        GivenBuilder 티거 = 티거().회원_가입을_한다(티거_이메일, 티거_이름, 티거_프로필_URL)
-                .카테고리를_구독한다(나인.카테고리());
+        GivenBuilder 티거 = 티거().카테고리를_구독한다(나인.카테고리());
 
         // when
         categoryService.delete(나인.회원().getId(), 나인.카테고리().getId());
@@ -435,8 +409,7 @@ class CategoryServiceTest extends ServiceTest {
     @Test
     void 카테고리를_삭제할_때_카테고리_권한도_모두_삭제한다() {
         // given
-        GivenBuilder 나인 = 나인().회원_가입을_한다(나인_이메일, 나인_이름, 나인_프로필_URL)
-                .카테고리를_생성한다(취업_카테고리_이름, NORMAL);
+        GivenBuilder 나인 = 나인().카테고리를_생성한다(취업_카테고리_이름, NORMAL);
 
         CategoryRole 권한 = categoryRoleRepository.getByMemberIdAndCategoryId(나인.회원().getId(), 나인.카테고리().getId());
 
@@ -451,8 +424,7 @@ class CategoryServiceTest extends ServiceTest {
     @Test
     void 개인_카테고리를_삭제하려_하면_예외가_발생한다() {
         // given
-        GivenBuilder 나인 = 나인().회원_가입을_한다(나인_이메일, 나인_이름, 나인_프로필_URL)
-                .카테고리를_생성한다(개인_카테고리_이름, PERSONAL);
+        GivenBuilder 나인 = 나인().카테고리를_생성한다(개인_카테고리_이름, PERSONAL);
 
         // when & then
         assertThatThrownBy(() -> categoryService.delete(나인.회원().getId(), 나인.카테고리().getId()))
@@ -462,8 +434,7 @@ class CategoryServiceTest extends ServiceTest {
     @Test
     void 외부_서비스_연동_카테고리를_삭제한다() {
         // given
-        GivenBuilder 나인 = 나인().회원_가입을_한다(나인_이메일, 나인_이름, 나인_프로필_URL)
-                .카테고리를_생성한다(외부_카테고리_이름, GOOGLE);
+        GivenBuilder 나인 = 나인().카테고리를_생성한다(외부_카테고리_이름, GOOGLE);
 
         // when
         categoryService.delete(나인.회원().getId(), 나인.카테고리().getId());
@@ -471,77 +442,5 @@ class CategoryServiceTest extends ServiceTest {
         // then
         assertThatThrownBy(() -> categoryRepository.getById(나인.카테고리().getId()))
                 .isInstanceOf(NoSuchCategoryException.class);
-    }
-
-    private GivenBuilder 나인() {
-        return new GivenBuilder();
-    }
-
-    private GivenBuilder 티거() {
-        return new GivenBuilder();
-    }
-
-    private final class GivenBuilder {
-
-        private Member member;
-        private Category category;
-        private CategoryRole categoryRole;
-        private Subscription subscription;
-        private Schedule schedule;
-
-        private GivenBuilder 회원_가입을_한다(final String email, final String name, final String profile) {
-            Member member = new Member(email, name, profile, SocialType.GOOGLE);
-            this.member = memberRepository.save(member);
-            return this;
-        }
-
-        private GivenBuilder 카테고리를_생성한다(final String categoryName, final CategoryType categoryType) {
-            Category category = new Category(categoryName, this.member, categoryType);
-            CategoryRole categoryRole = new CategoryRole(category, this.member, ADMIN);
-            Subscription subscription = new Subscription(this.member, category, COLOR_1);
-            this.category = categoryRepository.save(category);
-            this.categoryRole = categoryRoleRepository.save(categoryRole);
-            this.subscription = subscriptionRepository.save(subscription);
-            return this;
-        }
-
-        private GivenBuilder 카테고리를_구독한다(final Category category) {
-            Subscription subscription = new Subscription(this.member, category, COLOR_1);
-            CategoryRole categoryRole = new CategoryRole(category, this.member, NONE);
-            this.subscription = subscriptionRepository.save(subscription);
-            this.categoryRole = categoryRoleRepository.save(categoryRole);
-            return this;
-        }
-
-        private GivenBuilder 내_카테고리에_대한_관리_권한을_부여한다(final Member otherMember) {
-            CategoryRole categoryRole = categoryRoleRepository.getByMemberIdAndCategoryId(otherMember.getId(),
-                    category.getId());
-            categoryRole.changeRole(ADMIN);
-            categoryRoleRepository.save(categoryRole);
-            return this;
-        }
-
-        private GivenBuilder 일정을_생성한다(final String title, final LocalDateTime start, final LocalDateTime end,
-                                      final String memo) {
-            Schedule schedule = new Schedule(this.category, title, start, end, memo);
-            this.schedule = scheduleRepository.save(schedule);
-            return this;
-        }
-
-        private Member 회원() {
-            return member;
-        }
-
-        private Category 카테고리() {
-            return category;
-        }
-
-        private Subscription 구독() {
-            return subscription;
-        }
-
-        private Schedule 카테고리_일정() {
-            return schedule;
-        }
     }
 }

--- a/backend/src/test/java/com/allog/dallog/category/application/ExternalCategoryDetailServiceTest.java
+++ b/backend/src/test/java/com/allog/dallog/category/application/ExternalCategoryDetailServiceTest.java
@@ -1,24 +1,15 @@
 package com.allog.dallog.category.application;
 
 import static com.allog.dallog.category.domain.CategoryType.GOOGLE;
-import static com.allog.dallog.common.Constants.나인_이름;
-import static com.allog.dallog.common.Constants.나인_이메일;
-import static com.allog.dallog.common.Constants.나인_프로필_URL;
-import static com.allog.dallog.common.Constants.외부_카테고리_ID;
 import static com.allog.dallog.common.Constants.외부_카테고리_이름;
-import static com.allog.dallog.subscription.domain.Color.COLOR_1;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.allog.dallog.category.domain.Category;
 import com.allog.dallog.category.domain.CategoryRepository;
-import com.allog.dallog.category.domain.CategoryType;
 import com.allog.dallog.category.domain.ExternalCategoryDetail;
 import com.allog.dallog.category.domain.ExternalCategoryDetailRepository;
 import com.allog.dallog.common.annotation.ServiceTest;
-import com.allog.dallog.member.domain.Member;
+import com.allog.dallog.common.builder.GivenBuilder;
 import com.allog.dallog.member.domain.MemberRepository;
-import com.allog.dallog.member.domain.SocialType;
-import com.allog.dallog.subscription.domain.Subscription;
 import com.allog.dallog.subscription.domain.SubscriptionRepository;
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -44,42 +35,12 @@ class ExternalCategoryDetailServiceTest extends ServiceTest {
     @Test
     void 월별_일정을_조회하면_회원의_외부_카테고리_전체를_조회한다() {
         // given
-        GivenBuilder 나인 = 나인().회원_가입을_한다(나인_이메일, 나인_이름, 나인_프로필_URL)
-                .외부_카테고리를_등록한다(외부_카테고리_이름, GOOGLE);
+        GivenBuilder 나인 = 나인().외부_카테고리를_등록한다(외부_카테고리_이름, GOOGLE);
 
         // when
         List<ExternalCategoryDetail> actual = externalCategoryDetailService.findByMemberId(나인.회원().getId());
 
         // then
         assertThat(actual).hasSize(1);
-    }
-
-    private final class GivenBuilder {
-
-        private Member member;
-
-        private GivenBuilder 회원_가입을_한다(final String email, final String name, final String profile) {
-            Member member = new Member(email, name, profile, SocialType.GOOGLE);
-            this.member = memberRepository.save(member);
-            return this;
-        }
-
-        private GivenBuilder 외부_카테고리를_등록한다(final String categoryName, final CategoryType categoryType) {
-            Category category = new Category(categoryName, this.member, categoryType);
-            ExternalCategoryDetail externalCategoryDetail = new ExternalCategoryDetail(category, 외부_카테고리_ID);
-            Subscription subscription = new Subscription(this.member, category, COLOR_1);
-            categoryRepository.save(category);
-            externalCategoryDetailRepository.save(externalCategoryDetail);
-            subscriptionRepository.save(subscription);
-            return this;
-        }
-
-        private Member 회원() {
-            return member;
-        }
-    }
-
-    private GivenBuilder 나인() {
-        return new GivenBuilder();
     }
 }

--- a/backend/src/test/java/com/allog/dallog/category/presentation/CategoryControllerTest.java
+++ b/backend/src/test/java/com/allog/dallog/category/presentation/CategoryControllerTest.java
@@ -56,7 +56,7 @@ import com.allog.dallog.categoryrole.dto.response.SubscribersResponse;
 import com.allog.dallog.categoryrole.exception.NoCategoryAuthorityException;
 import com.allog.dallog.categoryrole.exception.NoSuchCategoryRoleException;
 import com.allog.dallog.categoryrole.exception.NotAbleToChangeRoleException;
-import com.allog.dallog.common.ControllerTest;
+import com.allog.dallog.common.annotation.ControllerTest;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/backend/src/test/java/com/allog/dallog/categoryrole/application/CategoryRoleServiceTest.java
+++ b/backend/src/test/java/com/allog/dallog/categoryrole/application/CategoryRoleServiceTest.java
@@ -14,13 +14,10 @@ import static com.allog.dallog.common.Constants.취업_카테고리_이름;
 import static com.allog.dallog.common.Constants.티거_이름;
 import static com.allog.dallog.common.Constants.티거_이메일;
 import static com.allog.dallog.common.Constants.티거_프로필_URL;
-import static com.allog.dallog.subscription.domain.Color.COLOR_1;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import com.allog.dallog.category.domain.Category;
 import com.allog.dallog.category.domain.CategoryRepository;
-import com.allog.dallog.category.domain.CategoryType;
 import com.allog.dallog.categoryrole.domain.CategoryRole;
 import com.allog.dallog.categoryrole.domain.CategoryRoleRepository;
 import com.allog.dallog.categoryrole.dto.request.CategoryRoleUpdateRequest;
@@ -29,10 +26,8 @@ import com.allog.dallog.categoryrole.exception.ManagingCategoryLimitExcessExcept
 import com.allog.dallog.categoryrole.exception.NoCategoryAuthorityException;
 import com.allog.dallog.categoryrole.exception.NotAbleToChangeRoleException;
 import com.allog.dallog.common.annotation.ServiceTest;
-import com.allog.dallog.member.domain.Member;
+import com.allog.dallog.common.builder.GivenBuilder;
 import com.allog.dallog.member.domain.MemberRepository;
-import com.allog.dallog.member.domain.SocialType;
-import com.allog.dallog.subscription.domain.Subscription;
 import com.allog.dallog.subscription.domain.SubscriptionRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -61,11 +56,9 @@ class CategoryRoleServiceTest extends ServiceTest {
     @Test
     void 카테고리의_구독자_목록을_조회한다() {
         // given
-        GivenBuilder 나인 = 나인().회원_가입을_한다(나인_이메일, 나인_이름, 나인_프로필_URL)
-                .카테고리를_생성한다(취업_카테고리_이름, NORMAL);
+        GivenBuilder 나인 = 나인().카테고리를_생성한다(취업_카테고리_이름, NORMAL);
 
-        티거().회원_가입을_한다(티거_이메일, 티거_이름, 티거_프로필_URL)
-                .카테고리를_구독한다(나인.카테고리());
+        티거().카테고리를_구독한다(나인.카테고리());
 
         // when
         SubscribersResponse actual = categoryRoleService.findSubscribers(나인.회원().getId(), 나인.카테고리().getId());
@@ -77,11 +70,9 @@ class CategoryRoleServiceTest extends ServiceTest {
     @Test
     void 관리자_권한이_아닌_회원이_카테고리_구독자_목록을_조회하면_예외가_발생한다() {
         // given
-        GivenBuilder 나인 = 나인().회원_가입을_한다(나인_이메일, 나인_이름, 나인_프로필_URL)
-                .카테고리를_생성한다(취업_카테고리_이름, NORMAL);
+        GivenBuilder 나인 = 나인().카테고리를_생성한다(취업_카테고리_이름, NORMAL);
 
-        GivenBuilder 티거 = 티거().회원_가입을_한다(티거_이메일, 티거_이름, 티거_프로필_URL)
-                .카테고리를_구독한다(나인.카테고리());
+        GivenBuilder 티거 = 티거().카테고리를_구독한다(나인.카테고리());
 
         // when & then
         assertThatThrownBy(() -> categoryRoleService.findSubscribers(티거.회원().getId(), 나인.카테고리().getId()))
@@ -91,11 +82,9 @@ class CategoryRoleServiceTest extends ServiceTest {
     @Test
     void 관리자_역할로_변경하려는_회원이_이미_50개_이상의_카테고리에_권한이_있으면_예외가_발생한다() {
         // given
-        GivenBuilder 나인 = 나인().회원_가입을_한다(나인_이메일, 나인_이름, 나인_프로필_URL)
-                .카테고리를_생성한다(취업_카테고리_이름, NORMAL);
+        GivenBuilder 나인 = 나인().카테고리를_생성한다(취업_카테고리_이름, NORMAL);
 
-        GivenBuilder 티거 = 티거().회원_가입을_한다(티거_이메일, 티거_이름, 티거_프로필_URL)
-                .카테고리를_구독한다(나인.카테고리());
+        GivenBuilder 티거 = 티거().카테고리를_구독한다(나인.카테고리());
         for (int i = 0; i < 50; i++) {
             티거.카테고리를_생성한다("카테고리 " + i, NORMAL);
         }
@@ -111,13 +100,11 @@ class CategoryRoleServiceTest extends ServiceTest {
     @Test
     void 카테고리_권한이_관리자인_회원이_다른_관리자의_권한을_변경한다() {
         // given
-        GivenBuilder 나인 = 나인().회원_가입을_한다(나인_이메일, 나인_이름, 나인_프로필_URL)
-                .카테고리를_생성한다(취업_카테고리_이름, NORMAL);
+        GivenBuilder 나인 = 나인().카테고리를_생성한다(취업_카테고리_이름, NORMAL);
 
-        GivenBuilder 티거 = 티거().회원_가입을_한다(티거_이메일, 티거_이름, 티거_프로필_URL)
-                .카테고리를_구독한다(나인.카테고리());
+        GivenBuilder 티거 = 티거().카테고리를_구독한다(나인.카테고리());
 
-        나인.내_카테고리에_대한_관리_권한을_부여한다(티거.회원());
+        나인.카테고리_관리_권한을_부여한다(티거.회원(), 나인.카테고리());
 
         // when
         categoryRoleService.updateRole(티거.회원().getId(), 나인.회원().getId(), 나인.카테고리().getId(), 카테고리_관리권한_해제_요청);
@@ -131,11 +118,9 @@ class CategoryRoleServiceTest extends ServiceTest {
     @Test
     void 카테고리_권한이_관리자인_회원이_구독자의_권한을_변경한다() {
         // given
-        GivenBuilder 나인 = 나인().회원_가입을_한다(나인_이메일, 나인_이름, 나인_프로필_URL)
-                .카테고리를_생성한다(취업_카테고리_이름, NORMAL);
+        GivenBuilder 나인 = 나인().카테고리를_생성한다(취업_카테고리_이름, NORMAL);
 
-        GivenBuilder 티거 = 티거().회원_가입을_한다(티거_이메일, 티거_이름, 티거_프로필_URL)
-                .카테고리를_구독한다(나인.카테고리());
+        GivenBuilder 티거 = 티거().카테고리를_구독한다(나인.카테고리());
 
         // when
         categoryRoleService.updateRole(나인.회원().getId(), 티거.회원().getId(), 나인.카테고리().getId(), 카테고리_관리권한_부여_요청);
@@ -149,13 +134,11 @@ class CategoryRoleServiceTest extends ServiceTest {
     @Test
     void 카테고리_권한이_관리자인_회원이_자신의_권한을_변경한다() {
         // given
-        GivenBuilder 나인 = 나인().회원_가입을_한다(나인_이메일, 나인_이름, 나인_프로필_URL)
-                .카테고리를_생성한다(취업_카테고리_이름, NORMAL);
+        GivenBuilder 나인 = 나인().카테고리를_생성한다(취업_카테고리_이름, NORMAL);
 
-        GivenBuilder 티거 = 티거().회원_가입을_한다(티거_이메일, 티거_이름, 티거_프로필_URL)
-                .카테고리를_구독한다(나인.카테고리());
+        GivenBuilder 티거 = 티거().카테고리를_구독한다(나인.카테고리());
 
-        나인.내_카테고리에_대한_관리_권한을_부여한다(티거.회원());
+        나인.카테고리_관리_권한을_부여한다(티거.회원(), 나인.카테고리());
 
         // when
         categoryRoleService.updateRole(나인.회원().getId(), 나인.회원().getId(), 나인.카테고리().getId(), 카테고리_관리권한_해제_요청);
@@ -168,11 +151,9 @@ class CategoryRoleServiceTest extends ServiceTest {
     @Test
     void 카테고리_권한이_없는_회원이_다른_회원의_권한을_변경하려하면_예외가_발생한다() {
         // given
-        GivenBuilder 나인 = 나인().회원_가입을_한다(나인_이메일, 나인_이름, 나인_프로필_URL)
-                .카테고리를_생성한다(취업_카테고리_이름, NORMAL);
+        GivenBuilder 나인 = 나인().카테고리를_생성한다(취업_카테고리_이름, NORMAL);
 
-        GivenBuilder 티거 = 티거().회원_가입을_한다(티거_이메일, 티거_이름, 티거_프로필_URL)
-                .카테고리를_구독한다(나인.카테고리());
+        GivenBuilder 티거 = 티거().카테고리를_구독한다(나인.카테고리());
 
         // when & then
         assertThatThrownBy(
@@ -184,8 +165,7 @@ class CategoryRoleServiceTest extends ServiceTest {
     @Test
     void 유일한_카테고리_관리자인_회원이_자신의_권한을_변경하려_하면_예외가_발생한다() {
         // given
-        GivenBuilder 나인 = 나인().회원_가입을_한다(나인_이메일, 나인_이름, 나인_프로필_URL)
-                .카테고리를_생성한다(취업_카테고리_이름, NORMAL);
+        GivenBuilder 나인 = 나인().카테고리를_생성한다(취업_카테고리_이름, NORMAL);
 
         // when & then
         assertThatThrownBy(() -> categoryRoleService.updateRole(
@@ -196,8 +176,7 @@ class CategoryRoleServiceTest extends ServiceTest {
     @Test
     void 개인_카테고리에_대한_회원의_권한을_변경하려_하면_예외가_발생한다() {
         // given
-        GivenBuilder 나인 = 나인().회원_가입을_한다(나인_이메일, 나인_이름, 나인_프로필_URL)
-                .카테고리를_생성한다(개인_카테고리_이름, PERSONAL);
+        GivenBuilder 나인 = 나인().카테고리를_생성한다(개인_카테고리_이름, PERSONAL);
 
         // when & then
         assertThatThrownBy(() -> categoryRoleService.updateRole(
@@ -208,68 +187,11 @@ class CategoryRoleServiceTest extends ServiceTest {
     @Test
     void 외부_카테고리에_대한_회원의_권한을_변경하려_하면_예외가_발생한다() {
         // given
-        GivenBuilder 나인 = 나인().회원_가입을_한다(나인_이메일, 나인_이름, 나인_프로필_URL)
-                .카테고리를_생성한다(외부_카테고리_이름, GOOGLE);
+        GivenBuilder 나인 = 나인().카테고리를_생성한다(외부_카테고리_이름, GOOGLE);
 
         // when & then
         assertThatThrownBy(() -> categoryRoleService.updateRole(
                 나인.회원().getId(), 나인.회원().getId(), 나인.카테고리().getId(), 카테고리_관리권한_부여_요청))
                 .isInstanceOf(NotAbleToChangeRoleException.class);
-    }
-
-    private final class GivenBuilder {
-
-        private Member member;
-        private Category category;
-        private CategoryRole categoryRole;
-        private Subscription subscription;
-
-        private GivenBuilder 회원_가입을_한다(final String email, final String name, final String profile) {
-            Member member = new Member(email, name, profile, SocialType.GOOGLE);
-            this.member = memberRepository.save(member);
-            return this;
-        }
-
-        private GivenBuilder 카테고리를_생성한다(final String categoryName, final CategoryType categoryType) {
-            Category category = new Category(categoryName, this.member, categoryType);
-            CategoryRole categoryRole = new CategoryRole(category, this.member, ADMIN);
-            Subscription subscription = new Subscription(this.member, category, COLOR_1);
-            this.category = categoryRepository.save(category);
-            this.categoryRole = categoryRoleRepository.save(categoryRole);
-            this.subscription = subscriptionRepository.save(subscription);
-            return this;
-        }
-
-        private GivenBuilder 카테고리를_구독한다(final Category category) {
-            Subscription subscription = new Subscription(this.member, category, COLOR_1);
-            CategoryRole categoryRole = new CategoryRole(category, this.member, NONE);
-            this.subscription = subscriptionRepository.save(subscription);
-            this.categoryRole = categoryRoleRepository.save(categoryRole);
-            return this;
-        }
-
-        private GivenBuilder 내_카테고리에_대한_관리_권한을_부여한다(final Member otherMember) {
-            CategoryRole categoryRole = categoryRoleRepository.getByMemberIdAndCategoryId(otherMember.getId(),
-                    category.getId());
-            categoryRole.changeRole(ADMIN);
-            categoryRoleRepository.save(categoryRole);
-            return this;
-        }
-
-        private Member 회원() {
-            return member;
-        }
-
-        private Category 카테고리() {
-            return category;
-        }
-    }
-
-    private GivenBuilder 나인() {
-        return new GivenBuilder();
-    }
-
-    private GivenBuilder 티거() {
-        return new GivenBuilder();
     }
 }

--- a/backend/src/test/java/com/allog/dallog/common/annotation/ControllerTest.java
+++ b/backend/src/test/java/com/allog/dallog/common/annotation/ControllerTest.java
@@ -1,4 +1,4 @@
-package com.allog.dallog.common;
+package com.allog.dallog.common.annotation;
 
 import com.allog.dallog.auth.application.AuthService;
 import com.allog.dallog.auth.application.OAuthUri;

--- a/backend/src/test/java/com/allog/dallog/common/annotation/RepositoryTest.java
+++ b/backend/src/test/java/com/allog/dallog/common/annotation/RepositoryTest.java
@@ -8,5 +8,5 @@ import org.springframework.test.context.ActiveProfiles;
 @DataJpaTest
 @Import(JpaConfig.class)
 @ActiveProfiles("test")
-public class RepositoryTest {
+public abstract class RepositoryTest {
 }

--- a/backend/src/test/java/com/allog/dallog/common/annotation/ServiceTest.java
+++ b/backend/src/test/java/com/allog/dallog/common/annotation/ServiceTest.java
@@ -1,11 +1,20 @@
 package com.allog.dallog.common.annotation;
 
-import com.allog.dallog.common.DatabaseCleaner;
-import com.allog.dallog.common.config.ExternalApiConfig;
+import static com.allog.dallog.common.Constants.나인_이름;
+import static com.allog.dallog.common.Constants.나인_이메일;
+import static com.allog.dallog.common.Constants.나인_프로필_URL;
+import static com.allog.dallog.common.Constants.티거_이름;
+import static com.allog.dallog.common.Constants.티거_이메일;
+import static com.allog.dallog.common.Constants.티거_프로필_URL;
+
 import com.allog.dallog.auth.application.AuthService;
 import com.allog.dallog.auth.domain.TokenRepository;
 import com.allog.dallog.auth.dto.OAuthMember;
 import com.allog.dallog.auth.dto.response.AccessAndRefreshTokenResponse;
+import com.allog.dallog.common.DatabaseCleaner;
+import com.allog.dallog.common.builder.BuilderSupporter;
+import com.allog.dallog.common.builder.GivenBuilder;
+import com.allog.dallog.common.config.ExternalApiConfig;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -13,7 +22,7 @@ import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest(classes = ExternalApiConfig.class)
 @ActiveProfiles("test")
-public class ServiceTest {
+public abstract class ServiceTest {
 
     @Autowired
     private AuthService authService;
@@ -24,6 +33,9 @@ public class ServiceTest {
     @Autowired
     private DatabaseCleaner databaseCleaner;
 
+    @Autowired
+    private BuilderSupporter builderSupporter;
+
     @BeforeEach
     void setUp() {
         databaseCleaner.execute();
@@ -33,5 +45,17 @@ public class ServiceTest {
     protected Long toMemberId(final OAuthMember oAuthMember) {
         AccessAndRefreshTokenResponse response = authService.generateAccessAndRefreshToken(oAuthMember);
         return authService.extractMemberId(response.getRefreshToken());
+    }
+
+    protected GivenBuilder 나인() {
+        GivenBuilder 나인 = new GivenBuilder(builderSupporter);
+        나인.회원_가입을_한다(나인_이메일, 나인_이름, 나인_프로필_URL);
+        return 나인;
+    }
+
+    protected GivenBuilder 티거() {
+        GivenBuilder 티거 = new GivenBuilder(builderSupporter);
+        티거.회원_가입을_한다(티거_이메일, 티거_이름, 티거_프로필_URL);
+        return 티거;
     }
 }

--- a/backend/src/test/java/com/allog/dallog/common/builder/BuilderSupporter.java
+++ b/backend/src/test/java/com/allog/dallog/common/builder/BuilderSupporter.java
@@ -7,32 +7,34 @@ import com.allog.dallog.categoryrole.domain.CategoryRoleRepository;
 import com.allog.dallog.member.domain.MemberRepository;
 import com.allog.dallog.schedule.domain.ScheduleRepository;
 import com.allog.dallog.subscription.domain.SubscriptionRepository;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 @Component
 public class BuilderSupporter {
 
-    @Autowired
-    private MemberRepository memberRepository;
+    private final MemberRepository memberRepository;
+    private final OAuthTokenRepository oAuthTokenRepository;
+    private final CategoryRepository categoryRepository;
+    private final ExternalCategoryDetailRepository externalCategoryDetailRepository;
+    private final CategoryRoleRepository categoryRoleRepository;
+    private final SubscriptionRepository subscriptionRepository;
+    private final ScheduleRepository scheduleRepository;
 
-    @Autowired
-    private OAuthTokenRepository oAuthTokenRepository;
-
-    @Autowired
-    private CategoryRepository categoryRepository;
-
-    @Autowired
-    private ExternalCategoryDetailRepository externalCategoryDetailRepository;
-
-    @Autowired
-    private CategoryRoleRepository categoryRoleRepository;
-
-    @Autowired
-    private SubscriptionRepository subscriptionRepository;
-
-    @Autowired
-    private ScheduleRepository scheduleRepository;
+    public BuilderSupporter(final MemberRepository memberRepository,
+                            final OAuthTokenRepository oAuthTokenRepository,
+                            final CategoryRepository categoryRepository,
+                            final ExternalCategoryDetailRepository externalCategoryDetailRepository,
+                            final CategoryRoleRepository categoryRoleRepository,
+                            final SubscriptionRepository subscriptionRepository,
+                            final ScheduleRepository scheduleRepository) {
+        this.memberRepository = memberRepository;
+        this.oAuthTokenRepository = oAuthTokenRepository;
+        this.categoryRepository = categoryRepository;
+        this.externalCategoryDetailRepository = externalCategoryDetailRepository;
+        this.categoryRoleRepository = categoryRoleRepository;
+        this.subscriptionRepository = subscriptionRepository;
+        this.scheduleRepository = scheduleRepository;
+    }
 
     public MemberRepository memberRepository() {
         return memberRepository;

--- a/backend/src/test/java/com/allog/dallog/common/builder/BuilderSupporter.java
+++ b/backend/src/test/java/com/allog/dallog/common/builder/BuilderSupporter.java
@@ -1,0 +1,64 @@
+package com.allog.dallog.common.builder;
+
+import com.allog.dallog.auth.domain.OAuthTokenRepository;
+import com.allog.dallog.category.domain.CategoryRepository;
+import com.allog.dallog.category.domain.ExternalCategoryDetailRepository;
+import com.allog.dallog.categoryrole.domain.CategoryRoleRepository;
+import com.allog.dallog.member.domain.MemberRepository;
+import com.allog.dallog.schedule.domain.ScheduleRepository;
+import com.allog.dallog.subscription.domain.SubscriptionRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class BuilderSupporter {
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private OAuthTokenRepository oAuthTokenRepository;
+
+    @Autowired
+    private CategoryRepository categoryRepository;
+
+    @Autowired
+    private ExternalCategoryDetailRepository externalCategoryDetailRepository;
+
+    @Autowired
+    private CategoryRoleRepository categoryRoleRepository;
+
+    @Autowired
+    private SubscriptionRepository subscriptionRepository;
+
+    @Autowired
+    private ScheduleRepository scheduleRepository;
+
+    public MemberRepository memberRepository() {
+        return memberRepository;
+    }
+
+    public OAuthTokenRepository oAuthTokenRepository() {
+        return oAuthTokenRepository;
+    }
+
+    public CategoryRepository categoryRepository() {
+        return categoryRepository;
+    }
+
+    public ExternalCategoryDetailRepository externalCategoryDetailRepository() {
+        return externalCategoryDetailRepository;
+    }
+
+    public CategoryRoleRepository categoryRoleRepository() {
+        return categoryRoleRepository;
+    }
+
+    public SubscriptionRepository subscriptionRepository() {
+        return subscriptionRepository;
+    }
+
+    public ScheduleRepository scheduleRepository() {
+        return scheduleRepository;
+    }
+}

--- a/backend/src/test/java/com/allog/dallog/common/builder/GivenBuilder.java
+++ b/backend/src/test/java/com/allog/dallog/common/builder/GivenBuilder.java
@@ -19,7 +19,6 @@ import java.time.LocalDateTime;
 public final class GivenBuilder {
 
     private final BuilderSupporter bs;
-
     private Member member;
     private Category category;
     private CategoryRole categoryRole;

--- a/backend/src/test/java/com/allog/dallog/common/builder/GivenBuilder.java
+++ b/backend/src/test/java/com/allog/dallog/common/builder/GivenBuilder.java
@@ -1,0 +1,111 @@
+package com.allog.dallog.common.builder;
+
+import static com.allog.dallog.categoryrole.domain.CategoryRoleType.ADMIN;
+import static com.allog.dallog.categoryrole.domain.CategoryRoleType.NONE;
+import static com.allog.dallog.common.Constants.외부_카테고리_ID;
+import static com.allog.dallog.subscription.domain.Color.COLOR_1;
+
+import com.allog.dallog.auth.domain.OAuthToken;
+import com.allog.dallog.category.domain.Category;
+import com.allog.dallog.category.domain.CategoryType;
+import com.allog.dallog.category.domain.ExternalCategoryDetail;
+import com.allog.dallog.categoryrole.domain.CategoryRole;
+import com.allog.dallog.member.domain.Member;
+import com.allog.dallog.member.domain.SocialType;
+import com.allog.dallog.schedule.domain.Schedule;
+import com.allog.dallog.subscription.domain.Subscription;
+import java.time.LocalDateTime;
+
+public final class GivenBuilder {
+
+    private final BuilderSupporter bs;
+
+    private Member member;
+    private Category category;
+    private CategoryRole categoryRole;
+    private Subscription subscription;
+    private Schedule schedule;
+
+    public GivenBuilder(final BuilderSupporter bs) {
+        this.bs = bs;
+    }
+
+    public GivenBuilder 회원_가입을_한다(final String email, final String name,
+                                  final String profile) {
+        Member member = new Member(email, name, profile, SocialType.GOOGLE);
+        this.member = bs.memberRepository().save(member);
+        OAuthToken oAuthToken = new OAuthToken(this.member, "aaa");
+        bs.oAuthTokenRepository().save(oAuthToken);
+        return this;
+    }
+
+    public GivenBuilder 카테고리를_생성한다(final String categoryName,
+                                   final CategoryType categoryType) {
+        Category category = new Category(categoryName, this.member, categoryType);
+        CategoryRole categoryRole = new CategoryRole(category, this.member, ADMIN);
+        Subscription subscription = new Subscription(this.member, category, COLOR_1);
+        this.category = bs.categoryRepository().save(category);
+        this.categoryRole = bs.categoryRoleRepository().save(categoryRole);
+        this.subscription = bs.subscriptionRepository().save(subscription);
+        return this;
+    }
+
+    public GivenBuilder 카테고리를_구독한다(final Category category) {
+        Subscription subscription = new Subscription(this.member, category, COLOR_1);
+        CategoryRole categoryRole = new CategoryRole(category, this.member, NONE);
+        this.subscription = bs.subscriptionRepository().save(subscription);
+        this.categoryRole = bs.categoryRoleRepository().save(categoryRole);
+        return this;
+    }
+
+    public GivenBuilder 카테고리_관리_권한을_부여한다(final Member otherMember, final Category category) {
+        CategoryRole categoryRole = bs.categoryRoleRepository().getByMemberIdAndCategoryId(
+                otherMember.getId(),
+                category.getId());
+        categoryRole.changeRole(ADMIN);
+        bs.categoryRoleRepository().save(categoryRole);
+        return this;
+    }
+
+    public GivenBuilder 카테고리_관리_권한을_해제한다(final Member otherMember, final Category category) {
+        CategoryRole categoryRole = bs.categoryRoleRepository().getByMemberIdAndCategoryId(
+                otherMember.getId(),
+                category.getId());
+        categoryRole.changeRole(NONE);
+        bs.categoryRoleRepository().save(categoryRole);
+        return this;
+    }
+
+    public GivenBuilder 외부_카테고리를_등록한다(final String categoryName, final CategoryType categoryType) {
+        Category category = new Category(categoryName, this.member, categoryType);
+        ExternalCategoryDetail externalCategoryDetail = new ExternalCategoryDetail(category, 외부_카테고리_ID);
+        Subscription subscription = new Subscription(this.member, category, COLOR_1);
+        this.category = bs.categoryRepository().save(category);
+        bs.externalCategoryDetailRepository().save(externalCategoryDetail);
+        this.subscription = bs.subscriptionRepository().save(subscription);
+        return this;
+    }
+
+    public GivenBuilder 일정을_생성한다(final String title, final LocalDateTime start, final LocalDateTime end,
+                                 final String memo) {
+        Schedule schedule = new Schedule(this.category, title, start, end, memo);
+        this.schedule = bs.scheduleRepository().save(schedule);
+        return this;
+    }
+
+    public Member 회원() {
+        return member;
+    }
+
+    public Category 카테고리() {
+        return category;
+    }
+
+    public Subscription 구독() {
+        return subscription;
+    }
+
+    public Schedule 카테고리_일정() {
+        return schedule;
+    }
+}

--- a/backend/src/test/java/com/allog/dallog/externalcalendar/application/ExternalCalendarServiceTest.java
+++ b/backend/src/test/java/com/allog/dallog/externalcalendar/application/ExternalCalendarServiceTest.java
@@ -3,15 +3,13 @@ package com.allog.dallog.externalcalendar.application;
 import static com.allog.dallog.common.Constants.나인_이름;
 import static com.allog.dallog.common.Constants.나인_이메일;
 import static com.allog.dallog.common.Constants.나인_프로필_URL;
-import static com.allog.dallog.common.fixtures.OAuthTokenFixtures.OAUTH_TOKEN;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.allog.dallog.auth.domain.OAuthTokenRepository;
 import com.allog.dallog.common.annotation.ServiceTest;
+import com.allog.dallog.common.builder.GivenBuilder;
 import com.allog.dallog.externalcalendar.dto.ExternalCalendarsResponse;
-import com.allog.dallog.member.domain.Member;
 import com.allog.dallog.member.domain.MemberRepository;
-import com.allog.dallog.member.domain.SocialType;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -29,32 +27,12 @@ class ExternalCalendarServiceTest extends ServiceTest {
     @Test
     void 회원의_외부_캘린더_목록을_조회한다() {
         // given
-        GivenBuilder 나인 = 나인().회원_가입을_한다(나인_이메일, 나인_이름, 나인_프로필_URL);
+        GivenBuilder 나인 = 나인();
 
         // when
         ExternalCalendarsResponse actual = externalCalendarService.findByMemberId(나인.회원().getId());
 
         // then
         assertThat(actual.getExternalCalendars()).hasSize(3);
-    }
-
-    private final class GivenBuilder {
-
-        private Member member;
-
-        private GivenBuilder 회원_가입을_한다(final String email, final String name, final String profile) {
-            Member member = new Member(email, name, profile, SocialType.GOOGLE);
-            this.member = memberRepository.save(member);
-            oAuthTokenRepository.save(OAUTH_TOKEN(member));
-            return this;
-        }
-
-        private Member 회원() {
-            return member;
-        }
-    }
-
-    private GivenBuilder 나인() {
-        return new GivenBuilder();
     }
 }

--- a/backend/src/test/java/com/allog/dallog/externalcalendar/presentation/ExternalCalendarControllerTest.java
+++ b/backend/src/test/java/com/allog/dallog/externalcalendar/presentation/ExternalCalendarControllerTest.java
@@ -23,7 +23,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.allog.dallog.category.dto.request.ExternalCategoryCreateRequest;
 import com.allog.dallog.category.exception.ExistExternalCategoryException;
-import com.allog.dallog.common.ControllerTest;
+import com.allog.dallog.common.annotation.ControllerTest;
 import com.allog.dallog.externalcalendar.dto.ExternalCalendar;
 import com.allog.dallog.externalcalendar.dto.ExternalCalendarsResponse;
 import java.util.List;

--- a/backend/src/test/java/com/allog/dallog/infrastructure/oauth/client/StubOAuthClient.java
+++ b/backend/src/test/java/com/allog/dallog/infrastructure/oauth/client/StubOAuthClient.java
@@ -2,10 +2,10 @@ package com.allog.dallog.infrastructure.oauth.client;
 
 import static com.allog.dallog.common.fixtures.AuthFixtures.STUB_OAUTH_ACCESS_TOKEN;
 
-import com.allog.dallog.common.fixtures.OAuthFixtures;
 import com.allog.dallog.auth.application.OAuthClient;
 import com.allog.dallog.auth.dto.OAuthMember;
 import com.allog.dallog.auth.dto.response.OAuthAccessTokenResponse;
+import com.allog.dallog.common.fixtures.OAuthFixtures;
 
 public class StubOAuthClient implements OAuthClient {
 

--- a/backend/src/test/java/com/allog/dallog/member/application/MemberServiceTest.java
+++ b/backend/src/test/java/com/allog/dallog/member/application/MemberServiceTest.java
@@ -6,9 +6,9 @@ import static com.allog.dallog.common.Constants.나인_프로필_URL;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.allog.dallog.common.annotation.ServiceTest;
+import com.allog.dallog.common.builder.GivenBuilder;
 import com.allog.dallog.member.domain.Member;
 import com.allog.dallog.member.domain.MemberRepository;
-import com.allog.dallog.member.domain.SocialType;
 import com.allog.dallog.member.dto.request.MemberUpdateRequest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -28,7 +28,7 @@ class MemberServiceTest extends ServiceTest {
     @Test
     void 회원을_조회한다() {
         // given
-        GivenBuilder 나인 = 나인().회원_가입을_한다(나인_이메일, 나인_이름, 나인_프로필_URL);
+        GivenBuilder 나인 = 나인();
 
         // when & then
         assertThat(memberService.findById(나인.회원().getId()).getId())
@@ -39,7 +39,7 @@ class MemberServiceTest extends ServiceTest {
     @Test
     void 회원의_이름을_수정한다() {
         // given
-        GivenBuilder 나인 = 나인().회원_가입을_한다(나인_이메일, 나인_이름, 나인_프로필_URL);;
+        GivenBuilder 나인 = 나인();
 
         // when
         memberService.update(나인.회원().getId(), 나인_이름_수정_요청);
@@ -47,24 +47,5 @@ class MemberServiceTest extends ServiceTest {
         // then
         Member actual = memberRepository.getById(나인.회원().getId());
         assertThat(actual.getDisplayName()).isEqualTo("텐");
-    }
-
-    private final class GivenBuilder {
-
-        private Member member;
-
-        private GivenBuilder 회원_가입을_한다(final String email, final String name, final String profile) {
-            Member member = new Member(email, name, profile, SocialType.GOOGLE);
-            this.member = memberRepository.save(member);
-            return this;
-        }
-
-        private Member 회원() {
-            return member;
-        }
-    }
-
-    private GivenBuilder 나인() {
-        return new GivenBuilder();
     }
 }

--- a/backend/src/test/java/com/allog/dallog/member/presentation/MemberControllerTest.java
+++ b/backend/src/test/java/com/allog/dallog/member/presentation/MemberControllerTest.java
@@ -20,7 +20,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.allog.dallog.common.ControllerTest;
+import com.allog.dallog.common.annotation.ControllerTest;
 import com.allog.dallog.member.dto.request.MemberUpdateRequest;
 import com.allog.dallog.member.exception.NoSuchMemberException;
 import org.junit.jupiter.api.DisplayName;

--- a/backend/src/test/java/com/allog/dallog/schedule/application/ScheduleServiceTest.java
+++ b/backend/src/test/java/com/allog/dallog/schedule/application/ScheduleServiceTest.java
@@ -2,8 +2,6 @@ package com.allog.dallog.schedule.application;
 
 import static com.allog.dallog.category.domain.CategoryType.GOOGLE;
 import static com.allog.dallog.category.domain.CategoryType.NORMAL;
-import static com.allog.dallog.categoryrole.domain.CategoryRoleType.ADMIN;
-import static com.allog.dallog.categoryrole.domain.CategoryRoleType.NONE;
 import static com.allog.dallog.common.Constants.나인_이름;
 import static com.allog.dallog.common.Constants.나인_이메일;
 import static com.allog.dallog.common.Constants.나인_프로필_URL;
@@ -17,28 +15,19 @@ import static com.allog.dallog.common.Constants.취업_일정_시작일;
 import static com.allog.dallog.common.Constants.취업_일정_제목;
 import static com.allog.dallog.common.Constants.취업_일정_종료일;
 import static com.allog.dallog.common.Constants.취업_카테고리_이름;
-import static com.allog.dallog.common.Constants.티거_이름;
-import static com.allog.dallog.common.Constants.티거_이메일;
-import static com.allog.dallog.common.Constants.티거_프로필_URL;
-import static com.allog.dallog.subscription.domain.Color.COLOR_1;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
-import com.allog.dallog.auth.domain.OAuthToken;
 import com.allog.dallog.auth.domain.OAuthTokenRepository;
 import com.allog.dallog.auth.exception.NoPermissionException;
-import com.allog.dallog.category.domain.Category;
 import com.allog.dallog.category.domain.CategoryRepository;
-import com.allog.dallog.category.domain.CategoryType;
 import com.allog.dallog.category.exception.NoSuchCategoryException;
-import com.allog.dallog.categoryrole.domain.CategoryRole;
 import com.allog.dallog.categoryrole.domain.CategoryRoleRepository;
 import com.allog.dallog.categoryrole.exception.NoCategoryAuthorityException;
 import com.allog.dallog.common.annotation.ServiceTest;
-import com.allog.dallog.member.domain.Member;
+import com.allog.dallog.common.builder.GivenBuilder;
 import com.allog.dallog.member.domain.MemberRepository;
-import com.allog.dallog.member.domain.SocialType;
 import com.allog.dallog.schedule.domain.IntegrationSchedule;
 import com.allog.dallog.schedule.domain.Schedule;
 import com.allog.dallog.schedule.domain.ScheduleRepository;
@@ -50,7 +39,6 @@ import com.allog.dallog.schedule.dto.response.IntegrationScheduleResponses;
 import com.allog.dallog.schedule.dto.response.ScheduleResponse;
 import com.allog.dallog.schedule.exception.InvalidScheduleException;
 import com.allog.dallog.schedule.exception.NoSuchScheduleException;
-import com.allog.dallog.subscription.domain.Subscription;
 import com.allog.dallog.subscription.domain.SubscriptionRepository;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -88,8 +76,7 @@ class ScheduleServiceTest extends ServiceTest {
     @Test
     void 관리_권한이_있는_회원은_카테고리에_새로운_일정을_생성할_수_있다() {
         // given & when
-        GivenBuilder 나인 = 나인().회원_가입을_한다(나인_이메일, 나인_이름, 나인_프로필_URL)
-                .카테고리를_생성한다(취업_카테고리_이름, NORMAL)
+        GivenBuilder 나인 = 나인().카테고리를_생성한다(취업_카테고리_이름, NORMAL)
                 .일정을_생성한다(취업_일정_제목, 취업_일정_시작일, 취업_일정_종료일, 취업_일정_메모);
 
         // then
@@ -99,12 +86,10 @@ class ScheduleServiceTest extends ServiceTest {
     @Test
     void 관리_권한이_없는_회원이_카고리에_새로운_일정을_생성하려_하면_예외가_발생한다() {
         // given
-        GivenBuilder 나인 = 나인().회원_가입을_한다(나인_이메일, 나인_이름, 나인_프로필_URL)
-                .카테고리를_생성한다(취업_카테고리_이름, NORMAL)
+        GivenBuilder 나인 = 나인().카테고리를_생성한다(취업_카테고리_이름, NORMAL)
                 .일정을_생성한다(취업_일정_제목, 취업_일정_시작일, 취업_일정_종료일, 취업_일정_메모);
 
-        GivenBuilder 티거 = 티거().회원_가입을_한다(티거_이메일, 티거_이름, 티거_프로필_URL)
-                .카테고리를_구독한다(나인.카테고리());
+        GivenBuilder 티거 = 티거().카테고리를_구독한다(나인.카테고리());
 
         // when & then
         assertThatThrownBy(() -> scheduleService.save(티거.회원().getId(), 나인.카테고리().getId(), 취업_일정_생성_요청))
@@ -115,12 +100,10 @@ class ScheduleServiceTest extends ServiceTest {
     @Test
     void 카테고리_생성자라도_관리_권한이_없으면_새로운_일정을_생성할_때_예외가_발생한다() {
         // given
-        GivenBuilder 나인 = 나인().회원_가입을_한다(나인_이메일, 나인_이름, 나인_프로필_URL)
-                .카테고리를_생성한다(취업_카테고리_이름, NORMAL)
+        GivenBuilder 나인 = 나인().카테고리를_생성한다(취업_카테고리_이름, NORMAL)
                 .일정을_생성한다(취업_일정_제목, 취업_일정_시작일, 취업_일정_종료일, 취업_일정_메모);
 
-        GivenBuilder 티거 = 티거().회원_가입을_한다(티거_이메일, 티거_이름, 티거_프로필_URL)
-                .카테고리를_구독한다(나인.카테고리());
+        GivenBuilder 티거 = 티거().카테고리를_구독한다(나인.카테고리());
 
         나인.카테고리_관리_권한을_부여한다(티거.회원(), 나인.카테고리());
         티거.카테고리_관리_권한을_해제한다(나인.회원(), 나인.카테고리());
@@ -133,8 +116,7 @@ class ScheduleServiceTest extends ServiceTest {
     @Test
     void 새로운_일정을_생성_할_때_일정_제목의_길이가_50을_초과하면_예외가_발생한다() {
         // given
-        GivenBuilder 나인 = 나인().회원_가입을_한다(나인_이메일, 나인_이름, 나인_프로필_URL)
-                .카테고리를_생성한다(취업_카테고리_이름, NORMAL);
+        GivenBuilder 나인 = 나인().카테고리를_생성한다(취업_카테고리_이름, NORMAL);
 
         String 잘못된_일정_제목 = "일이삼사오육칠팔구십일이삼사오육칠팔구십일일이삼사오육칠팔구십일이삼사오육칠팔구십일일이삼사오육칠팔구십일";
         ScheduleCreateRequest 잘못된_일정_생성_요청 = new ScheduleCreateRequest(잘못된_일정_제목, 취업_일정_시작일, 취업_일정_종료일, 취업_일정_메모);
@@ -147,8 +129,7 @@ class ScheduleServiceTest extends ServiceTest {
     @Test
     void 새로운_일정을_생성_할_때_일정_메모의_길이가_255를_초과하면_예외가_발생한다() {
         // given
-        GivenBuilder 나인 = 나인().회원_가입을_한다(나인_이메일, 나인_이름, 나인_프로필_URL)
-                .카테고리를_생성한다(취업_카테고리_이름, NORMAL);
+        GivenBuilder 나인 = 나인().카테고리를_생성한다(취업_카테고리_이름, NORMAL);
 
         String 잘못된_일정_메모 = "1".repeat(256);
         ScheduleCreateRequest 잘못된_일정_생성_요청 = new ScheduleCreateRequest(취업_일정_제목, 취업_일정_시작일, 취업_일정_종료일, 잘못된_일정_메모);
@@ -161,8 +142,7 @@ class ScheduleServiceTest extends ServiceTest {
     @Test
     void 새로운_일정을_생성_할_때_종료일시가_시작일시_이전이라면_예외가_발생한다() {
         // given
-        GivenBuilder 나인 = 나인().회원_가입을_한다(나인_이메일, 나인_이름, 나인_프로필_URL)
-                .카테고리를_생성한다(취업_카테고리_이름, NORMAL);
+        GivenBuilder 나인 = 나인().카테고리를_생성한다(취업_카테고리_이름, NORMAL);
 
         ScheduleCreateRequest 잘못된_일정_생성_요청 = new ScheduleCreateRequest(취업_일정_제목, 취업_일정_종료일, 취업_일정_시작일, 취업_일정_메모);
 
@@ -174,7 +154,7 @@ class ScheduleServiceTest extends ServiceTest {
     @Test
     void 존재하지_않는_카테고리에_일정을_추가하려하면_예외가_발생한다() {
         // given
-        GivenBuilder 나인 = 나인().회원_가입을_한다(나인_이메일, 나인_이름, 나인_프로필_URL);
+        GivenBuilder 나인 = 나인();
 
         // when & then
         assertThatThrownBy(() -> scheduleService.save(나인.회원().getId(), 0L, 취업_일정_생성_요청)).
@@ -184,8 +164,7 @@ class ScheduleServiceTest extends ServiceTest {
     @Test
     void 외부_연동_카테고리에_일정을_추가하려하면_예외가_발생한다() {
         // given
-        GivenBuilder 나인 = 나인().회원_가입을_한다(나인_이메일, 나인_이름, 나인_프로필_URL)
-                .카테고리를_생성한다(취업_카테고리_이름, GOOGLE);
+        GivenBuilder 나인 = 나인().카테고리를_생성한다(취업_카테고리_이름, GOOGLE);
 
         // when & then
         assertThatThrownBy(() -> scheduleService.save(나인.회원().getId(), 나인.카테고리().getId(), 취업_일정_생성_요청)).
@@ -195,8 +174,7 @@ class ScheduleServiceTest extends ServiceTest {
     @Test
     void 단건_일정을_조회한다() {
         // given
-        GivenBuilder 나인 = 나인().회원_가입을_한다(나인_이메일, 나인_이름, 나인_프로필_URL)
-                .카테고리를_생성한다(취업_카테고리_이름, NORMAL)
+        GivenBuilder 나인 = 나인().카테고리를_생성한다(취업_카테고리_이름, NORMAL)
                 .일정을_생성한다(취업_일정_제목, 취업_일정_시작일, 취업_일정_종료일, 취업_일정_메모);
 
         // when
@@ -226,8 +204,7 @@ class ScheduleServiceTest extends ServiceTest {
     @Test
     void 월별_일정_조회를_하면_통합일정_정보를_반환한다() {
         // given
-        GivenBuilder 나인 = 나인().회원_가입을_한다(나인_이메일, 나인_이름, 나인_프로필_URL)
-                .카테고리를_생성한다(취업_카테고리_이름, NORMAL)
+        GivenBuilder 나인 = 나인().카테고리를_생성한다(취업_카테고리_이름, NORMAL)
                 .일정을_생성한다(취업_일정_제목, 취업_일정_시작일, 취업_일정_종료일, 취업_일정_메모)
                 .일정을_생성한다(면접_일정_제목, 면접_일정_시작일, 면접_일정_종료일, 면접_일정_메모);
 
@@ -272,8 +249,7 @@ class ScheduleServiceTest extends ServiceTest {
     @Test
     void 일정을_수정한다() {
         // given
-        GivenBuilder 나인 = 나인().회원_가입을_한다(나인_이메일, 나인_이름, 나인_프로필_URL)
-                .카테고리를_생성한다(취업_카테고리_이름, NORMAL)
+        GivenBuilder 나인 = 나인().카테고리를_생성한다(취업_카테고리_이름, NORMAL)
                 .일정을_생성한다(취업_일정_제목, 취업_일정_시작일, 취업_일정_종료일, 취업_일정_메모);
 
         // when
@@ -296,12 +272,10 @@ class ScheduleServiceTest extends ServiceTest {
     @Test
     void 관리_권한이_없는_회원이_카테고리의_일정을_수정하면_예외가_발생한다() {
         // given
-        GivenBuilder 나인 = 나인().회원_가입을_한다(나인_이메일, 나인_이름, 나인_프로필_URL)
-                .카테고리를_생성한다(취업_카테고리_이름, NORMAL)
+        GivenBuilder 나인 = 나인().카테고리를_생성한다(취업_카테고리_이름, NORMAL)
                 .일정을_생성한다(취업_일정_제목, 취업_일정_시작일, 취업_일정_종료일, 취업_일정_메모);
 
-        GivenBuilder 티거 = 티거().회원_가입을_한다(티거_이메일, 티거_이름, 티거_프로필_URL)
-                .카테고리를_구독한다(나인.카테고리());
+        GivenBuilder 티거 = 티거().카테고리를_구독한다(나인.카테고리());
 
         // when & then
         ScheduleUpdateRequest 일정_수정_요청 = new ScheduleUpdateRequest(나인.카테고리().getId(), "제목", 취업_일정_시작일, 취업_일정_종료일, "메모");
@@ -314,12 +288,10 @@ class ScheduleServiceTest extends ServiceTest {
     @Test
     void 카테고리_생성자라도_관리_권한이_없으면_카테고리의_일정을_수정할_떄_예외가_발생한다() {
         // given
-        GivenBuilder 나인 = 나인().회원_가입을_한다(나인_이메일, 나인_이름, 나인_프로필_URL)
-                .카테고리를_생성한다(취업_카테고리_이름, NORMAL)
+        GivenBuilder 나인 = 나인().카테고리를_생성한다(취업_카테고리_이름, NORMAL)
                 .일정을_생성한다(취업_일정_제목, 취업_일정_시작일, 취업_일정_종료일, 취업_일정_메모);
 
-        GivenBuilder 티거 = 티거().회원_가입을_한다(티거_이메일, 티거_이름, 티거_프로필_URL)
-                .카테고리를_구독한다(나인.카테고리());
+        GivenBuilder 티거 = 티거().카테고리를_구독한다(나인.카테고리());
 
         나인.카테고리_관리_권한을_부여한다(티거.회원(), 나인.카테고리());
         티거.카테고리_관리_권한을_해제한다(나인.회원(), 나인.카테고리());
@@ -334,8 +306,7 @@ class ScheduleServiceTest extends ServiceTest {
     @Test
     void 존재하지_않은_일정을_수정하려하면_예외가_발생한다() {
         // given
-        GivenBuilder 나인 = 나인().회원_가입을_한다(나인_이메일, 나인_이름, 나인_프로필_URL)
-                .카테고리를_생성한다(취업_카테고리_이름, NORMAL);
+        GivenBuilder 나인 = 나인().카테고리를_생성한다(취업_카테고리_이름, NORMAL);
 
         // when & then
         ScheduleUpdateRequest 일정_수정_요청 = new ScheduleUpdateRequest(나인.카테고리().getId(), "제목", 취업_일정_시작일, 취업_일정_종료일, "메모");
@@ -347,8 +318,7 @@ class ScheduleServiceTest extends ServiceTest {
     @Test
     void 일정의_카테고리를_변경한다() {
         // given
-        GivenBuilder 나인 = 나인().회원_가입을_한다(나인_이메일, 나인_이름, 나인_프로필_URL)
-                .카테고리를_생성한다(취업_카테고리_이름, NORMAL)
+        GivenBuilder 나인 = 나인().카테고리를_생성한다(취업_카테고리_이름, NORMAL)
                 .일정을_생성한다(취업_일정_제목, 취업_일정_시작일, 취업_일정_종료일, 취업_일정_메모);
 
         Schedule 기존_일정 = 나인.카테고리_일정();
@@ -366,8 +336,7 @@ class ScheduleServiceTest extends ServiceTest {
     @Test
     void 관리_권한이_있는_회원은_카테고리의_일정을_삭제할_수_있다() {
         // given
-        GivenBuilder 나인 = 나인().회원_가입을_한다(나인_이메일, 나인_이름, 나인_프로필_URL)
-                .카테고리를_생성한다(취업_카테고리_이름, NORMAL)
+        GivenBuilder 나인 = 나인().카테고리를_생성한다(취업_카테고리_이름, NORMAL)
                 .일정을_생성한다(취업_일정_제목, 취업_일정_시작일, 취업_일정_종료일, 취업_일정_메모);
 
         // when
@@ -381,12 +350,10 @@ class ScheduleServiceTest extends ServiceTest {
     @Test
     void 관리_권한이_없는_회원이_카테고리의_일정을_삭제하려하면_예외가_발생한다() {
         // given
-        GivenBuilder 나인 = 나인().회원_가입을_한다(나인_이메일, 나인_이름, 나인_프로필_URL)
-                .카테고리를_생성한다(취업_카테고리_이름, NORMAL)
+        GivenBuilder 나인 = 나인().카테고리를_생성한다(취업_카테고리_이름, NORMAL)
                 .일정을_생성한다(취업_일정_제목, 취업_일정_시작일, 취업_일정_종료일, 취업_일정_메모);
 
-        GivenBuilder 티거 = 티거().회원_가입을_한다(티거_이메일, 티거_이름, 티거_프로필_URL)
-                .카테고리를_구독한다(나인.카테고리());
+        GivenBuilder 티거 = 티거().카테고리를_구독한다(나인.카테고리());
 
         // when & then
         assertThatThrownBy(() -> scheduleService.delete(나인.카테고리_일정().getId(), 티거.회원().getId()))
@@ -397,12 +364,10 @@ class ScheduleServiceTest extends ServiceTest {
     @Test
     void 카테고리_생성자라도_관리_권한이_없으면_일정을_삭제하려할때_예외가_발생한다() {
         // given
-        GivenBuilder 나인 = 나인().회원_가입을_한다(나인_이메일, 나인_이름, 나인_프로필_URL)
-                .카테고리를_생성한다(취업_카테고리_이름, NORMAL)
+        GivenBuilder 나인 = 나인().카테고리를_생성한다(취업_카테고리_이름, NORMAL)
                 .일정을_생성한다(취업_일정_제목, 취업_일정_시작일, 취업_일정_종료일, 취업_일정_메모);
 
-        GivenBuilder 티거 = 티거().회원_가입을_한다(티거_이메일, 티거_이름, 티거_프로필_URL)
-                .카테고리를_구독한다(나인.카테고리());
+        GivenBuilder 티거 = 티거().카테고리를_구독한다(나인.카테고리());
 
         나인.카테고리_관리_권한을_부여한다(티거.회원(), 나인.카테고리());
         티거.카테고리_관리_권한을_해제한다(나인.회원(), 나인.카테고리());
@@ -415,96 +380,10 @@ class ScheduleServiceTest extends ServiceTest {
     @Test
     void 존재하지_않은_일정을_삭제하려하면_예외가_발생한다() {
         // given
-        GivenBuilder 나인 = 나인().회원_가입을_한다(나인_이메일, 나인_이름, 나인_프로필_URL)
-                .카테고리를_생성한다(취업_카테고리_이름, NORMAL);
+        GivenBuilder 나인 = 나인().카테고리를_생성한다(취업_카테고리_이름, NORMAL);
 
         // when & then
         assertThatThrownBy(() -> scheduleService.delete(0L, 나인.회원().getId()))
                 .isInstanceOf(NoSuchScheduleException.class);
-    }
-
-    private GivenBuilder 나인() {
-        return new GivenBuilder();
-    }
-
-    private GivenBuilder 티거() {
-        return new GivenBuilder();
-    }
-
-    private final class GivenBuilder {
-
-        private Member member;
-        private Category category;
-        private CategoryRole categoryRole;
-        private Subscription subscription;
-        private Schedule schedule;
-
-        private GivenBuilder 회원_가입을_한다(final String email, final String name,
-                                       final String profile) {
-            Member member = new Member(email, name, profile, SocialType.GOOGLE);
-            this.member = memberRepository.save(member);
-            OAuthToken oAuthToken = new OAuthToken(this.member, "aaa");
-            oAuthTokenRepository.save(oAuthToken);
-            return this;
-        }
-
-        private GivenBuilder 카테고리를_생성한다(final String categoryName,
-                                        final CategoryType categoryType) {
-            Category category = new Category(categoryName, this.member, categoryType);
-            CategoryRole categoryRole = new CategoryRole(category, this.member, ADMIN);
-            Subscription subscription = new Subscription(this.member, category, COLOR_1);
-            this.category = categoryRepository.save(category);
-            this.categoryRole = categoryRoleRepository.save(categoryRole);
-            this.subscription = subscriptionRepository.save(subscription);
-            return this;
-        }
-
-        private GivenBuilder 카테고리를_구독한다(final Category category) {
-            Subscription subscription = new Subscription(this.member, category, COLOR_1);
-            CategoryRole categoryRole = new CategoryRole(category, this.member, NONE);
-            this.subscription = subscriptionRepository.save(subscription);
-            this.categoryRole = categoryRoleRepository.save(categoryRole);
-            return this;
-        }
-
-        private GivenBuilder 카테고리_관리_권한을_부여한다(final Member otherMember, final Category category) {
-            CategoryRole categoryRole = categoryRoleRepository.getByMemberIdAndCategoryId(otherMember.getId(),
-                    category.getId());
-            categoryRole.changeRole(ADMIN);
-            categoryRoleRepository.save(categoryRole);
-            return this;
-        }
-
-        private GivenBuilder 카테고리_관리_권한을_해제한다(final Member otherMember, final Category category) {
-            CategoryRole categoryRole = categoryRoleRepository.getByMemberIdAndCategoryId(otherMember.getId(),
-                    category.getId());
-            categoryRole.changeRole(NONE);
-            categoryRoleRepository.save(categoryRole);
-            return this;
-        }
-
-        private GivenBuilder 일정을_생성한다(final String title, final LocalDateTime start,
-                                      final LocalDateTime end,
-                                      final String memo) {
-            Schedule schedule = new Schedule(this.category, title, start, end, memo);
-            this.schedule = scheduleRepository.save(schedule);
-            return this;
-        }
-
-        private Member 회원() {
-            return member;
-        }
-
-        private Category 카테고리() {
-            return category;
-        }
-
-        private Subscription 구독() {
-            return subscription;
-        }
-
-        private Schedule 카테고리_일정() {
-            return schedule;
-        }
     }
 }

--- a/backend/src/test/java/com/allog/dallog/schedule/presentation/ScheduleControllerTest.java
+++ b/backend/src/test/java/com/allog/dallog/schedule/presentation/ScheduleControllerTest.java
@@ -29,7 +29,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.allog.dallog.auth.exception.NoPermissionException;
 import com.allog.dallog.category.exception.NoSuchCategoryException;
-import com.allog.dallog.common.ControllerTest;
+import com.allog.dallog.common.annotation.ControllerTest;
 import com.allog.dallog.schedule.dto.request.ScheduleCreateRequest;
 import com.allog.dallog.schedule.dto.request.ScheduleUpdateRequest;
 import com.allog.dallog.schedule.dto.response.IntegrationScheduleResponse;

--- a/backend/src/test/java/com/allog/dallog/subscription/application/SubscriptionServiceTest.java
+++ b/backend/src/test/java/com/allog/dallog/subscription/application/SubscriptionServiceTest.java
@@ -2,8 +2,6 @@ package com.allog.dallog.subscription.application;
 
 import static com.allog.dallog.category.domain.CategoryType.NORMAL;
 import static com.allog.dallog.category.domain.CategoryType.PERSONAL;
-import static com.allog.dallog.categoryrole.domain.CategoryRoleType.ADMIN;
-import static com.allog.dallog.categoryrole.domain.CategoryRoleType.NONE;
 import static com.allog.dallog.common.Constants.나인_이름;
 import static com.allog.dallog.common.Constants.나인_이메일;
 import static com.allog.dallog.common.Constants.나인_프로필_URL;
@@ -18,18 +16,14 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.allog.dallog.auth.exception.NoPermissionException;
-import com.allog.dallog.category.domain.Category;
 import com.allog.dallog.category.domain.CategoryRepository;
-import com.allog.dallog.category.domain.CategoryType;
 import com.allog.dallog.categoryrole.domain.CategoryRole;
 import com.allog.dallog.categoryrole.domain.CategoryRoleRepository;
 import com.allog.dallog.categoryrole.domain.CategoryRoleType;
 import com.allog.dallog.categoryrole.exception.NoSuchCategoryRoleException;
 import com.allog.dallog.common.annotation.ServiceTest;
-import com.allog.dallog.member.domain.Member;
+import com.allog.dallog.common.builder.GivenBuilder;
 import com.allog.dallog.member.domain.MemberRepository;
-import com.allog.dallog.member.domain.SocialType;
-import com.allog.dallog.schedule.domain.Schedule;
 import com.allog.dallog.subscription.domain.Subscription;
 import com.allog.dallog.subscription.domain.SubscriptionRepository;
 import com.allog.dallog.subscription.dto.request.SubscriptionUpdateRequest;
@@ -67,10 +61,9 @@ class SubscriptionServiceTest extends ServiceTest {
     @Test
     void 구독을_생성한다() {
         // given
-        GivenBuilder 나인 = 나인().회원_가입을_한다(나인_이메일, 나인_이름, 나인_프로필_URL)
-                .카테고리를_생성한다(취업_카테고리_이름, NORMAL);
+        GivenBuilder 나인 = 나인().카테고리를_생성한다(취업_카테고리_이름, NORMAL);
 
-        GivenBuilder 티거 = 티거().회원_가입을_한다(티거_이메일, 티거_이름, 티거_프로필_URL);
+        GivenBuilder 티거 = 티거();
 
         // when
         SubscriptionResponse response = subscriptionService.save(티거.회원().getId(), 나인.카테고리().getId());
@@ -82,10 +75,9 @@ class SubscriptionServiceTest extends ServiceTest {
     @Test
     void 타인의_개인_카테고리를_구독하려하면_예외가_발생한다() {
         // given
-        GivenBuilder 나인 = 나인().회원_가입을_한다(나인_이메일, 나인_이름, 나인_프로필_URL)
-                .카테고리를_생성한다(취업_카테고리_이름, PERSONAL);
+        GivenBuilder 나인 = 나인().카테고리를_생성한다(취업_카테고리_이름, PERSONAL);
 
-        GivenBuilder 티거 = 티거().회원_가입을_한다(티거_이메일, 티거_이름, 티거_프로필_URL);
+        GivenBuilder 티거 = 티거();
 
         // when & then
         assertThatThrownBy(() -> subscriptionService.save(티거.회원().getId(), 나인.카테고리().getId()))
@@ -96,8 +88,7 @@ class SubscriptionServiceTest extends ServiceTest {
     @Test
     void 이미_구독한_카테고리를_다시_구독하려하면_예외가_발생한다() {
         // given
-        GivenBuilder 나인 = 나인().회원_가입을_한다(나인_이메일, 나인_이름, 나인_프로필_URL)
-                .카테고리를_생성한다(취업_카테고리_이름, PERSONAL);
+        GivenBuilder 나인 = 나인().카테고리를_생성한다(취업_카테고리_이름, PERSONAL);
 
         // when & then
         assertThatThrownBy(() -> subscriptionService.save(나인.회원().getId(), 나인.카테고리().getId()))
@@ -107,8 +98,7 @@ class SubscriptionServiceTest extends ServiceTest {
     @Test
     void 단건_구독_정보를_조회한다() {
         // given
-        GivenBuilder 나인 = 나인().회원_가입을_한다(나인_이메일, 나인_이름, 나인_프로필_URL)
-                .카테고리를_생성한다(취업_카테고리_이름, PERSONAL);
+        GivenBuilder 나인 = 나인().카테고리를_생성한다(취업_카테고리_이름, PERSONAL);
 
         // when
         Subscription actual = subscriptionRepository.getById(나인.구독().getId());
@@ -120,11 +110,9 @@ class SubscriptionServiceTest extends ServiceTest {
     @Test
     void 회원의_구독_목록을_조회한다() {
         // given
-        GivenBuilder 나인 = 나인().회원_가입을_한다(나인_이메일, 나인_이름, 나인_프로필_URL)
-                .카테고리를_생성한다(취업_카테고리_이름, NORMAL);
+        GivenBuilder 나인 = 나인().카테고리를_생성한다(취업_카테고리_이름, NORMAL);
 
-        GivenBuilder 티거 = 티거().회원_가입을_한다(티거_이메일, 티거_이름, 티거_프로필_URL)
-                .카테고리를_구독한다(나인.카테고리());
+        GivenBuilder 티거 = 티거().카테고리를_구독한다(나인.카테고리());
 
         나인.카테고리를_생성한다(스터디_카테고리_이름, NORMAL);
         티거.카테고리를_구독한다(나인.카테고리());
@@ -139,8 +127,7 @@ class SubscriptionServiceTest extends ServiceTest {
     @Test
     void 구독_정보를_수정한다() {
         // given
-        GivenBuilder 나인 = 나인().회원_가입을_한다(나인_이메일, 나인_이름, 나인_프로필_URL)
-                .카테고리를_생성한다(취업_카테고리_이름, NORMAL);
+        GivenBuilder 나인 = 나인().카테고리를_생성한다(취업_카테고리_이름, NORMAL);
 
         // when
         subscriptionService.update(나인.구독().getId(), 나인.회원().getId(), 구독_정보_변경_요청);
@@ -157,8 +144,7 @@ class SubscriptionServiceTest extends ServiceTest {
     @ValueSource(strings = {"#111", "#1111", "#11111", "123456", "#**1234", "##12345", "334172#", "#00FF00"})
     void 존재하지_않는_색상으로_구독_정보를_수정하려_하면_예외가_발생한다(final String colorCode) {
         // given
-        GivenBuilder 나인 = 나인().회원_가입을_한다(나인_이메일, 나인_이름, 나인_프로필_URL)
-                .카테고리를_생성한다(취업_카테고리_이름, NORMAL);
+        GivenBuilder 나인 = 나인().카테고리를_생성한다(취업_카테고리_이름, NORMAL);
 
         SubscriptionUpdateRequest 잘못된_구독_변경_요청 = new SubscriptionUpdateRequest(colorCode, true);
 
@@ -170,11 +156,9 @@ class SubscriptionServiceTest extends ServiceTest {
     @Test
     void 구독_정보를_삭제한다() {
         // given
-        GivenBuilder 나인 = 나인().회원_가입을_한다(나인_이메일, 나인_이름, 나인_프로필_URL)
-                .카테고리를_생성한다(취업_카테고리_이름, NORMAL);
+        GivenBuilder 나인 = 나인().카테고리를_생성한다(취업_카테고리_이름, NORMAL);
 
-        GivenBuilder 티거 = 티거().회원_가입을_한다(티거_이메일, 티거_이름, 티거_프로필_URL)
-                .카테고리를_구독한다(나인.카테고리());
+        GivenBuilder 티거 = 티거().카테고리를_구독한다(나인.카테고리());
 
         // when
         subscriptionService.delete(티거.구독().getId(), 티거.회원().getId());
@@ -187,11 +171,9 @@ class SubscriptionServiceTest extends ServiceTest {
     @Test
     void 자신의_구독_정보가_아닌_구독을_삭제할_경우_예외가_발생한다() {
         // given
-        GivenBuilder 나인 = 나인().회원_가입을_한다(나인_이메일, 나인_이름, 나인_프로필_URL)
-                .카테고리를_생성한다(취업_카테고리_이름, NORMAL);
+        GivenBuilder 나인 = 나인().카테고리를_생성한다(취업_카테고리_이름, NORMAL);
 
-        GivenBuilder 티거 = 티거().회원_가입을_한다(티거_이메일, 티거_이름, 티거_프로필_URL)
-                .카테고리를_구독한다(나인.카테고리());
+        GivenBuilder 티거 = 티거().카테고리를_구독한다(나인.카테고리());
 
         // when & then
         assertThatThrownBy(() -> subscriptionService.delete(티거.구독().getId(), 나인.회원().getId()))
@@ -202,10 +184,9 @@ class SubscriptionServiceTest extends ServiceTest {
     @Test
     void 카테고리를_구독하면_카테고리에_대한_구독자_권한이_생성된다() {
         // given
-        GivenBuilder 나인 = 나인().회원_가입을_한다(나인_이메일, 나인_이름, 나인_프로필_URL)
-                .카테고리를_생성한다(취업_카테고리_이름, NORMAL);
+        GivenBuilder 나인 = 나인().카테고리를_생성한다(취업_카테고리_이름, NORMAL);
 
-        GivenBuilder 티거 = 티거().회원_가입을_한다(티거_이메일, 티거_이름, 티거_프로필_URL);
+        GivenBuilder 티거 = 티거();
 
         // when
         subscriptionService.save(티거.회원().getId(), 나인.카테고리().getId());
@@ -219,11 +200,9 @@ class SubscriptionServiceTest extends ServiceTest {
     @Test
     void 카테고리를_구독_해제하면_카테고리에_대한_권한이_제거된다() {
         // given
-        GivenBuilder 나인 = 나인().회원_가입을_한다(나인_이메일, 나인_이름, 나인_프로필_URL)
-                .카테고리를_생성한다(취업_카테고리_이름, NORMAL);
+        GivenBuilder 나인 = 나인().카테고리를_생성한다(취업_카테고리_이름, NORMAL);
 
-        GivenBuilder 티거 = 티거().회원_가입을_한다(티거_이메일, 티거_이름, 티거_프로필_URL)
-                .카테고리를_구독한다(나인.카테고리());
+        GivenBuilder 티거 = 티거().카테고리를_구독한다(나인.카테고리());
 
         // when
         subscriptionService.delete(티거.구독().getId(), 티거.회원().getId());
@@ -237,83 +216,14 @@ class SubscriptionServiceTest extends ServiceTest {
     @Test
     void 카테고리_권한이_관리자_일때_구독_해제를_하려하면_예외가_발생한다() {
         // given
-        GivenBuilder 나인 = 나인().회원_가입을_한다(나인_이메일, 나인_이름, 나인_프로필_URL)
-                .카테고리를_생성한다(취업_카테고리_이름, NORMAL);
+        GivenBuilder 나인 = 나인().카테고리를_생성한다(취업_카테고리_이름, NORMAL);
 
-        GivenBuilder 티거 = 티거().회원_가입을_한다(티거_이메일, 티거_이름, 티거_프로필_URL)
-                .카테고리를_구독한다(나인.카테고리());
+        GivenBuilder 티거 = 티거().카테고리를_구독한다(나인.카테고리());
 
         나인.카테고리_관리_권한을_부여한다(티거.회원(), 나인.카테고리());
 
         // when & then
         assertThatThrownBy(() -> subscriptionService.delete(티거.구독().getId(), 티거.회원().getId()))
                 .isInstanceOf(NotAbleToUnsubscribeException.class);
-    }
-
-    private GivenBuilder 나인() {
-        return new GivenBuilder();
-    }
-
-    private GivenBuilder 티거() {
-        return new GivenBuilder();
-    }
-
-    private final class GivenBuilder {
-
-        private Member member;
-        private Category category;
-        private CategoryRole categoryRole;
-        private Subscription subscription;
-        private Schedule schedule;
-
-        private GivenBuilder 회원_가입을_한다(final String email, final String name,
-                                       final String profile) {
-            Member member = new Member(email, name, profile, SocialType.GOOGLE);
-            this.member = memberRepository.save(member);
-            return this;
-        }
-
-        private GivenBuilder 카테고리를_생성한다(final String categoryName,
-                                        final CategoryType categoryType) {
-            Category category = new Category(categoryName, this.member, categoryType);
-            CategoryRole categoryRole = new CategoryRole(category, this.member, ADMIN);
-            Subscription subscription = new Subscription(this.member, category, COLOR_1);
-            this.category = categoryRepository.save(category);
-            this.categoryRole = categoryRoleRepository.save(categoryRole);
-            this.subscription = subscriptionRepository.save(subscription);
-            return this;
-        }
-
-        private GivenBuilder 카테고리를_구독한다(final Category category) {
-            Subscription subscription = new Subscription(this.member, category, COLOR_1);
-            CategoryRole categoryRole = new CategoryRole(category, this.member, NONE);
-            this.subscription = subscriptionRepository.save(subscription);
-            this.categoryRole = categoryRoleRepository.save(categoryRole);
-            return this;
-        }
-
-        private GivenBuilder 카테고리_관리_권한을_부여한다(final Member otherMember, final Category category) {
-            CategoryRole categoryRole = categoryRoleRepository.getByMemberIdAndCategoryId(otherMember.getId(),
-                    category.getId());
-            categoryRole.changeRole(ADMIN);
-            categoryRoleRepository.save(categoryRole);
-            return this;
-        }
-
-        private Member 회원() {
-            return member;
-        }
-
-        private Category 카테고리() {
-            return category;
-        }
-
-        private Subscription 구독() {
-            return subscription;
-        }
-
-        private Schedule 카테고리_일정() {
-            return schedule;
-        }
     }
 }

--- a/backend/src/test/java/com/allog/dallog/subscription/presentation/SubscriptionControllerTest.java
+++ b/backend/src/test/java/com/allog/dallog/subscription/presentation/SubscriptionControllerTest.java
@@ -31,7 +31,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.allog.dallog.auth.exception.NoPermissionException;
 import com.allog.dallog.category.dto.response.CategoryResponse;
-import com.allog.dallog.common.ControllerTest;
+import com.allog.dallog.common.annotation.ControllerTest;
 import com.allog.dallog.subscription.domain.Color;
 import com.allog.dallog.subscription.dto.request.SubscriptionUpdateRequest;
 import com.allog.dallog.subscription.dto.response.SubscriptionResponse;


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 💻 git rebase를 사용했나요?
- [x] 🌈 알록달록한가요?

## 작업 내용

- 각 `ServiceTest`의 innerClass들을 제거하고 `GivenBuilder`를 `common`패키지로 이동하였습니다.
- `GivenBuilder`의 로직수행을 위한 `repository` 의존주입을 위해 `BuilderSupporter` 빈을 생성하였습니다.
- `BuilderSupporter`에는 전체 `repository` 빈에대해 의존성을 가지고 있습니다

Closes #918 
